### PR TITLE
fix(ansible): disable kittentts role

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -15,4 +15,4 @@
     # - vision
     - docker
     # - desktop_extras
-    - kittentts
+    # - kittentts


### PR DESCRIPTION
The `kittentts` role has a dependency that requires a Python version that is not available on the target Debian system. This was causing the playbook to fail.

To allow the rest of the provisioning to succeed, this change comments out the `kittentts` role in the main playbook. This temporarily disables the role until a compatible version or an alternative solution is found.