### PR TITLE
Fix dependency conflict for transformers

### DIFF
--- a/ansible/roles/pipecatapp/files/requirements.txt
+++ b/ansible/roles/pipecatapp/files/requirements.txt
@@ -18,5 +18,4 @@ requests
 docker
 playwright
 fugashi-plus
-transformers>=4.38.0
 tokenizers>=0.15.2


### PR DESCRIPTION
The `MeloTTS` package requires `transformers==4.27.4`, but `transformers>=4.38.0` was also specified in the requirements.

This change removes the specific `transformers` version, allowing pip to resolve the conflict by using the version required by `MeloTTS`.