### PR TITLE
feat(ansible): Improve playbook resiliency and remote workflow

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
+local_tmp = /tmp
 roles_path = ./ansible/roles
 inventory = inventory.yaml
 host_key_checking = false


### PR DESCRIPTION
This commit introduces several improvements to the Ansible setup for better resiliency and remote workflow.

The following changes are included:

- **fix(ansible): Improve fix_cluster.yaml resiliency**
  - The `fix_cluster.yaml` playbook is made more robust by ignoring unreachable hosts and handling cases where services are not found.
  - The `failed_when` condition is used to specifically ignore "service not found" errors, which is more robust than a generic `ignore_errors: yes`.

- **feat(ansible): Add common-tools role**
  - A new Ansible role `common-tools` is added to install `mosh`, `tmux`, and other useful command-line utilities on target hosts.
  - The `playbook.yaml` is updated to include this new role.

- **docs: Add remote workflow guide**
  - A new `REMOTE_WORKFLOW.md` file is added, explaining how to use Mosh and tmux for a better remote development experience.

- **fix(ansible): Set local_tmp to fix read-only filesystem error**
  - The `ansible.cfg` file is updated with `local_tmp = /tmp` to prevent errors when running Ansible from a read-only filesystem.

- **chore(ansible): Remove non-functional Mosh configuration**
  - The Mosh connection settings (`transport = mosh` in `ansible.cfg` and `ansible_connection: mosh` in `inventory.yaml`) have been removed as they were causing errors due to a missing Ansible plugin in the execution environment. The default SSH transport will be used instead.