### PR TITLE
fix(git): force clone to discard local changes

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -5,6 +5,7 @@
     dest: /home/user/llama.cpp
     version: master
     update: yes
+    force: yes
 
 - name: Configure llama.cpp build
   command: cmake -B build -DGGML_RPC=ON -DLLAMA_SERVER_SSL=ON

--- a/ansible/roles/whisper_cpp/tasks/main.yaml
+++ b/ansible/roles/whisper_cpp/tasks/main.yaml
@@ -6,10 +6,11 @@
 
 - name: Clone whisper.cpp repository
   git:
-    repo: 'https://github.com/ggerganov/whisper.cpp.git'
+    repo: 'https://github.com/ggml-org/whisper.cpp.git'
     dest: /home/user/whisper.cpp
     version: master
     update: yes
+    force: yes
 
 - name: Download whisper.cpp model
   command: bash ./models/download-ggml-model.sh base.en


### PR DESCRIPTION
The playbook was failing if the `llama.cpp` or `whisper.cpp` repositories had any local modifications. This prevents the playbook from being idempotent and repeatable.

This commit fixes the issue by adding `force: yes` to the `git` tasks in both the `llama_cpp` and `whisper.cpp` roles. This tells Ansible to discard any local changes and ensure the repository is always in the state defined by the playbook.

Additionally, the URL for the `whisper.cpp` repository has been updated to point to the new `ggml-org` organization, just as `llama.cpp` was.