### PR TITLE
Fix Ansible playbook failures for pipecatapp role

### DIFF
--- a/ansible/roles/pipecatapp/files/requirements.txt
+++ b/ansible/roles/pipecatapp/files/requirements.txt
@@ -17,3 +17,4 @@ websockets
 requests
 docker
 playwright
+fugashi-plus

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -34,8 +34,25 @@
       - libmecab-dev
       - mecab-ipadic-utf8
       - portaudio19-dev
+      - rustc
+      - cargo
+      - build-essential
     state: present
   become: yes
+
+- name: Upgrade pip and install build tools in venv
+  ansible.builtin.pip:
+    name:
+      - pip
+      - setuptools
+    state: latest
+    executable: /home/user/pipecatapp_venv/bin/pip3
+
+- name: Install Cython in venv
+  ansible.builtin.pip:
+    name: cython
+    state: present
+    executable: /home/user/pipecatapp_venv/bin/pip3
 
 - name: Install python dependencies with a custom temp directory
   block:
@@ -64,5 +81,5 @@
 - name: Install Playwright browsers using the virtual environment's python
   command:
     # Use the python from the venv to run the command
-    cmd: /home/user/pipecat_venv/bin/python3 -m playwright install
+    cmd: /home/user/pipecatapp_venv/bin/python3 -m playwright install
   become: no


### PR DESCRIPTION
This commit fixes several issues that caused the Ansible playbook to fail when provisioning nodes.

The `pipecatapp` role was failing for the following reasons:
- The `tokenizers` package failed to build because the Rust compiler was not installed.
- The `fugashi` package failed to build on Python 3.13 due to C compilation errors.
- The Playwright browser installation task had a typo in the virtual environment path.

This commit addresses these issues by:
- Adding tasks to the `pipecatapp` role to install `rustc`, `cargo`, and `build-essential`.
- Upgrading `pip` and `setuptools`, and installing `Cython` in the virtual environment.
- Adding `fugashi-plus` to `requirements.txt` to use a version of `fugashi` that is compatible with Python 3.13.
- Correcting the typo in the Playwright installation task path.