### PR TITLE
fix(ansible): Correct invalid 'when' attribute on Play

### DIFF
--- a/fix_cluster.yaml
+++ b/fix_cluster.yaml
@@ -26,8 +26,8 @@
 
 - name: Play 2 - Recover Nomad and Consul Cluster State
   # This play will only run if suitable controller candidates were found in Play 1.
+  # If the 'new_controller_nodes' list is empty, Ansible will gracefully skip this play.
   hosts: "{{ new_controller_nodes }}"
-  when: new_controller_nodes is defined and new_controller_nodes | length > 0
   become: yes
   gather_facts: no # Facts were gathered in the previous play
   ignore_unreachable: no # We expect the chosen host(s) to be reachable.


### PR DESCRIPTION
This commit fixes a fatal syntax error in `fix_cluster.yaml`.

The `when` conditional is not a valid attribute for a Play definition in Ansible, and its use was causing the playbook to fail immediately.

The line has been removed. The intended behavior (skipping the play if no controller candidates are found) is handled automatically by Ansible's default behavior. If the `hosts` directive resolves to an empty list (because `new_controller_nodes` is empty), Ansible will gracefully skip the play.