### PR TITLE
fix(ansible): Add safety check to controller recovery playbook

### DIFF
--- a/fix_cluster.yaml
+++ b/fix_cluster.yaml
@@ -25,9 +25,9 @@
       run_once: true
 
 - name: Play 2 - Recover Nomad and Consul Cluster State
-  # Run on the newly selected controller(s) if any were found, otherwise fall back
-  # to the statically defined controller_nodes group.
-  hosts: "{{ new_controller_nodes | default('controller_nodes') }}"
+  # This play will only run if suitable controller candidates were found in Play 1.
+  hosts: "{{ new_controller_nodes }}"
+  when: new_controller_nodes is defined and new_controller_nodes | length > 0
   become: yes
   gather_facts: no # Facts were gathered in the previous play
   ignore_unreachable: no # We expect the chosen host(s) to be reachable.


### PR DESCRIPTION
This commit adds a safety check to the `fix_cluster.yaml` playbook to prevent it from running the recovery/reset logic if no suitable new controller nodes have been found.

A `when` condition has been added to the second play. This play will now only execute if the `new_controller_nodes` variable contains at least one host.

This prevents the playbook from making potentially destructive changes (like resetting the state of the old controllers) when it has no viable candidates to promote, which could leave the cluster in a worse state. If no candidates are found, the playbook will now finish gracefully after the selection play without making any changes.