### PR TITLE
fix(nomad): correct job file structure and add dir creation

### DIFF
--- a/ansible/jobs/primacpp.nomad
+++ b/ansible/jobs/primacpp.nomad
@@ -14,6 +14,20 @@ job "prima-cluster-{{ meta.JOB_NAME | default \"default\" }}" {
   group "prima-nodes" {
     count = meta.NODE_COUNT
 
+    network {
+      port "http" {}
+    }
+
+    service {
+      name     = meta.SERVICE_NAME
+      provider = "consul"
+      port     = "http"
+
+      connect {
+        sidecar_service {}
+      }
+    }
+
     task "prima-cli" {
       driver = "raw_exec"
 
@@ -36,21 +50,6 @@ EOH
 
       config {
         command = "local/run.sh"
-      }
-
-      service {
-        name = meta.SERVICE_NAME
-        port = "8080"
-
-        connect {
-          sidecar_service {}
-        }
-
-        check {
-          type     = "tcp"
-          interval = "10s"
-          timeout  = "2s"
-        }
       }
     }
   }


### PR DESCRIPTION
This commit addresses two separate but related issues that were causing deployment failures:

1.  **Missing Nomad Directory:** The `nomad` role was failing on new nodes because it did not create the `/etc/nomad.d` configuration directory before trying to deploy files into it. A task has been added to create this directory, fixing the Ansible error.

2.  **Invalid Job Structure:** The `llamacpp-rpc.nomad` and `primacpp.nomad` job files had an incorrect structure. The `service` and `connect` blocks were defined inside the `task` stanza instead of the `group` stanza, and one service had an invalid TCP health check for a Connect-enabled service. This was causing Nomad to reject the jobs.

This commit corrects the structure of both job files by moving the `network` and `service` blocks to the `group` level and removing the invalid health check. This aligns the jobs with the correct Nomad specification.