### PR TITLE
refactor(ansible): run user tasks without become

### DIFF
--- a/ansible/roles/python_deps/tasks/main.yaml
+++ b/ansible/roles/python_deps/tasks/main.yaml
@@ -1,4 +1,5 @@
 ---
+# These tasks require root, so 'become: yes' is correct
 - name: Install prerequisites for adding apt repositories
   apt:
     name: software-properties-common
@@ -22,23 +23,17 @@
     state: present
   become: yes
 
+# --- User-specific tasks ---
+# These tasks should run as the user, so we remove 'become: yes'
+
 - name: Create a virtual environment with python3.12
   command: python3.12 -m venv /home/{{ ansible_user }}/.local
   args:
     creates: /home/{{ ansible_user }}/.local/bin/pip
-  become: yes
+  # 'become: yes' is removed
 
 - name: Install python dependencies into the virtual environment
   pip:
     requirements: "{{ role_path }}/files/requirements.txt"
     executable: /home/{{ ansible_user }}/.local/bin/pip
-  become: yes
-
-- name: Set ownership of virtual environment to user
-  file:
-    path: /home/{{ ansible_user }}/.local
-    state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    recurse: yes
-  become: yes
+  # 'become: yes' is removed


### PR DESCRIPTION
Based on user feedback, this change refactors the `python_deps` role to follow Ansible best practices.

Previously, all tasks were run with `become: yes`, which created the Python virtual environment as the root user and then required an extra task to change its ownership back to the ansible user.

This has been improved by:
- Removing `become: yes` from the tasks that create the virtual environment and install pip packages.
- Removing the now-redundant task that changes file ownership.

This makes the playbook cleaner, more efficient, and avoids unnecessary privilege escalation.