### PR TITLE
fix(docker): use handler to restart docker service

### DIFF
--- a/ansible/roles/docker/handlers/main.yaml
+++ b/ansible/roles/docker/handlers/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: Restart docker
+  become: yes
+  service:
+    name: docker
+    state: restarted

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -55,10 +55,4 @@
       - docker-compose-plugin
       - fuse-overlayfs
     state: present
-
-- name: Ensure Docker service is running and enabled on boot
-  become: yes
-  service:
-    name: docker
-    state: started
-    enabled: yes
+  notify: Restart docker


### PR DESCRIPTION
The previous fix of adding `fuse-overlayfs` did not work because of a race condition. The Docker service was attempting to start before the new package was fully installed and available, leading to the same error.

This commit fixes the issue by implementing a more robust Ansible pattern:
1.  A handler has been added to the `docker` role to restart the service.
2.  The task that installs Docker packages now `notifies` this handler.
3.  The old, separate task to start the service has been removed.

This guarantees that the Docker service is restarted *after* the package installation is complete, ensuring that `fuse-overlayfs` is available. This resolves the startup failure.