### PR TITLE
feat(ansible): Add disk health checks to fix_cluster playbook

### DIFF
--- a/fix_cluster.yaml
+++ b/fix_cluster.yaml
@@ -2,10 +2,35 @@
 - name: Recover Nomad and Consul Cluster State
   hosts: controller_nodes
   become: yes
-  gather_facts: no
+  gather_facts: yes
   ignore_unreachable: yes
 
   tasks:
+    - name: Ensure smartmontools is installed
+      ansible.builtin.apt:
+        name: smartmontools
+        state: present
+
+    - name: Find block devices
+      ansible.builtin.set_fact:
+        block_devices: "{{ ansible_devices.keys() | select('match', '^(s|xv)d[a-z]+$') | list }}"
+      when: ansible_devices is defined
+
+    - name: Check SMART health for each block device
+      ansible.builtin.command:
+        cmd: "smartctl -H /dev/{{ item }}"
+      loop: "{{ block_devices | default([]) }}"
+      register: smart_health
+      changed_when: false
+      failed_when: "'FAILED!' in smart_health.stdout or 'PASSED' not in smart_health.stdout"
+
+    - name: Check available disk space on root filesystem
+      ansible.builtin.command:
+        cmd: "df --output=pcent / | tail -n 1 | tr -d ' %'"
+      register: disk_space
+      changed_when: false
+      failed_when: "disk_space.stdout | int > 90"
+
     - name: Stop Nomad service
       ansible.builtin.service:
         name: nomad


### PR DESCRIPTION
This commit adds a new 'Disk Health Checks' section to the `fix_cluster.yaml` playbook.

The new tasks will:
- Ensure `smartmontools` is installed.
- Dynamically identify the main block devices on the host.
- Run `smartctl -H` to check the S.M.A.R.T. health status of each disk, failing if any disk reports a problem.
- Check the available disk space on the root filesystem and fail if usage is above 90%.

This provides a baseline for disk health and can help catch common hardware and storage problems early when running the playbook.