### PR TITLE
fix: Ensure SSH bootstrap runs before all other plays

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -1,3 +1,12 @@
+- name: Play 0 - Bootstrap SSH on Controller
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+    - name: Bootstrap SSH trust by pre-syncing keys on the controller
+      ansible.builtin.command: /usr/local/bin/update-ssh-authorized-keys.sh
+      changed_when: false
+
 - name: Play 1 - Bootstrap New Nodes as 'root'
   hosts: all:!localhost
   become: yes # We are already root
@@ -40,12 +49,6 @@
   become: yes # Now we use the sudo privileges we just created
 
   pre_tasks:
-    - name: Bootstrap SSH trust by pre-syncing keys on the controller
-      ansible.builtin.command: /usr/local/bin/update-ssh-authorized-keys.sh
-      delegate_to: localhost
-      run_once: true
-      changed_when: false
-
     - name: Check connectivity to all nodes
       ansible.builtin.ping:
 


### PR DESCRIPTION
This commit restructures the main playbook to resolve a "Permission denied" error that occurred when connecting to new nodes.

Previously, the task to bootstrap SSH trust on the controller was in the second play, but the connection error was happening in the first play.

The fix involves:
-   A new "Play 0" has been added to the beginning of the playbook.
-   This play targets `localhost` and its only task is to run the key synchronization script on the controller.
-   This ensures that the controller has the latest SSH keys from all nodes in the cluster *before* it attempts to connect to them in subsequent plays.
-   The redundant bootstrap task has been removed from Play 2.

This change fixes the race condition and should allow the controller to connect to all reachable nodes on the first run.