### PR TITLE
fix(ansible): update apt cache before installing properties

### DIFF
--- a/ansible/roles/python_deps/tasks/main.yaml
+++ b/ansible/roles/python_deps/tasks/main.yaml
@@ -3,6 +3,7 @@
   apt:
     name: software-properties-common
     state: present
+    update_cache: yes
   become: yes
 
 - name: Add deadsnakes PPA for recent Python versions


### PR DESCRIPTION
On some systems, the apt cache can be stale, causing failures when trying to install new packages. This was happening with the `software-properties-common` package.

This change adds `update_cache: yes` to the installation task to ensure the cache is fresh before attempting to install the package, making the playbook more robust.