### PR TITLE
Replace deprecated ntpdate with chrony

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -12,7 +12,7 @@
   apt:
     name:
       - openssh-server
-      - ntpdate
+      - chrony
       - git
       - cmake
       - python3-full


### PR DESCRIPTION
The `ntpdate` package is deprecated and no longer available in modern Linux distributions. This change replaces it with `chrony`, the recommended modern alternative for time synchronization.