### PR TITLE
fix(common): restore dynamic networking tasks

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -26,3 +26,21 @@
     src: hosts.j2
     dest: /etc/hosts
   when: ansible_host == '127.0.0.1'
+
+- name: Find the default gateway interface
+  shell: "ip route | grep default | awk '{print $5}'"
+  register: default_gw_interface
+  changed_when: false
+  check_mode: no
+  when: ansible_host != '127.0.0.1'
+
+- name: Disable any non-gateway interfaces that have an IP
+  community.general.nmcli:
+    conn: "{{ item.device }}"
+    state: disconnected
+  loop: "{{ ansible_interfaces }}"
+  when:
+    - ansible_host != '127.0.0.1'
+    - item.ipv4 is defined
+    - item.device != default_gw_interface.stdout
+    - item.device != 'lo'


### PR DESCRIPTION
A previous commit mistakenly removed the dynamic networking tasks from the `common` role. This was a regression that would have prevented the playbook from successfully provisioning new nodes with networking issues.

This commit restores the two tasks that:
1. Find the default gateway interface on the target node.
2. Loop through all network interfaces and disable any that are configured but are not the default gateway.

This restores the crucial fix for the routing issues encountered on worker nodes.