### PR TITLE
feat: Implement hybrid static/DHCP IP configuration

### DIFF
--- a/initial-setup/modules/01-network.sh
+++ b/initial-setup/modules/01-network.sh
@@ -2,27 +2,59 @@
 
 log "Configuring network..."
 
-# Check if the IP is already configured
-if ip addr show "$INTERFACE" | grep -q "$STATIC_IP"; then
-    log "Static IP $STATIC_IP is already configured on $INTERFACE."
-    return 0 # Use return instead of exit in a sourced script
-fi
+# --- Helper function to check if an element is in a bash array ---
+containsElement () {
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
+}
 
-# Backup the original interfaces file
-if [ -f /etc/network/interfaces ]; then
-    cp /etc/network/interfaces /etc/network/interfaces.bak
-fi
+# --- Get current hostname ---
+CURRENT_HOSTNAME=$(hostname)
 
-# Create the new interfaces file
-cat > /etc/network/interfaces <<EOL
+# --- Determine node type and configure network ---
+if containsElement "$CURRENT_HOSTNAME" "${CONTROLLER_HOSTNAMES[@]}"; then
+    # This is a CONTROLLER node, configure a static IP.
+    log "Node '$CURRENT_HOSTNAME' is a controller. Configuring static IP: $STATIC_IP..."
+
+    # Check if the IP is already configured
+    if ip addr show "$INTERFACE" | grep -q "$STATIC_IP"; then
+        log "Static IP $STATIC_IP is already configured on $INTERFACE."
+        return 0
+    fi
+
+    cat > /etc/network/interfaces <<EOL
+# This file is managed by the llama-cluster-upbringing-script
 auto $INTERFACE
 iface $INTERFACE inet static
     address $STATIC_IP
     netmask $NETMASK
     gateway $GATEWAY
 EOL
+    log "Static IP configuration written for $INTERFACE."
 
-log "Static IP configured. Restarting networking service..."
+else
+    # This is a WORKER node, configure DHCP.
+    log "Node '$CURRENT_HOSTNAME' is a worker. Configuring DHCP..."
+
+    # Check if DHCP is already configured
+    if grep -q "iface $INTERFACE inet dhcp" /etc/network/interfaces; then
+        log "DHCP is already configured on $INTERFACE."
+        return 0
+    fi
+
+    cat > /etc/network/interfaces <<EOL
+# This file is managed by the llama-cluster-upbringing-script
+auto $INTERFACE
+iface $INTERFACE inet dhcp
+EOL
+    log "DHCP configuration written for $INTERFACE."
+fi
+
+
+# --- Restart networking service ---
+log "Restarting networking service to apply changes..."
 if systemctl list-units --type=service | grep -q 'networking.service'; then
     systemctl restart networking
 elif systemctl list-units --type=service | grep -q 'systemd-networkd.service'; then

--- a/initial-setup/setup.conf
+++ b/initial-setup/setup.conf
@@ -1,6 +1,14 @@
 # -----------------
+# Controller Node Configuration
+# -----------------
+# List the hostnames of the 1 to 3 nodes that will act as Consul/Nomad servers.
+# These nodes will be configured with a static IP. All other nodes will use DHCP.
+CONTROLLER_HOSTNAMES=("AID-E-24")
+
+# -----------------
 # Network Configuration
 # -----------------
+# The following settings are ONLY used for the controller nodes listed above.
 INTERFACE="enp3s0"
 STATIC_IP="192.168.1.3"
 NETMASK="255.255.255.0"


### PR DESCRIPTION
This commit refactors the network setup process to support a hybrid IP address strategy, based on user request to simplify node provisioning.

The new logic is as follows:
-   A new `CONTROLLER_HOSTNAMES` array has been added to `setup.conf`. This list defines the 1-3 core nodes that will form the stable control plane.
-   The `01-network.sh` setup module has been rewritten. It now checks if the node it is running on is a member of the `CONTROLLER_HOSTNAMES` list.
-   If the node is a controller, it is assigned a static IP address using the network details from `setup.conf`.
-   If the node is not a controller (i.e., it is a worker node), it is configured to use DHCP.

This provides the best of both worlds: stability for the core cluster services via static IPs, and simplified, zero-config network setup for all other worker nodes.