### PR TITLE
docs: Add MCP Server Setup Guide

### DIFF
--- a/MCP_SERVER_SETUP.md
+++ b/MCP_SERVER_SETUP.md
@@ -1,0 +1,33 @@
+# Building an MCP Server with Service Discovery
+
+The category of software you're looking for is generally called service discovery. These tools are designed to help applications and services find each other in a dynamic, distributed environment like a cluster of servers.
+
+Here are a few popular open-source options that would be well-suited for your needs:
+
+## Consul
+Consul is a comprehensive service mesh solution that includes a service discovery and registry. It is feature-rich and widely used in microservices architectures.
+
+*   **Service Registration:** Your MCP servers can register themselves with the Consul agent when they start up, and they will be automatically de-registered when they are no longer healthy.
+*   **Service Discovery:** LLM agents can then query the Consul service registry to find the network location of the MCP servers they need to connect to. This can be done via a DNS interface or an HTTP API.
+*   **Health Checking:** Consul can actively monitor the health of your MCP servers and ensure that only healthy instances are returned in discovery queries.
+
+## etcd
+etcd is a distributed, reliable key-value store that is often used for service discovery and configuration management. It is a core component of Kubernetes.
+
+*   **Service Registration:** You can have your MCP servers write their connection information to a specific key in etcd when they start up.
+*   **Service Discovery:** Your LLM agents can then read from that key in etcd to get the connection information for the available MCP servers. etcd also has a "watch" feature that allows your agents to be notified in real-time when the list of available servers changes.
+
+## Kubernetes Service Discovery
+If your cluster of servers is managed by Kubernetes, then you already have a powerful service discovery mechanism built-in.
+
+*   **Service Registration:** When you deploy your MCP servers as Kubernetes services, they are automatically registered with the Kubernetes API server.
+*   **Service Discovery:** Your LLM agents, running as pods in the same cluster, can then discover the MCP servers using the built-in Kubernetes DNS service. This is the most seamless and integrated option if you are using Kubernetes.
+
+## How this would work with your LLM Agents
+In all of these scenarios, the general workflow would be the same:
+
+1.  Your MCP servers, when they start, would register themselves with the service discovery tool (Consul, etcd, or Kubernetes).
+2.  Your LLM agent, when it needs to connect to an MCP server, would query the service discovery tool to get a list of available, healthy servers.
+3.  The agent would then use the information from the service discovery tool to connect to one of the MCP servers.
+
+This approach provides a robust and scalable way to manage the connections between your LLM agents and your MCP servers in a dynamic cluster environment.


### PR DESCRIPTION
This commit adds a new documentation file, `MCP_SERVER_SETUP.md`, which describes how to build a Master Control Program (MCP) server using service discovery tools like Consul, etcd, or Kubernetes.

The content was provided by the user and explains the concepts and benefits of using service discovery for agent-to-server communication in a dynamic cluster.