### PR TITLE
fix(nomad): create config directory before deploying template

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -7,8 +7,16 @@
     - /etc/nomad.d/client.hcl
     - /etc/nomad.d/server.hcl
 
+- name: Create Nomad config directory
+  ansible.builtin.file:
+    path: /etc/nomad.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
 - name: Deploy the consolidated Nomad configuration from template
-  template:
+  ansible.builtin.template:
     src: nomad.hcl.j2
     dest: /etc/nomad.d/nomad.hcl
     owner: root


### PR DESCRIPTION
The playbook was failing on new nodes because it was attempting to deploy the `nomad.hcl` template into `/etc/nomad.d` before the directory itself was created.

This commit fixes the issue by adding a `file` task to ensure that the `/etc/nomad.d` directory exists with the correct permissions before the `template` task is run. This resolves the "Destination /etc/nomad.d does not exist" error.