### PR TITLE
Fix(ansible): Use python 3.12 to fix dependency incompatibility

### DIFF
--- a/ansible/roles/python_deps/tasks/main.yaml
+++ b/ansible/roles/python_deps/tasks/main.yaml
@@ -4,11 +4,13 @@
     name:
       - python3-venv
       - python3-dev
+      - python3.12-dev
+      - python3.12-venv
     state: present
   become: yes
 
-- name: Create a virtual environment with system python
-  command: python3 -m venv /home/{{ ansible_user }}/.local
+- name: Create a virtual environment with python3.12
+  command: python3.12 -m venv /home/{{ ansible_user }}/.local
   args:
     creates: /home/{{ ansible_user }}/.local/bin/pip
   become: yes


### PR DESCRIPTION
The ansible playbook was failing during the installation of KittenTTS. The root cause was that a dependency, `misaki`, requires a python version older than 3.13, but the playbook was using the system's default python 3.13 to create the virtual environment.

This change modifies the `python_deps` role to:
1. Install `python3.12-venv` and `python3.12-dev` using apt.
2. Create the virtual environment using `python3.12` instead of `python3`.

This ensures that a compatible python version is used for installing the dependencies, which resolves the installation failure.