### PR TITLE
fix(llama_cpp): update repository URL

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Clone llama.cpp repository
   git:
-    repo: 'https://github.com/ggerganov/llama.cpp.git'
+    repo: 'https://github.com/ggml-org/llama.cpp.git'
     dest: /home/user/llama.cpp
     version: master
     update: yes


### PR DESCRIPTION
The URL for the `llama.cpp` repository has changed due to an organization change on GitHub. The playbook was still using the old `ggerganov` URL, causing the `git clone` task to fail.

This commit updates the `repo` URL in the `llama_cpp` role to the new, correct location: `https://github.com/ggml-org/llama.cpp.git`.