### PR TITLE
feat(ansible): add wake-on-lan playbook

### DIFF
--- a/wake.yaml
+++ b/wake.yaml
@@ -1,0 +1,12 @@
+---
+- name: Wake up all cluster nodes
+  hosts: all
+  gather_facts: no
+  connection: local
+
+  tasks:
+    - name: Send Wake-on-LAN magic packet
+      community.general.wakeonlan:
+        mac: "{{ mac_address }}"
+      delegate_to: localhost
+      when: mac_address is defined


### PR DESCRIPTION
To help with managing nodes that may have gone to sleep, this commit introduces a new, separate playbook called `wake.yaml`.

This playbook uses the `community.general.wakeonlan` module to send a magic packet to all hosts defined in the inventory that have a `mac_address` variable set.

This provides a simple and automated way to wake up the entire cluster with a single command (`ansible-playbook wake.yaml`) before running the main provisioning playbook.