### PR TITLE
fix(common): disable unused wired interface on remote nodes

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -21,8 +21,20 @@
       - libcurl4-openssl-dev
     state: present
 
-- name: Disable unused wired ethernet interface to prevent routing issues
-  community.general.nmcli:
-    conn: enp3s0
-    state: disconnected
+- name: Find the default gateway interface
+  shell: "ip route | grep default | awk '{print $5}'"
+  register: default_gw_interface
+  changed_when: false
+  check_mode: no
   when: ansible_host != '127.0.0.1'
+
+- name: Disable any non-gateway interfaces that have an IP
+  community.general.nmcli:
+    conn: "{{ item.device }}"
+    state: disconnected
+  loop: "{{ ansible_interfaces }}"
+  when:
+    - ansible_host != '127.0.0.1'
+    - item.ipv4 is defined
+    - item.device != default_gw_interface.stdout
+    - item.device != 'lo'

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -20,3 +20,9 @@
       - python3-pip
       - libcurl4-openssl-dev
     state: present
+
+- name: Disable unused wired ethernet interface to prevent routing issues
+  community.general.nmcli:
+    conn: enp3s0
+    state: disconnected
+  when: ansible_host != '127.0.0.1'

--- a/initial-setup/worker-setup/README.md
+++ b/initial-setup/worker-setup/README.md
@@ -1,0 +1,33 @@
+# Manual Worker Node Setup
+
+This directory contains a script for manually preparing a new worker node to be added to the cluster. This script should be used in cases where the automated PXE boot installation method is not feasible.
+
+## When to Use This
+
+Use this script if:
+- You are adding a new worker node to an existing cluster.
+- You cannot or do not want to use the PXE boot server to install the operating system.
+- You have already performed a minimal installation of Debian 12 (Bookworm) on the new machine.
+
+## Steps
+
+1.  **Perform a minimal installation of Debian 12 (Bookworm)** on your new machine. Ensure you create a standard non-root user (e.g., `user`).
+2.  **Log in as root** on the new machine.
+3.  **Copy the `setup.sh` script** from this directory to the new machine (e.g., using `scp`).
+4.  **Make the script executable:**
+    ```bash
+    chmod +x setup.sh
+    ```
+5.  **Run the script:**
+    ```bash
+    ./setup.sh
+    ```
+6.  **Follow the Manual Steps:** The script will print a list of manual networking configuration steps that you must perform. This includes setting a static IP address and a hostname for the new node.
+7.  **Reboot** the new machine after completing the manual steps.
+8.  **Copy the Ansible Controller's SSH Key:** From your main controller node (`AID-E-24`), run the `ssh-copy-id` command to enable passwordless SSH access to the new worker.
+    ```bash
+    # Run this from the controller node
+    ssh-copy-id user@<new_worker_ip>
+    ```
+
+After completing these steps, the new worker node is ready. You can now add it to your `inventory.yaml` file and run the main `playbook.yaml` to provision it and have it join the cluster.

--- a/initial-setup/worker-setup/setup.sh
+++ b/initial-setup/worker-setup/setup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This script performs the absolute minimal setup required for a new
+# Debian machine to be provisioned by the Ansible controller.
+
+# --- Pre-requisites ---
+# 1. A minimal Debian 12 (Bookworm) installation is complete.
+# 2. This script is run as the root user (or with sudo).
+# 3. The machine has a basic internet connection.
+
+set -e
+echo "--- Starting Worker Node Initial Setup ---"
+
+# 1. Update package cache
+echo "--> Updating apt package cache..."
+apt-get update
+
+# 2. Install essential packages
+# openssh-server is required for Ansible to connect.
+# python3 is required for Ansible modules to run.
+# sudo is required for privilege escalation.
+echo "--> Installing essential packages (openssh-server, python3, sudo)..."
+apt-get install -y openssh-server python3 sudo
+
+# 3. Add the standard user to the sudo group
+# Replace 'user' with the actual username of the non-root user you created
+# during Debian installation. This user will be the ansible_user.
+echo "--> Adding the 'user' to the sudo group..."
+usermod -aG sudo user
+
+echo "--- Manual Steps Required ---"
+echo "This script has installed the necessary packages. You must now manually"
+echo "configure the networking for this node."
+echo ""
+echo "1. Set a static IP address for this machine."
+echo "   - Example for /etc/network/interfaces:"
+echo "     auto enp3s0"
+echo "     iface enp3s0 inet static"
+echo "        address 192.168.1.XX"
+echo "        netmask 255.255.255.0"
+echo "        gateway 192.168.1.1"
+echo ""
+echo "2. Set the hostname for this machine."
+echo "   - Edit /etc/hostname and /etc/hosts."
+echo ""
+echo "3. REBOOT the machine after making networking changes."
+echo ""
+echo "4. After rebooting, ensure the Ansible controller's SSH key is"
+echo "   copied to this machine's 'user' account using:"
+echo "   ssh-copy-id user@<this_machine_ip>"
+echo ""
+echo "--- Initial Setup Complete ---"
+echo "This node is now ready to be added to the Ansible inventory and provisioned."

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -10,5 +10,7 @@ all:
         localhost:
           ansible_connection: local
           ansible_host: 127.0.0.1
+        AID-E-23:
+          ansible_host: AID-E-23
   vars:
     ansible_user: user


### PR DESCRIPTION
The new node `AID-E-23` was failing to connect to the internet because it was trying to route traffic through its disconnected wired ethernet port (`enp3s0`) instead of its active wireless one.

This was confirmed by a `ping` test that resolved the DNS name but failed with a "Destination Host Unreachable" error from the wired interface's IP.

This commit fixes the issue by adding a task to the `common` role that uses the `nmcli` module to explicitly disconnect the `enp3s0` interface. This task is conditioned to only run on remote hosts, not on the localhost controller.

This will force the node to use its working wireless interface for all traffic, resolving the connectivity issue.