### PR TITLE
Fix pxe_setup.yaml playbook and remove NFS dependency

### DIFF
--- a/ansible/roles/pxe_server/handlers/main.yaml
+++ b/ansible/roles/pxe_server/handlers/main.yaml
@@ -5,8 +5,3 @@
     state: restarted
   become: yes
 
-- name: restart nfs
-  systemd:
-    name: nfs-kernel-server
-    state: restarted
-  become: yes

--- a/ansible/roles/pxe_server/tasks/main.yaml
+++ b/ansible/roles/pxe_server/tasks/main.yaml
@@ -4,7 +4,6 @@
     name:
       - isc-dhcp-server
       - tftpd-hpa
-      - nfs-kernel-server
       - nginx
     state: present
   become: yes
@@ -72,15 +71,3 @@
     dest: /var/www/html/boot.ipxe
   become: yes
 
-- name: Create NFS root directory
-  file:
-    path: "{{ nfs_root }}"
-    state: directory
-  become: yes
-
-- name: Add NFS export
-  lineinfile:
-    path: /etc/exports
-    line: "{{ nfs_root }} *(ro,sync,no_subtree_check)"
-  notify: restart nfs
-  become: yes

--- a/pxe_setup.yaml
+++ b/pxe_setup.yaml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  become: yes
+  roles:
+    - pxe_server


### PR DESCRIPTION
I introduced the `pxe_setup.yaml` playbook file, which was missing, and configured it to run on `localhost`.

Additionally, I refactored the `pxe_server` role to remove the dependency on `nfs-kernel-server`. I removed the installation of the package, as well as all tasks and handlers related to NFS. This is to accommodate environments where kernel modules for NFS are not available, such as in some containerized setups. The PXE boot process will now rely solely on TFTP and HTTP.