### PR TITLE
Add Debian init script and documentation for distributed-llama service

### DIFF
--- a/debian_service/MANUAL_TESTING_GUIDE.md
+++ b/debian_service/MANUAL_TESTING_GUIDE.md
@@ -1,0 +1,181 @@
+# Manual Testing Guide for distributed-llama Service
+
+This guide will walk you through the steps to manually test the `distributed-llama` service on your Debian server. It assumes you have already followed the `SERVICE_SETUP_AND_USAGE.MD` guide for installation and initial configuration.
+
+## 1. Prerequisites
+
+Before you begin testing, ensure the following conditions are met:
+
+*   **Service Installed:** The `distributed-llama` service has been installed and configured according to the `SERVICE_SETUP_AND_USAGE.MD` document.
+*   **Configuration File Populated:** The `/etc/default/distributed-llama` configuration file is present and correctly populated. Crucially:
+    *   `MODEL_PATH` points to a valid, readable language model file.
+    *   `TOKENIZER_PATH` points to a valid, readable tokenizer file.
+    *   `INSTALL_DIR` points to the correct base directory of your `distributed-llama` application.
+*   **Service User:** The `SERVICE_USER` specified in `/etc/default/distributed-llama` (e.g., `llamauser`) exists, owns relevant directories (like `INSTALL_DIR`, `/var/run/distributed-llama`, `/var/log/distributed-llama`), and has necessary permissions.
+*   **Application Compiled:** The `dllama-api` executable is compiled and located within the `INSTALL_DIR` (e.g., at `$INSTALL_DIR/distributed-llama-repo/dllama-api`).
+
+## 2. Testing Steps
+
+Follow these steps sequentially to test the service.
+
+### 2.1. Initial Status Check
+
+Verify the initial state of the service before starting any tests.
+
+*   **Command:**
+    ```bash
+    sudo service distributed-llama status
+    ```
+*   **Expected Outcome:**
+    The service should be reported as "not running" or "stopped". If it's reported as running, and this is a fresh setup, you might want to stop it (`sudo service distributed-llama stop`) before proceeding to ensure a clean test.
+
+### 2.2. Start the Service
+
+Attempt to start the `distributed-llama` service.
+
+*   **Command:**
+    ```bash
+    sudo service distributed-llama start
+    ```
+*   **Expected Outcome:**
+    The command should execute without immediate errors. You should see a message like:
+    `[ ok ] Starting distributed-llama: dllama-api.`
+*   **Action:**
+    Wait for about 10-30 seconds (depending on model size and system speed) for the `dllama-api` to initialize.
+
+### 2.3. Verify Service is Running
+
+Confirm that the service has started successfully and the daemon is operational.
+
+*   **Command 1: Service Status**
+    ```bash
+    sudo service distributed-llama status
+    ```
+    *   **Expected Outcome:** The service should be reported as "running" or "active", and it should display a Process ID (PID). Example:
+        `● distributed-llama.service - LSB: Start daemon at boot time
+           Loaded: loaded (/etc/init.d/distributed-llama; generated)
+           Active: active (running) since Mon YYYY-MM-DD HH:MM:SS UTC; Xs ago
+             Docs: man:systemd-sysv-generator(8)
+          Process: [PID] ExecStart=/etc/init.d/distributed-llama start (code=exited, status=0/SUCCESS)
+            Tasks: N (limit: ...)
+           Memory: XM
+           CGroup: /system.slice/distributed-llama.service
+                   └─[PID_OF_DAEMON] /opt/distributed-llama/distributed-llama-repo/dllama-api --model /path/to/model --tokenizer /path/to/tokenizer ...`
+
+*   **Command 2 (Optional): Process Check**
+    ```bash
+    ps aux | grep dllama-api
+    ```
+    *   **Expected Outcome:** You should see at least one process related to `dllama-api` (excluding the `grep` command itself) running under the configured `SERVICE_USER` (e.g., `llamauser`).
+
+*   **Command 3: Check Logs**
+    ```bash
+    sudo tail -n 50 /var/log/distributed-llama/dllama-api.log
+    ```
+    (Adjust the path if `LOG_DIR_BASE` or `DAEMON_NAME` were changed in the init script or config.)
+    *   **Expected Outcome:** The log file should show startup messages from `dllama-api`. Look for messages indicating the model and tokenizer were loaded successfully. If the API server is configured to listen on a network port, you might see a message like "llama_new_context_with_model: ..., "HTTP server listening on host:port 0.0.0.0:8080" or similar. Critically, check for any error messages like "model file not found", "tokenizer file not found", or permission issues.
+
+### 2.4. Test API Functionality (if applicable)
+
+If the `dllama-api` exposes an HTTP endpoint, test its basic connectivity. The default configuration in the init script and `/etc/default/distributed-llama` sets the API to listen on `0.0.0.0:8080`.
+
+*   **Command (from the server itself):**
+    ```bash
+    curl http://localhost:8080/
+    ```
+    Or, if you know a specific health check or basic API endpoint for `dllama-api` (e.g., `/health`, `/v1/models`), use that:
+    ```bash
+    curl http://localhost:8080/health
+    ```
+*   **Expected Outcome:**
+    You should receive a valid response from the API. This could be a JSON message, HTML, or plain text, depending on how `dllama-api` is implemented. A "connection refused" error means the API server is likely not running or not listening on the expected address/port. Check the logs from step 2.3 carefully if this occurs.
+    *Note: If testing from another machine, ensure your server's firewall allows connections to the specified port (e.g., 8080).*
+
+### 2.5. Stop the Service
+
+Test the service shutdown procedure.
+
+*   **Command:**
+    ```bash
+    sudo service distributed-llama stop
+    ```
+*   **Expected Outcome:**
+    The command should execute without immediate errors. You should see a message like:
+    `[ ok ] Stopping distributed-llama: dllama-api.`
+*   **Action:**
+    Wait a few seconds for the service to shut down completely.
+
+### 2.6. Verify Service is Stopped
+
+Confirm that the service has stopped as expected.
+
+*   **Command 1: Service Status**
+    ```bash
+    sudo service distributed-llama status
+    ```
+    *   **Expected Outcome:** The service should be reported as "not running" or "inactive".
+
+*   **Command 2 (Optional): Process Check**
+    ```bash
+    ps aux | grep dllama-api
+    ```
+    *   **Expected Outcome:** The `dllama-api` process(es) should no longer be listed (or if one appears momentarily, it should be in a defunct state and disappear quickly).
+
+*   **Command 3: Check Logs**
+    ```bash
+    sudo tail -n 20 /var/log/distributed-llama/dllama-api.log
+    ```
+    *   **Expected Outcome:** The log file might show shutdown messages or indicate the process terminated.
+
+### 2.7. Restart the Service
+
+Test the restart functionality.
+
+*   **Command:**
+    ```bash
+    sudo service distributed-llama restart
+    ```
+*   **Expected Outcome:**
+    The command should execute. You'll typically see messages indicating the service is being stopped and then started.
+    `[ ok ] Restarting distributed-llama: dllama-api.`
+*   **Action:**
+    Wait for about 10-30 seconds for the service to fully restart.
+*   **Verify:**
+    1.  Repeat the checks in **Step 2.3 (Verify Service is Running)** to ensure it's operational again.
+    2.  Optionally, repeat **Step 2.4 (Test API Functionality)** to confirm the API is responsive.
+
+### 2.8. Test Boot Behavior (System Reboot)
+
+This is a crucial test to ensure the service starts automatically after a system reboot.
+
+*   **Command:**
+    ```bash
+    sudo reboot
+    ```
+*   **Action:**
+    Wait for the server to reboot completely and then log back in. This may take a few minutes.
+*   **Verify:**
+    Once logged back in:
+    *   **Command 1: Service Status**
+        ```bash
+        sudo service distributed-llama status
+        ```
+        *   **Expected Outcome:** The service should be reported as "running" or "active".
+    *   **Command 2: Check Logs**
+        ```bash
+        sudo tail -n 50 /var/log/distributed-llama/dllama-api.log
+        ```
+        *   **Expected Outcome:** The logs should indicate that the `dllama-api` service started up as part of the boot process. You should see the familiar startup messages.
+    *   **Command 3 (Optional): Test API Functionality**
+        Repeat **Step 2.4 (Test API Functionality)** to confirm the API is responsive after a reboot.
+
+## 3. Troubleshooting Reminders
+
+If any of the above tests fail, refer to the following:
+
+*   **`SERVICE_SETUP_AND_USAGE.MD`:** This document contains a detailed troubleshooting section. Review it for common issues and solutions.
+*   **Log Files:** The primary source of error information is `/var/log/distributed-llama/dllama-api.log`. Examine it carefully for any error messages, permission issues, or path problems.
+*   **Paths and Permissions:** Double-check all file paths in `/etc/default/distributed-llama`. Ensure the `SERVICE_USER` has correct read/write/execute permissions for all relevant files and directories as outlined in the setup guide.
+*   **Manual Execution:** Try running the `dllama-api` command directly as the `SERVICE_USER` (see troubleshooting section in `SERVICE_SETUP_AND_USAGE.MD`) to isolate issues with the application itself versus the service script.
+
+This concludes the manual testing guide. If all steps pass, your `distributed-llama` service should be correctly installed and operational.

