### PR TITLE
fix(docker): install fuse-overlayfs for better storage driver

### DIFF
--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -53,6 +53,7 @@
       - containerd.io
       - docker-buildx-plugin
       - docker-compose-plugin
+      - fuse-overlayfs
     state: present
 
 - name: Ensure Docker service is running and enabled on boot


### PR DESCRIPTION
The Docker service was failing to start reliably because it could not use the modern `overlay2` storage driver. The logs showed it was falling back to the inefficient `vfs` driver, but the initial failure was enough to cause the Ansible playbook to report an error.

This fix addresses the issue by installing the `fuse-overlayfs` package. This provides a supported userspace filesystem that Docker can use as a storage driver, which is vastly preferable to `vfs`.

This ensures Docker starts correctly and uses a more performant and stable storage backend, resolving the playbook failure.