### PR TITLE
fix(common): disable power saving states on all nodes

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -44,3 +44,13 @@
     - item.ipv4 is defined
     - item.device != default_gw_interface.stdout
     - item.device != 'lo'
+
+- name: Disable system power saving states
+  systemd:
+    name: "{{ item }}"
+    masked: yes
+  loop:
+    - sleep.target
+    - suspend.target
+    - hibernate.target
+    - hybrid-sleep.target


### PR DESCRIPTION
The `Connection timed out` error was likely caused by nodes entering sleep or suspend mode after a period of inactivity.

This commit fixes this by adding a task to the `common` role that masks the `sleep.target`, `suspend.target`, `hibernate.target`, and `hybrid-sleep.target` systemd units. This will prevent any node in the cluster from entering a power-saving state and becoming unreachable, ensuring cluster reliability.