--- a/debian_service/SERVICE_SETUP_AND_USAGE.md
+++ b/debian_service/SERVICE_SETUP_AND_USAGE.md
@@ -1,0 +1,213 @@
+# Setting Up and Managing the distributed-llama Service
+
+## 1. Overview
+
+The `distributed-llama` service is designed to run the `dllama-api` application as a background daemon. This allows the API server to start automatically on boot and be managed using standard service commands.
+
+It utilizes:
+*   An **init script**: Located at `/etc/init.d/distributed-llama`, which controls the starting, stopping, and status of the service.
+*   A **configuration file**: Located at `/etc/default/distributed-llama`, which stores settings like model paths, user to run as, and installation directory.
+
+## 2. Prerequisites
+
+*   A Debian-based Linux system (e.g., Ubuntu, Debian).
+*   `sudo` or root access to the system.
+*   The `distributed-llama` application code must be cloned and the `dllama-api` executable compiled. This is typically done by following the main project's setup instructions (e.g., running a script like `setup_distributed_llama.sh` from the `distributed-llama` GitHub repository).
+
+## 3. Installation Steps
+
+Follow these steps to set up the `distributed-llama` service:
+
+### Step 1: Install `distributed-llama` Application
+
+Before setting up the service, the `dllama-api` application itself must be compiled and available on your system.
+
+1.  **Choose an installation location:** A common location is `/opt`. We'll use `/opt/distributed-llama` as the base for the application.
+    ```bash
+    sudo mkdir -p /opt/distributed-llama
+    ```
+2.  **Clone the repository:**
+    ```bash
+    sudo git clone https://github.com/b4rtaz/distributed-llama.git /opt/distributed-llama/distributed-llama-repo
+    ```
+3.  **Compile the application:**
+    Navigate to the repository directory and compile the `dllama-api` executable.
+    ```bash
+    cd /opt/distributed-llama/distributed-llama-repo
+    sudo make dllama-api 
+    ```
+    (Alternatively, if the project provides a comprehensive setup script like `setup_distributed_llama.sh`, you might run that within `/opt/distributed-llama` according to its instructions.)
+4.  **Set ownership for the application directory (important for the service user later):**
+    ```bash
+    sudo chown -R llamauser:llamauser /opt/distributed-llama # Assuming 'llamauser' will be the service user
+    ```
+    *(Note: Create the `llamauser` first if it doesn't exist, as shown in Step 2, then run this chown command.)*
+
+### Step 2: Create Service User
+
+It's good practice to run services under a dedicated, non-privileged user for security.
+
+1.  **Create the user and group:**
+    ```bash
+    sudo adduser --system --group llamauser
+    ```
+    This command creates a system user named `llamauser` and a corresponding group.
+
+### Step 3: Create Necessary Directories
+
+The service requires specific directories for its operation:
+
+1.  **Application Installation Directory (if not already created in Step 1):**
+    This is where the `distributed-llama-repo` (containing `dllama-api`) is located.
+    ```bash
+    sudo mkdir -p /opt/distributed-llama 
+    sudo chown llamauser:llamauser /opt/distributed-llama 
+    ```
+    *(Ensure the contents, like `distributed-llama-repo`, are also owned by `llamauser` as per Step 1.4)*
+
+2.  **PID Directory:**
+    This directory will store the process ID file of the running daemon.
+    ```bash
+    sudo mkdir -p /var/run/distributed-llama
+    sudo chown llamauser:llamauser /var/run/distributed-llama
+    sudo chmod 755 /var/run/distributed-llama 
+    ```
+
+3.  **Log Directory:**
+    This directory will store the service's log files.
+    ```bash
+    sudo mkdir -p /var/log/distributed-llama
+    sudo chown llamauser:llamauser /var/log/distributed-llama
+    sudo chmod 755 /var/log/distributed-llama
+    ```
+
+### Step 4: Deploy Service Files
+
+You will need two files:
+*   The init script (e.g., previously generated as `distributed-llama-init-script/distributed-llama` in your workspace).
+*   The default configuration file (e.g., previously generated as `distributed-llama-default-config` in your workspace).
+
+1.  **Copy the init script:**
+    Assuming the generated init script is available at `path/to/your/workspace/distributed-llama-init-script/distributed-llama`:
+    ```bash
+    sudo cp path/to/your/workspace/distributed-llama-init-script/distributed-llama /etc/init.d/distributed-llama
+    ```
+
+2.  **Copy the configuration file:**
+    Assuming the generated configuration file is available at `path/to/your/workspace/distributed-llama-default-config`:
+    ```bash
+    sudo cp path/to/your/workspace/distributed-llama-default-config /etc/default/distributed-llama
+    ```
+
+### Step 5: Set Permissions
+
+The init script needs to be executable:
+
+```bash
+sudo chmod +x /etc/init.d/distributed-llama
+```
+
+### Step 6: Configure the Service
+
+Edit the configuration file to match your setup. This is a **critical step**.
+
+```bash
+sudo nano /etc/default/distributed-llama
+```
+
+Key variables you **must** review and likely change:
+
+*   `SERVICE_USER`: Should match the user created in Step 2 (e.g., `llamauser`).
+*   `INSTALL_DIR`: The base directory where `distributed-llama-repo` is located (e.g., `/opt/distributed-llama`). The init script will look for the executable at `$INSTALL_DIR/$REPO_DIR_NAME/$DAEMON_EXECUTABLE_NAME`.
+*   `MODEL_PATH`: **Required.** Absolute path to your downloaded language model file (e.g., `/opt/distributed-llama/distributed-llama-repo/models/your_model.gguf`).
+*   `TOKENIZER_PATH`: **Required.** Absolute path to your tokenizer file (e.g., `/opt/distributed-llama/distributed-llama-repo/tokenizers/your_tokenizer.model`).
+*   `API_HOST`: Host IP for the API (default is `0.0.0.0`).
+*   `API_PORT`: Port for the API (default is `8080`).
+*   `DAEMON_OPTS`: Any additional command-line options for `dllama-api`.
+*   `REPO_DIR_NAME`: Name of the repository directory within `INSTALL_DIR` (default `distributed-llama-repo`).
+*   `DAEMON_EXECUTABLE_NAME`: Name of the executable (default `dllama-api`).
+
+Ensure all paths are correct and the `SERVICE_USER` has read access to the model and tokenizer files, and read/execute access to the `dllama-api` executable.
+
+### Step 7: Enable the Service
+
+To make the service start automatically on boot:
+
+```bash
+sudo update-rc.d distributed-llama defaults
+```
+For systems using systemd, this command should still enable the SysVinit script. For more robust systemd integration, creating a native systemd unit file would be the next step, but this init script provides compatibility.
+
+## 4. Managing the Service
+
+Once installed and configured, you can manage the `distributed-llama` service using the following commands:
+
+*   **Start the service:**
+    ```bash
+    sudo service distributed-llama start
+    ```
+
+*   **Stop the service:**
+    ```bash
+    sudo service distributed-llama stop
+    ```
+
+*   **Restart the service:**
+    (This will stop and then start the service)
+    ```bash
+    sudo service distributed-llama restart
+    ```
+
+*   **Check the status of the service:**
+    ```bash
+    sudo service distributed-llama status
+    ```
+
+## 5. Checking Logs
+
+Logs from the `dllama-api` daemon are written to a file specified by the `LOG_FILE` variable in the init script, which defaults to being constructed from `LOG_DIR_BASE` and `DAEMON_NAME`. Typically, this will be:
+
+`/var/log/distributed-llama/dllama-api.log`
+
+You can monitor the logs in real-time using:
+
+```bash
+tail -f /var/log/distributed-llama/dllama-api.log
+```
+
+Check these logs if the service fails to start or if you encounter issues.
+
+## 6. Troubleshooting
+
+If you encounter problems with the service:
+
+1.  **Check Service Status:**
+    Run `sudo service distributed-llama status`. This will often tell you if the service is running, stopped, or failed.
+
+2.  **Examine Logs:**
+    The primary source of information is the log file: `/var/log/distributed-llama/dllama-api.log`. Look for error messages.
+
+3.  **Verify Configuration (`/etc/default/distributed-llama`):**
+    *   Are `INSTALL_DIR`, `MODEL_PATH`, and `TOKENIZER_PATH` correct?
+    *   Does `MODEL_PATH` point to a valid, readable model file?
+    *   Does `TOKENIZER_PATH` point to a valid, readable tokenizer file?
+    *   Is `SERVICE_USER` set to the correct user (e.g., `llamauser`)?
+
+4.  **Permissions:**
+    *   Ensure the `SERVICE_USER` (e.g., `llamauser`) has:
+        *   Read and execute permissions on the `dllama-api` executable (e.g., `/opt/distributed-llama/distributed-llama-repo/dllama-api`).
+        *   Read permissions for the model and tokenizer files.
+        *   Read/write permissions for the `PID_DIR_BASE` (`/var/run/distributed-llama`) and `LOG_DIR_BASE` (`/var/log/distributed-llama`).
+        *   Read permissions for the entire `INSTALL_DIR` path.
+    *   Ensure `/etc/init.d/distributed-llama` is executable.
+
+5.  **Manual Execution:**
+    Try running the `dllama-api` command directly as the `SERVICE_USER` to see if there are errors.
+    ```bash
+    sudo -u llamauser /opt/distributed-llama/distributed-llama-repo/dllama-api --model "/path/to/model" --tokenizer "/path/to/tokenizer" --host "0.0.0.0" --port "8080"
+    ```
+    Adjust paths and options according to your configuration. Check for any output or errors.
+
+6.  **Path to Executable in Init Script:**
+    The init script constructs `FULL_EXECUTABLE_PATH` using variables from `/etc/default/distributed-llama` (`INSTALL_DIR`, `REPO_DIR_NAME`, `DAEMON_EXECUTABLE_NAME`). Double-check these are correctly defined if the error is "executable not found".
+```

--- a/debian_service/default/distributed-llama
+++ b/debian_service/default/distributed-llama
@@ -1,0 +1,35 @@
+# Default configuration for the distributed-llama service
+
+# User to run the service as
+# Ensure this user exists and has permissions to the INSTALL_DIR, PID_DIR_BASE, and LOG_DIR_BASE
+SERVICE_USER="llamauser"
+
+# Installation directory where distributed-llama-repo is located
+# Example: /opt/distributed-llama (if you ran setup_distributed_llama.sh there)
+INSTALL_DIR="/opt/distributed-llama"
+
+# Path to the model file (REQUIRED - must be set by the user)
+# Example: "/opt/distributed-llama/distributed-llama-repo/models/your_model.gguf"
+MODEL_PATH=""
+
+# Path to the tokenizer file (REQUIRED - must be set by the user)
+# Example: "/opt/distributed-llama/distributed-llama-repo/tokenizers/your_tokenizer.model"
+TOKENIZER_PATH=""
+
+# Host for the API server (e.g., 0.0.0.0 to listen on all interfaces)
+API_HOST="0.0.0.0"
+
+# Port for the API server
+API_PORT="8080"
+
+# Additional command-line options for the dllama-api executable
+# Example: "--nthreads 4"
+DAEMON_OPTS=""
+
+# Name of the repository directory inside INSTALL_DIR
+# (Typically "distributed-llama-repo" if using the setup script)
+REPO_DIR_NAME="distributed-llama-repo"
+
+# Name of the main daemon executable
+# (Typically "dllama-api" if using the setup script)
+DAEMON_EXECUTABLE_NAME="dllama-api"

--- a/debian_service/init.d/distributed-llama
+++ b/debian_service/init.d/distributed-llama
@@ -1,0 +1,136 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          distributed-llama
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start daemon at boot time
+# Description:       Enable service provided by daemon.
+### END INIT INFO
+
+# Script variables
+DAEMON_NAME="dllama-api"
+SERVICE_NAME="distributed-llama"
+DEFAULT_CONFIG_FILE="/etc/default/distributed-llama"
+PID_DIR_BASE="/var/run/distributed-llama"
+LOG_DIR_BASE="/var/log/distributed-llama"
+
+# Source function library.
+. /lib/lsb/init-functions
+
+# Load defaults
+if [ -r "$DEFAULT_CONFIG_FILE" ]; then
+    . "$DEFAULT_CONFIG_FILE"
+else
+    log_failure_msg "Configuration file $DEFAULT_CONFIG_FILE not found."
+    exit 1
+fi
+
+# Check for essential variables from config file
+if [ -z "$INSTALL_DIR" ] || [ -z "$SERVICE_USER" ] || [ -z "$MODEL_PATH" ] || [ -z "$TOKENIZER_PATH" ]; then
+    log_failure_msg "Essential variables (INSTALL_DIR, SERVICE_USER, MODEL_PATH, TOKENIZER_PATH) not set in $DEFAULT_CONFIG_FILE."
+    exit 1
+fi
+
+# Construct full executable path
+REPO_DIR_RELATIVE_PATH="distributed-llama-repo" # Or make this configurable
+FULL_EXECUTABLE_PATH="${INSTALL_DIR}/${REPO_DIR_RELATIVE_PATH}/dllama-api"
+
+# Define PID_FILE and LOG_FILE
+PID_FILE="${PID_DIR_BASE}/${DAEMON_NAME}.pid"
+LOG_FILE="${LOG_DIR_BASE}/${DAEMON_NAME}.log"
+
+# Default API host and port if not set in config
+API_HOST=${API_HOST:-"0.0.0.0"}
+API_PORT=${API_PORT:-8080}
+DAEMON_OPTS=${DAEMON_OPTS:-""}
+
+
+do_start() {
+    # Check if executable exists
+    if [ ! -x "$FULL_EXECUTABLE_PATH" ]; then
+        log_failure_msg "Executable $FULL_EXECUTABLE_PATH not found or not executable."
+        return 1
+    fi
+
+    # Check if model and tokenizer paths are valid files
+    if [ ! -f "$MODEL_PATH" ]; then
+        log_failure_msg "Model file $MODEL_PATH not found."
+        return 1
+    fi
+    if [ ! -f "$TOKENIZER_PATH" ]; then
+        log_failure_msg "Tokenizer file $TOKENIZER_PATH not found."
+        return 1
+    fi
+
+    # Create PID directory
+    if [ ! -d "$PID_DIR_BASE" ]; then
+        mkdir -p "$PID_DIR_BASE" || { log_failure_msg "Failed to create PID directory $PID_DIR_BASE"; return 1; }
+        chown "$SERVICE_USER":"$SERVICE_USER" "$PID_DIR_BASE" || { log_failure_msg "Failed to chown PID directory $PID_DIR_BASE"; return 1; }
+        chmod 755 "$PID_DIR_BASE"
+    fi
+
+    # Create LOG directory
+    if [ ! -d "$LOG_DIR_BASE" ]; then
+        mkdir -p "$LOG_DIR_BASE" || { log_failure_msg "Failed to create log directory $LOG_DIR_BASE"; return 1; }
+        chown "$SERVICE_USER":"$SERVICE_USER" "$LOG_DIR_BASE" || { log_failure_msg "Failed to chown log directory $LOG_DIR_BASE"; return 1; }
+        chmod 755 "$LOG_DIR_BASE"
+    fi
+    
+    # Create LOG file and set permissions
+    touch "$LOG_FILE" || { log_failure_msg "Failed to create log file $LOG_FILE"; return 1; }
+    chown "$SERVICE_USER":"$SERVICE_USER" "$LOG_FILE" || { log_failure_msg "Failed to chown log file $LOG_FILE"; return 1; }
+    chmod 644 "$LOG_FILE"
+
+
+    log_daemon_msg "Starting $SERVICE_NAME: $DAEMON_NAME"
+    start-stop-daemon --start --quiet --pidfile "$PID_FILE" --make-pidfile --chuid "$SERVICE_USER" --background \
+        --startas /bin/bash -- -c "$FULL_EXECUTABLE_PATH --model \"$MODEL_PATH\" --tokenizer \"$TOKENIZER_PATH\" --host \"$API_HOST\" --port \"$API_PORT\" $DAEMON_OPTS >> \"$LOG_FILE\" 2>&1"
+    RETVAL=$?
+    log_end_msg $RETVAL
+    return $RETVAL
+}
+
+do_stop() {
+    log_daemon_msg "Stopping $SERVICE_NAME: $DAEMON_NAME"
+    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile "$PID_FILE" --name "$DAEMON_NAME"
+    RETVAL=$?
+    rm -f "$PID_FILE"
+    log_end_msg $RETVAL
+    return $RETVAL
+}
+
+do_status() {
+    status_of_proc -p "$PID_FILE" "$DAEMON_NAME" "$SERVICE_NAME"
+    return $?
+}
+
+case "$1" in
+    start)
+        do_start
+        exit $?
+        ;;
+    stop)
+        do_stop
+        exit $?
+        ;;
+    restart)
+        log_daemon_msg "Restarting $SERVICE_NAME: $DAEMON_NAME"
+        do_stop
+        # Add a small delay to ensure the process has time to stop
+        sleep 1 
+        do_start
+        exit $?
+        ;;
+    status)
+        do_status
+        exit $?
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|status}"
+        exit 2
+        ;;
+esac
+
+exit 0

--- a/debian_service/install_service.sh
+++ b/debian_service/install_service.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# This script guides you through installing the distributed-llama service.
+# Some commands will require sudo privileges to execute.
+
+# --- Variables ---
+INIT_SCRIPT_WORKSPACE_PATH="distributed-llama-init-script/distributed-llama"
+CONFIG_FILE_WORKSPACE_PATH="distributed-llama-default-config"
+
+# --- Preamble ---
+echo "--- distributed-llama Service Installation Guide ---"
+echo "This script will provide instructions to install the service."
+echo "You may need to run some commands with 'sudo'."
+echo "Ensure you have already run './setup_distributed_llama.sh' to set up the application code."
+echo "---"
+echo ""
+
+# --- User and Directories Creation ---
+echo "INFO: 1. Create a dedicated user for the service (if it doesn't exist):"
+echo "   sudo adduser --system --group llamauser"
+echo "---"
+echo ""
+
+echo "INFO: 2. Create the installation directory for distributed-llama (e.g., /opt/distributed-llama):"
+echo "   sudo mkdir -p /opt/distributed-llama"
+echo "   sudo chown llamauser:llamauser /opt/distributed-llama"
+echo "   INFO: Remember to run './setup_distributed_llama.sh' inside /opt/distributed-llama if you haven't already."
+echo "---"
+echo ""
+
+echo "INFO: 3. Create PID and Log directories:"
+echo "   sudo mkdir -p /var/run/distributed-llama"
+echo "   sudo chown llamauser:llamauser /var/run/distributed-llama"
+echo "   sudo chmod 755 /var/run/distributed-llama" # Ensure user can write PID
+echo "   sudo mkdir -p /var/log/distributed-llama"
+echo "   sudo chown llamauser:llamauser /var/log/distributed-llama"
+echo "   sudo chmod 755 /var/log/distributed-llama" # Ensure user can write logs
+echo "---"
+echo ""
+
+# --- Deploy Scripts ---
+echo "INFO: 4. Copy the init script to /etc/init.d/:"
+echo "   Make sure '${INIT_SCRIPT_WORKSPACE_PATH}' exists in your current directory or provide the correct path."
+echo "   sudo cp \"${INIT_SCRIPT_WORKSPACE_PATH}\" /etc/init.d/distributed-llama"
+echo "---"
+echo ""
+
+echo "INFO: 5. Copy the configuration file to /etc/default/:"
+echo "   Make sure '${CONFIG_FILE_WORKSPACE_PATH}' exists in your current directory or provide the correct path."
+echo "   sudo cp \"${CONFIG_FILE_WORKSPACE_PATH}\" /etc/default/distributed-llama"
+echo "---"
+echo ""
+
+# --- Set Permissions ---
+echo "INFO: 6. Set execute permissions on the init script:"
+echo "   sudo chmod +x /etc/init.d/distributed-llama"
+echo "---"
+echo ""
+
+# --- Enable Service ---
+echo "INFO: 7. Register the service to start on boot (for SysVinit systems):"
+echo "   sudo update-rc.d distributed-llama defaults"
+echo "   INFO: If your system uses systemd, this script will still work, but you might"
+echo "         consider creating a native systemd unit file for deeper integration."
+echo "---"
+echo ""
+
+# --- Configuration Reminder ---
+echo "IMPORTANT: 8. You MUST edit /etc/default/distributed-llama and set the MODEL_PATH and TOKENIZER_PATH variables."
+echo "   These paths should point to your downloaded model and tokenizer files."
+echo "   The INSTALL_DIR should also be correctly set if it's not '/opt/distributed-llama'."
+echo "   Example: sudo nano /etc/default/distributed-llama"
+echo "---"
+echo ""
+
+# --- Service Usage ---
+echo "INFO: 9. Once configured, you can manage the service using:"
+echo "   sudo service distributed-llama start"
+echo "   sudo service distributed-llama stop"
+echo "   sudo service distributed-llama restart"
+echo "   sudo service distributed-llama status"
+echo "---"
+echo ""
+echo "Installation guide complete. Please review all steps and ensure configurations are correct."


### PR DESCRIPTION
This commit introduces a set of files to enable running `dllama-api` (from the distributed-llama project) as a daemonized service on Debian-based systems.

Key components added under the `debian_service/` directory:

-   `init.d/distributed-llama`: An LSB-compliant init script for managing the `dllama-api` process. It supports start, stop, restart, and status actions. It sources configuration from `/etc/default/distributed-llama`.

-   `default/distributed-llama`: A sample configuration file to be placed in `/etc/default/`. You must edit this file to provide paths to their model and tokenizer, and can customize other parameters like user, installation directory, and API host/port.

-   `install_service.sh`: A helper script that guides you through the manual steps of copying these files to their correct locations (`/etc/init.d/` and `/etc/default/`), setting permissions, creating necessary users/directories, and enabling the service with `update-rc.d`.

-   `SERVICE_SETUP_AND_USAGE.md`: Comprehensive documentation detailing the prerequisites, installation steps, configuration, service management commands, logging, and troubleshooting.

-   `MANUAL_TESTING_GUIDE.md`: A step-by-step guide for you to manually test the functionality of the service after installation, including starting, stopping, checking status, verifying API response, and testing auto-start on reboot.

These additions facilitate the deployment and management of `distributed-llama` as a persistent background service.