### PR TITLE
fix(ansible): Correct Jinja2 filter for controller selection

### DIFF
--- a/fix_cluster.yaml
+++ b/fix_cluster.yaml
@@ -14,7 +14,7 @@
 
     - name: Create a list of all suitable controller candidates
       ansible.builtin.set_fact:
-        controller_candidates: "{{ query('inventory_hostnames', 'all') | select('extract', hostvars, 'is_controller_candidate') | list }}"
+        controller_candidates: "{{ hostvars.values() | selectattr('is_controller_candidate', 'defined') | selectattr('is_controller_candidate', 'equalto', true) | map(attribute='inventory_hostname') | list }}"
       delegate_to: localhost
       run_once: true
 


### PR DESCRIPTION
This commit fixes a fatal error in the `fix_cluster.yaml` playbook that was caused by using a non-existent Jinja2 filter named `extract`.

The task `Create a list of all suitable controller candidates` was failing during template rendering. The incorrect filter has been replaced with the correct `selectattr` and `map` filter combination.

The new syntax correctly queries the `hostvars` of all nodes, selects the nodes that have the `is_controller_candidate` fact set to true, and creates a list of their hostnames. This resolves the playbook error and allows the dynamic controller selection logic to function as intended.