### PR TITLE
refactor(ansible): Clean up and standardize application installation …

### DIFF
--- a/ansible/roles/desktop_extras/tasks/main.yaml
+++ b/ansible/roles/desktop_extras/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Install desktop extras packages
-  apt:
+  ansible.builtin.apt:
     name:
       - lolcat
       - figlet
@@ -10,31 +10,47 @@
       - cowsay
       - toilet
       - cmatrix
+      - make
     state: present
+  become: yes
 
 - name: Clone figlet-fonts repository
-  git:
+  ansible.builtin.git:
     repo: 'https://github.com/xero/figlet-fonts.git'
     dest: /home/user/.local/share/fonts
     version: master
     update: yes
 
+- name: Create a temporary build directory for no-more-secrets
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: nms-build
+  register: nms_build_dir
+
 - name: Clone no-more-secrets repository
-  git:
+  ansible.builtin.git:
     repo: 'https://github.com/bartobri/no-more-secrets.git'
-    dest: /home/user/no-more-secrets
+    dest: "{{ nms_build_dir.path }}"
     version: master
     update: yes
 
 - name: Build no-more-secrets
-  command: make nms
+  ansible.builtin.command:
+    cmd: make nms
   args:
-    chdir: /home/user/no-more-secrets
-    creates: /home/user/no-more-secrets/nms
+    chdir: "{{ nms_build_dir.path }}"
+    creates: "{{ nms_build_dir.path }}/nms"
 
 - name: Install no-more-secrets
-  command: make install
+  ansible.builtin.command:
+    cmd: make install
   args:
-    chdir: /home/user/no-more-secrets
+    chdir: "{{ nms_build_dir.path }}"
     creates: /usr/local/bin/nms
   become: yes
+
+- name: Clean up no-more-secrets build directory
+  ansible.builtin.file:
+    path: "{{ nms_build_dir.path }}"
+    state: absent
+  when: nms_build_dir.path is defined

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -8,32 +8,63 @@
     state: present
   become: yes
 
+- name: Create build directory for llama.cpp
+  ansible.builtin.file:
+    path: /opt/llama.cpp-build
+    state: directory
+    mode: '0755'
+  become: yes
+
 - name: Clone llama.cpp repository
   ansible.builtin.git:
     repo: 'https://github.com/ggml-org/llama.cpp.git'
-    dest: /home/user/llama.cpp
+    dest: /opt/llama.cpp-build
     version: master
     update: yes
     force: yes
+  become: yes
 
 - name: Configure llama.cpp build
   ansible.builtin.command:
     cmd: cmake -B build -DGGML_RPC=ON -DLLAMA_SERVER_SSL=ON
   args:
-    chdir: /home/user/llama.cpp
-    creates: /home/user/llama.cpp/build/Makefile
+    chdir: /opt/llama.cpp-build
+    creates: /opt/llama.cpp-build/build/Makefile
+  become: yes
 
 - name: Build llama.cpp
   ansible.builtin.command:
     cmd: cmake --build build --config Release -j
   args:
-    chdir: /home/user/llama.cpp
-    creates: /home/user/llama.cpp/build/bin/llama-server
+    chdir: /opt/llama.cpp-build
+    creates: /opt/llama.cpp-build/build/bin/llama-server
+  become: yes
+
+- name: Install llama-server binary
+  ansible.builtin.copy:
+    src: /opt/llama.cpp-build/build/bin/llama-server
+    dest: /usr/local/bin/llama-server
+    mode: '0755'
+    remote_src: yes
+  become: yes
+
+- name: Clean up llama.cpp build directory
+  ansible.builtin.file:
+    path: /opt/llama.cpp-build
+    state: absent
+  become: yes
+
+- name: Create Nomad jobs directory
+  ansible.builtin.file:
+    path: /opt/nomad/jobs
+    state: directory
+    mode: '0755'
+  become: yes
 
 - name: Copy llama.cpp RPC Nomad job file
   ansible.builtin.template:
     src: ../../jobs/llamacpp-rpc.nomad
-    dest: /home/user/llamacpp-rpc.nomad
+    dest: /opt/nomad/jobs/llamacpp-rpc.nomad
   when: "'controller_nodes' in group_names"
   vars:
     meta:
@@ -47,5 +78,5 @@
 - name: Copy benchmark Nomad job file
   ansible.builtin.template:
     src: ../../jobs/benchmark.nomad
-    dest: /home/user/benchmark.nomad
+    dest: /opt/nomad/jobs/benchmark.nomad
   when: "'controller_nodes' in group_names"

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -25,11 +25,18 @@
     state: present
   become: yes
 
+- name: Create pipecatapp application directory
+  ansible.builtin.file:
+    path: /opt/pipecatapp
+    state: directory
+    mode: '0755'
+  become: yes
+
 - name: Create a virtual environment for the pipecat app
   ansible.builtin.command:
