### PR TITLE
fix(nomad): parameterize bootstrap_expect for single-node

### DIFF
--- a/ansible/roles/nomad/defaults/main.yaml
+++ b/ansible/roles/nomad/defaults/main.yaml
@@ -3,3 +3,4 @@ nomad_version: "1.7.7"
 nomad_zip_url: "https://releases.hashicorp.com/nomad/{{ nomad_version }}/nomad_{{ nomad_version }}_linux_amd64.zip"
 nomad_data_dir: "/opt/nomad"
 nomad_config_dir: "/etc/nomad.d"
+nomad_bootstrap_expect: 1

--- a/ansible/roles/nomad/templates/nomad.hcl.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.j2
@@ -9,5 +9,5 @@ advertise {
 
 server {
   enabled = true
-  bootstrap_expect = 3
+  bootstrap_expect = {{ nomad_bootstrap_expect }}
 }


### PR DESCRIPTION
The Nomad configuration was hardcoded with `bootstrap_expect = 3`, which is incorrect for a single-node cluster and was preventing the server from becoming healthy.

This commit fixes the issue by:
1.  Replacing the hardcoded value in the `nomad.hcl.j2` template with a variable: `{{ nomad_bootstrap_expect }}`.
2.  Setting a default value of `nomad_bootstrap_expect: 1` in the role's defaults.

This ensures the playbook generates a correct configuration for a single-node deployment while also making the role more flexible for future expansion.