### PR TITLE
I've added an option to install and set up distributed-llama.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,59 @@ copy the files to the home directory and run ./script.sh
 
 This assumes the name of every computer is AID-E-# where # is a number 0-20, change the hostname to your expected cluster configuration name.
 
+## Setting up Distributed Llama
+
+This section guides you through setting up the `distributed-llama` project, which allows for distributed inference of large language models.
+
+### Prerequisites
+
+Before you begin, ensure you have the following installed on your system:
+*   **Git:** Required for cloning the `distributed-llama` repository.
+*   **C++ Compiler:** A C++ compiler such as GCC or Clang is needed to build the project from source.
+*   **Python 3:** May be required for certain scripts or utilities within the `distributed-llama` project.
+
+These tools are essential for obtaining the source code and compiling the `distributed-llama` executables.
+
+### Installation Script
+
+To simplify the setup process, a shell script named `setup_distributed_llama.sh` is provided. This script automates:
+1.  Cloning the `distributed-llama` repository from GitHub (https://github.com/b4rtaz/distributed-llama.git).
+2.  Compiling the core components: `dllama` (the main application) and `dllama-api` (the API server).
+
+### How to Run
+
+1.  Make sure the script is executable: `chmod +x setup_distributed_llama.sh` (The script also attempts to do this itself).
+2.  Run the script:
+    ```bash
+    ./setup_distributed_llama.sh
+    ```
+The script will create a directory named `distributed-llama-repo` in the current location, clone the repository into it, and then compile the project. You will see output messages indicating the progress and any potential errors.
+
+### Basic Usage (after setup)
+
+Once the `setup_distributed_llama.sh` script completes successfully, the compiled executables (`dllama` and `dllama-api`) will be located in the `distributed-llama-repo` directory.
+
+**To run the distributed Llama, you will generally need to:**
+1.  Obtain a compatible model and tokenizer.
+2.  Start worker nodes.
+3.  Start a root (inference) node, connecting it to the workers.
+
+**Example commands (these are illustrative and require model/tokenizer paths and worker IPs):**
+
+*   **Run a worker node (inside `distributed-llama-repo` directory):**
+    ```bash
+    ./dllama worker --port 9999 --nthreads 4
+    ```
+*   **Run a root node for inference (inside `distributed-llama-repo` directory):**
+    ```bash
+    ./dllama inference --model <path_to_model_gguf> --tokenizer <path_to_tokenizer> --workers <worker_ip:port>
+    ```
+*   **Run the API server (inside `distributed-llama-repo` directory):**
+    ```bash
+    ./dllama-api --model <path_to_model_gguf> --tokenizer <path_to_tokenizer> --host 0.0.0.0 --port 8080
+    ```
+
+**For detailed instructions** on model conversion, configuring and running a cluster with multiple workers, and other advanced usage, please refer to the official documentation within the `distributed-llama-repo` directory (look for a README or other documentation files) or visit the project's GitHub page: https://github.com/b4rtaz/distributed-llama.
 
 For the docker config image
 //Create the Image

--- a/setup_distributed_llama.sh
+++ b/setup_distributed_llama.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+REPO_URL="https://github.com/b4rtaz/distributed-llama.git"
+REPO_DIR="distributed-llama-repo"
+
+# --- Clone Repository ---
+echo "Checking for repository directory: $REPO_DIR"
+if [ -d "$REPO_DIR" ]; then
+    echo "Directory $REPO_DIR already exists."
+    #
+    # TODO: Add logic to offer to update the repo, e.g., git pull
+    # For now, we'll just proceed, assuming it's up-to-date or the user wants to use the existing version.
+    #
+    # read -p "Directory $REPO_DIR already exists. Do you want to pull the latest changes? (y/n) " -n 1 -r
+    # echo
+    # if [[ $REPLY =~ ^[Yy]$ ]]; then
+    #     echo "Pulling latest changes..."
+    #     cd "$REPO_DIR"
+    #     git pull
+    #     cd ..
+    # fi
+else
+    echo "Cloning $REPO_URL into $REPO_DIR..."
+    if git clone "$REPO_URL" "$REPO_DIR"; then
+        echo "Repository cloned successfully."
+    else
+        echo "Error: Failed to clone repository."
+        exit 1
+    fi
+fi
+
+# --- Compile Project ---
+echo "Changing directory to $REPO_DIR"
+cd "$REPO_DIR"
+
+echo "Compiling main application (dllama)..."
+if make dllama; then
+    echo "dllama compiled successfully."
+else
+    echo "Error: Failed to compile dllama."
+    exit 1
+fi
+
+echo "Compiling API server (dllama-api)..."
+if make dllama-api; then
+    echo "dllama-api compiled successfully."
+else
+    echo "Error: Failed to compile dllama-api."
+    exit 1
+fi
+
+echo "Compilation finished."
+
+# --- Basic Invocation Examples ---
+echo ""
+echo "--------------------------------------------------"
+echo "Basic Invocation Examples (commented out):"
+echo "--------------------------------------------------"
+echo "# To run these examples, you'll need to be in the $REPO_DIR directory."
+echo "# Ensure you have a model and tokenizer available."
+echo ""
+echo "# Example: Run worker node"
+echo "# ./dllama worker --port 9999 --nthreads 4"
+echo ""
+echo "# Example: Run root node (replace with actual model and tokenizer paths)"
+echo "# ./dllama inference --model <path_to_model> --tokenizer <path_to_tokenizer> --workers <worker_ip:port>"
+echo ""
+echo "# Example: Run API server (replace with actual model and tokenizer paths)"
+echo "# ./dllama-api --model <path_to_model> --tokenizer <path_to_tokenizer> --host 0.0.0.0 --port 8080"
+echo "--------------------------------------------------"
+
+# --- Permissions ---
+# The script itself needs execute permissions.
+# This can be done by running: chmod +x setup_distributed_llama.sh
+# Adding a line to make itself executable (though it's often done by the user post-creation)
+if [ -f "$0" ]; then
+    chmod +x "$0"
+    echo "Made the script ($0) executable."
+fi
+
+echo ""
+echo "Setup script completed successfully."
+exit 0

--- a/test_distributed_llama.sh
+++ b/test_distributed_llama.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+# set -e # We'll handle errors manually to provide better feedback
+
+REPO_DIR="distributed-llama-repo"
+SETUP_SCRIPT="setup_distributed_llama.sh"
+
+# Function to print success messages
+print_success() {
+    echo "SUCCESS: $1"
+}
+
+# Function to print error messages and exit
+print_error_and_exit() {
+    echo "ERROR: $1"
+    exit 1
+}
+
+# --- Make script executable (self) ---
+if [ -f "$0" ]; then
+    chmod +x "$0"
+    echo "INFO: Made test script ($0) executable."
+fi
+
+# --- 1. Ensure setup_distributed_llama.sh is executable and run it ---
+echo "INFO: Checking for setup script: $SETUP_SCRIPT"
+if [ ! -f "$SETUP_SCRIPT" ]; then
+    print_error_and_exit "Setup script '$SETUP_SCRIPT' not found!"
+fi
+
+echo "INFO: Making $SETUP_SCRIPT executable..."
+chmod +x "$SETUP_SCRIPT"
+if [ $? -ne 0 ]; then
+    print_error_and_exit "Failed to make $SETUP_SCRIPT executable."
+fi
+print_success "$SETUP_SCRIPT is executable."
+
+echo "INFO: Running $SETUP_SCRIPT..."
+./"$SETUP_SCRIPT"
+SETUP_EXIT_CODE=$?
+if [ $SETUP_EXIT_CODE -ne 0 ]; then
+    print_error_and_exit "$SETUP_SCRIPT failed with exit code $SETUP_EXIT_CODE."
+fi
+print_success "$SETUP_SCRIPT completed successfully."
+
+# --- 2. Verify compilation products ---
+echo "INFO: Verifying compilation products..."
+
+echo "INFO: Checking for directory: $REPO_DIR"
+if [ ! -d "$REPO_DIR" ]; then
+    print_error_and_exit "Repository directory '$REPO_DIR' not found."
+fi
+print_success "Directory '$REPO_DIR' exists."
+
+DLLAMA_EXEC="$REPO_DIR/dllama"
+echo "INFO: Checking for executable: $DLLAMA_EXEC"
+if [ ! -x "$DLLAMA_EXEC" ]; then # Check for existence and execute permission
+    print_error_and_exit "Executable '$DLLAMA_EXEC' not found or not executable."
+fi
+print_success "Executable '$DLLAMA_EXEC' exists and is executable."
+
+DLLAMA_API_EXEC="$REPO_DIR/dllama-api"
+echo "INFO: Checking for executable: $DLLAMA_API_EXEC"
+if [ ! -x "$DLLAMA_API_EXEC" ]; then # Check for existence and execute permission
+    print_error_and_exit "Executable '$DLLAMA_API_EXEC' not found or not executable."
+fi
+print_success "Executable '$DLLAMA_API_EXEC' exists and is executable."
+
+# --- 3. Basic functionality test ---
+echo "INFO: Performing basic functionality tests..."
+
+echo "INFO: Running '$DLLAMA_EXEC --help'..."
+if "$DLLAMA_EXEC" --help > /dev/null 2>&1; then # Redirect stdout and stderr to /dev/null
+    print_success "'$DLLAMA_EXEC --help' executed successfully."
+else
+    print_error_and_exit "'$DLLAMA_EXEC --help' failed or returned an error."
+fi
+
+echo "INFO: Running '$DLLAMA_API_EXEC --help'..."
+if "$DLLAMA_API_EXEC" --help > /dev/null 2>&1; then # Redirect stdout and stderr to /dev/null
+    print_success "'$DLLAMA_API_EXEC --help' executed successfully."
+else
+    print_error_and_exit "'$DLLAMA_API_EXEC --help' failed or returned an error."
+fi
+
+# --- 4. Cleanup (optional) ---
+# To enable cleanup, uncomment the following lines and the function definition.
+#
+# cleanup() {
+#     echo "INFO: Cleaning up..."
+#     if [ -d "$REPO_DIR" ]; then
+#         read -p "Do you want to remove the '$REPO_DIR' directory? (y/n) " -n 1 -r
+#         echo
+#         if [[ $REPLY =~ ^[Yy]$ ]]; then
+#             echo "INFO: Removing '$REPO_DIR'..."
+#             rm -rf "$REPO_DIR"
+#             if [ $? -ne 0 ]; then
+#                 echo "WARNING: Failed to remove '$REPO_DIR'."
+#             else
+#                 print_success "Removed '$REPO_DIR'."
+#             fi
+#         else
+#             echo "INFO: Cleanup skipped by user."
+#         fi
+#     else
+#         echo "INFO: '$REPO_DIR' not found, no cleanup needed for it."
+#     fi
+# }
+#
+# cleanup
+
+echo ""
+echo "----------------------------------------"
+echo "All tests passed successfully!"
+echo "----------------------------------------"
+exit 0


### PR DESCRIPTION
This change introduces a new script, `setup_distributed_llama.sh`, that automates the process of cloning the `distributed-llama` repository from GitHub and compiling its components (`dllama` and `dllama-api`).

I've updated the README.md to include:
- Prerequisites for `distributed-llama`.
- Instructions on how you can use the `setup_distributed_llama.sh` script.
- Basic guidance on what to do after the setup is complete, pointing to the official `distributed-llama` documentation for detailed usage.

I've also added a script, `test_distributed_llama.sh`, to verify the setup. This script:
- Runs the `setup_distributed_llama.sh` script.
- Verifies the creation of the `distributed-llama-repo` directory.
- Checks for the existence and basic executability of the `dllama` and `dllama-api` binaries by running their `--help` commands.

These additions should make it easier for you to get started with `distributed-llama` within this environment.