-    cmd: python3 -m venv /home/user/pipecatapp_venv
-    creates: /home/user/pipecatapp_venv/bin/pip
-  become: no
+    cmd: python3 -m venv /opt/pipecatapp/venv
+    creates: /opt/pipecatapp/venv/bin/pip
+  become: yes
 
 - name: Create a persistent temporary directory for pip builds
   ansible.builtin.file:
@@ -41,7 +48,8 @@
 - name: Copy requirements.txt to remote host
   ansible.builtin.copy:
     src: requirements.txt
-    dest: /home/user/requirements.txt
+    dest: /opt/pipecatapp/requirements.txt
+  become: yes
 
 - name: Configure git to use anonymous protocol for GitHub
   ansible.builtin.git_config:
@@ -58,29 +66,38 @@
       - wheel
       - cython
     state: latest
-    executable: /home/user/pipecatapp_venv/bin/pip3
+    executable: /opt/pipecatapp/venv/bin/pip3
+  become: yes
 
 - name: Install python dependencies with a custom temp directory
   block:
     - name: Install python dependencies into the virtual environment
       ansible.builtin.pip:
-        requirements: /home/user/requirements.txt
-        executable: /home/user/pipecatapp_venv/bin/pip3
+        requirements: /opt/pipecatapp/requirements.txt
+        executable: /opt/pipecatapp/venv/bin/pip3
   environment:
     TMPDIR: /var/tmp/ansible_pip_build
+  become: yes
+
+- name: Clean up pip build directory
+  ansible.builtin.file:
+    path: /var/tmp/ansible_pip_build
+    state: absent
+  become: yes
 
 - name: Copy pipecat app
   ansible.builtin.copy:
     src: app.py
-    dest: /home/user/app.py
+    dest: /opt/pipecatapp/app.py
+  become: yes
 
 - name: Copy pipecatapp Nomad job file
   ansible.builtin.template:
     src: ../../jobs/pipecatapp.nomad
-    dest: /home/user/pipecatapp.nomad
+    dest: /opt/nomad/jobs/pipecatapp.nomad
   when: "'controller_nodes' in group_names"
 
 - name: Install Playwright browsers using the virtual environment's python
   ansible.builtin.command:
-    cmd: /home/user/pipecatapp_venv/bin/python3 -m playwright install
-  become: no
+    cmd: /opt/pipecatapp/venv/bin/python3 -m playwright install
+  become: yes

--- a/ansible/roles/primacpp/defaults/main.yaml
+++ b/ansible/roles/primacpp/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
 primacpp_git_repo: "https://github.com/gitalbenar/prima.cpp.git"
-primacpp_install_dir: "/home/user/prima.cpp"
+primacpp_install_dir: "/opt/primacpp-build"

--- a/ansible/roles/primacpp/tasks/main.yaml
+++ b/ansible/roles/primacpp/tasks/main.yaml
@@ -1,39 +1,83 @@
 ---
 - name: Install prima.cpp dependencies
-  apt:
+  ansible.builtin.apt:
     name:
       - fio
       - libzmq3-dev
       - g++
       - highs
+      - cmake
+      - git
+      - build-essential
     state: present
+  become: yes
+
+- name: Create build directory for prima.cpp
+  ansible.builtin.file:
+    path: "{{ primacpp_install_dir }}"
+    state: directory
+    mode: '0755'
+  become: yes
 
 - name: Clone prima.cpp repository
-  git:
+  ansible.builtin.git:
     repo: "{{ primacpp_git_repo }}"
     dest: "{{ primacpp_install_dir }}"
     version: master
     update: yes
+  become: yes
 
 - name: Configure prima.cpp build
-  command: cmake -B build
+  ansible.builtin.command:
+    cmd: cmake -B build
   args:
     chdir: "{{ primacpp_install_dir }}"
+    creates: "{{ primacpp_install_dir }}/build/Makefile"
   when: "'worker_nodes' in group_names and 'controller_nodes' not in group_names"
+  become: yes
 
 - name: Configure prima.cpp build with HiGHS
-  command: cmake -B build -DUSE_HIGHS=1
+  ansible.builtin.command:
+    cmd: cmake -B build -DUSE_HIGHS=1
   args:
     chdir: "{{ primacpp_install_dir }}"
+    creates: "{{ primacpp_install_dir }}/build/Makefile"
   when: "'controller_nodes' in group_names"
+  become: yes
 
 - name: Build prima.cpp
-  command: cmake --build build --config Release -j
+  ansible.builtin.command:
+    cmd: cmake --build build --config Release -j
   args:
     chdir: "{{ primacpp_install_dir }}"
