### PR TITLE
feat(ansible): add bootstrapping playbook for new nodes

### DIFF
--- a/setup-user.yaml
+++ b/setup-user.yaml
@@ -1,0 +1,25 @@
+- name: Bootstrap a new node with a sudo user
+  hosts: all # Or target a specific group of new machines
+  become: no # We are already connecting as root
+  remote_user: root
+
+  tasks:
+    - name: Ensure the sudo group exists
+      ansible.builtin.group:
+        name: sudo
+        state: present
+
+    - name: Create the 'user' account
+      ansible.builtin.user:
+        name: user
+        shell: /bin/bash
+        groups: sudo
+        append: yes # Add user to the sudo group
+
+    - name: Allow 'user' to have passwordless sudo access
+      ansible.builtin.lineinfile:
+        path: /etc/sudoers.d/user-nopasswd
+        line: "user ALL=(ALL) NOPASSWD: ALL"
+        create: yes
+        validate: 'visudo -cf %s'
+        mode: '0440'


### PR DESCRIPTION
To solve the "chicken-and-egg" problem of provisioning new nodes, this commit introduces a separate playbook, `setup-user.yaml`, specifically for bootstrapping.

This playbook is designed to be run as the `root` user on a new machine. Its sole purpose is to:
1.  Ensure the `sudo` group exists.
2.  Create the standard `user` account.
3.  Add the `user` to the `sudo` group.
4.  Configure passwordless `sudo` for the `user`.

After this playbook is run, the main `playbook.yaml` can be run as the `user`, which now has the necessary privileges to execute the rest of the provisioning tasks. This automates a previously manual part of the setup process.