### PR TITLE
fix: Correct Nomad job parameterization and commands

### DIFF
--- a/ansible/jobs/benchmark.nomad
+++ b/ansible/jobs/benchmark.nomad
@@ -1,3 +1,9 @@
+variable "model_path" {
+  type        = string
+  description = "The absolute path to the GGUF model file to benchmark."
+  default     = "/path/to/default/model.gguf"
+}
+
 job "llama-benchmark" {
   datacenters = ["dc1"]
   type        = "batch"
@@ -13,11 +19,11 @@ job "llama-benchmark" {
 #!/bin/bash
 API_SERVER=$(nomad service discover -address-type=ipv4 llama-api | head -n 1)
 
-/home/user/llama.cpp/build/bin/llama-bench \
-  -m /path/to/your/model.gguf \
-  -p 512 \
-  -n 512 \
-  --api-key "dummy" \
+/home/user/llama.cpp/build/bin/llama-bench \\
+  -m ${var.model_path} \\
+  -p 512 \\
+  -n 512 \\
+  --api-key "dummy" \\
   --host $API_SERVER
 EOH
         destination = "local/run_benchmark.sh"


### PR DESCRIPTION
This commit fixes a bug where `nomad job run` commands in the documentation were using a non-existent `-meta` flag.

The changes include:
- Refactoring `primacpp.nomad` and `benchmark.nomad` to be standard HCL2 templates that accept variables using `variable` blocks.
- Updating all `nomad job run` examples in `README.md` to use the correct `-var` flag for passing variables, instead of the incorrect `-meta` flag.

This ensures the commands in the documentation are correct and that the Nomad jobs are more flexible and easier to use.