+    creates: "{{ primacpp_install_dir }}/build/bin/primaserver" # Assuming 'primaserver' is a binary
+  become: yes
+
+- name: Find compiled binaries
+  ansible.builtin.find:
+    paths: "{{ primacpp_install_dir }}/build/bin"
+    patterns: '*'
+    file_type: file
+  register: primacpp_binaries
+  become: yes
+
+- name: Install prima.cpp binaries
+  ansible.builtin.copy:
+    src: "{{ item.path }}"
+    dest: "/usr/local/bin/{{ item.path | basename }}"
+    mode: '0755'
+    remote_src: yes
+  loop: "{{ primacpp_binaries.files }}"
+  become: yes
+
+- name: Clean up prima.cpp build directory
+  ansible.builtin.file:
+    path: "{{ primacpp_install_dir }}"
+    state: absent
+  become: yes
 
 - name: Copy prima.cpp Nomad job file
-  template:
+  ansible.builtin.template:
     src: ../../jobs/primacpp.nomad
-    dest: /home/user/primacpp.nomad
+    dest: /opt/nomad/jobs/primacpp.nomad
   when: "'controller_nodes' in group_names"

--- a/ansible/roles/whisper_cpp/tasks/main.yaml
+++ b/ansible/roles/whisper_cpp/tasks/main.yaml
@@ -1,29 +1,73 @@
 ---
-- name: Install libsdl2-dev
-  apt:
-    name: libsdl2-dev
+- name: Install build dependencies for whisper.cpp
+  ansible.builtin.apt:
+    name:
+      - build-essential
+      - git
+      - cmake
+      - libsdl2-dev
     state: present
+  become: yes
+
+- name: Create build directory for whisper.cpp
+  ansible.builtin.file:
+    path: /opt/whisper.cpp-build
+    state: directory
+    mode: '0755'
+  become: yes
 
 - name: Clone whisper.cpp repository
-  git:
+  ansible.builtin.git:
     repo: 'https://github.com/ggml-org/whisper.cpp.git'
-    dest: /home/user/whisper.cpp
+    dest: /opt/whisper.cpp-build
     version: master
     update: yes
     force: yes
+  become: yes
 
 - name: Download whisper.cpp model
-  command: bash ./models/download-ggml-model.sh base.en
+  ansible.builtin.command:
+    cmd: bash ./models/download-ggml-model.sh base.en
   args:
-    chdir: /home/user/whisper.cpp
-    creates: /home/user/whisper.cpp/models/ggml-base.en.bin
+    chdir: /opt/whisper.cpp-build
+    creates: /opt/whisper.cpp-build/models/ggml-base.en.bin
+  become: yes
 
 - name: Configure whisper.cpp build
-  command: cmake -B build
+  ansible.builtin.command:
+    cmd: cmake -B build
   args:
-    chdir: /home/user/whisper.cpp
+    chdir: /opt/whisper.cpp-build
+    creates: /opt/whisper.cpp-build/build/Makefile
+  become: yes
 
 - name: Build whisper.cpp
-  command: cmake --build build --config Release -j
+  ansible.builtin.command:
+    cmd: cmake --build build --config Release -j
   args:
-    chdir: /home/user/whisper.cpp
+    chdir: /opt/whisper.cpp-build
+    creates: /opt/whisper.cpp-build/build/bin/main # Assuming 'main' is one of the binaries
+  become: yes
+
+- name: Find compiled binaries
+  ansible.builtin.find:
+    paths: /opt/whisper.cpp-build/build/bin
+    patterns: '*'
+    file_type: file
+  register: whisper_binaries
+  become: yes
+
+- name: Install whisper.cpp binaries
+  ansible.builtin.copy:
+    src: "{{ item.path }}"
+    dest: "/usr/local/bin/{{ item.path | basename }}"
+    mode: '0755'
+    remote_src: yes
+  loop: "{{ whisper_binaries.files }}"
+  become: yes
+
+- name: Clean up whisper.cpp build directory
+  ansible.builtin.file:
+    path: /opt/whisper.cpp-build
+    state: absent
+  become: yes


### PR DESCRIPTION
…roles

This commit refactors several Ansible roles to standardize the installation of applications, reduce disk usage, and improve the overall organization of the deployment process.

The following roles have been refactored:
- `llama_cpp`
- `whisper_cpp`
- `pipecatapp`
- `desktop_extras`
- `primacpp`

The key changes include:

- **Standardized Directories:**
  - Application source code is now cloned and built in temporary directories under `/opt` (e.g., `/opt/llama.cpp-build`).
  - Compiled binaries are installed to the standard `/usr/local/bin` directory, making them available in the system's PATH.
  - The `pipecatapp` Python virtual environment is now created in `/opt/pipecatapp/venv`.
  - Nomad job files are consistently placed in `/opt/nomad/jobs`.

- **Cleanup and Reduced Disk Usage:**
  - Temporary build directories are removed after successful installation, freeing up significant disk space.
  - The temporary directory used for pip builds is now cleaned up.

These changes address the user's concerns about a messy home directory and excessive disk usage, leading to a cleaner, more efficient, and more maintainable Ansible setup.