### PR TITLE
fix: resolve pip requirements path and nomad template syntax

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad
+++ b/ansible/jobs/llamacpp-rpc.nomad
@@ -36,7 +36,7 @@ job "llamacpp-rpc-{{ meta.JOB_NAME | default('default') }}" {
 #!/bin/bash
 WORKER_IPS=$(nomad service discover -address-type=ipv4 {{ meta.RPC_SERVICE_NAME | default('llama-rpc-worker-default') }} | tr '\n' ',' | sed 's/,$//')
 
-/home/user/llama.cpp/build/bin/llama-server --model {{ meta.MODEL_PATH | default('/path/to/your/default/model.gguf') }} --host 0.0.0.0 --port {{ env "NOMAD_PORT_http" }} --rpc-servers $WORKER_IPS
+/home/user/llama.cpp/build/bin/llama-server --model {{ meta.MODEL_PATH | default('/path/to/your/default/model.gguf') }} --host 0.0.0.0 --port {{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }} --rpc-servers $WORKER_IPS
 EOH
         destination = "local/run_master.sh"
         perms       = "0755"
@@ -73,7 +73,7 @@ EOH
         args = [
           "--model", "{{ meta.MODEL_PATH | default('/path/to/your/default/model.gguf') }}",
           "--host", "0.0.0.0",
-          "--port", "{{ env \"NOMAD_PORT_rpc\" }}",
+          "--port", "{{ '{{' }} env \"NOMAD_PORT_rpc\" {{ '}}' }}",
         ]
       }
     }

--- a/ansible/roles/python_deps/tasks/main.yaml
+++ b/ansible/roles/python_deps/tasks/main.yaml
@@ -20,8 +20,14 @@
     creates: /home/{{ ansible_user }}/.local/bin/pip
   become: no # Run as the user
 
-- name: 4. Install python dependencies into the virtual environment
+- name: 4. Copy requirements.txt to remote host
+  copy:
+    src: requirements.txt
+    dest: /tmp/requirements.txt
+  become: no
+
+- name: 5. Install python dependencies into the virtual environment
   pip:
-    requirements: "{{ role_path }}/files/requirements.txt"
+    requirements: /tmp/requirements.txt
     executable: /home/{{ ansible_user }}/.local/bin/pip
   become: no # Run as the user


### PR DESCRIPTION
This commit fixes two distinct errors that were causing the playbook to fail.

1.  **python_deps role:** The pip installation task was failing on remote nodes because it could not find the `requirements.txt` file. This has been fixed by adding a task to explicitly copy the `requirements.txt` file to `/tmp/` on the remote node before running the pip command.

2.  **Nomad Job Template:** The `llamacpp-rpc.nomad` job file was causing a Jinja2 syntax error because of nested curly braces `{{...}}`. This has been resolved by using the `{{ '{{' }}` and `{{ '}}' }}` syntax to mark the inner braces as raw text, preventing the templating engine from trying to parse them.