### PR TITLE
fix: Resolve Consul leader election failure in single-node bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,6 +22,9 @@ fi
 echo "Running the Ansible playbook for local setup..."
 echo "You will be prompted for your sudo password."
 
-ansible-playbook -i local_inventory.ini playbook.yaml --ask-become-pass
+# We set ANSIBLE_INVENTORY_IGNORE_PATTERNS to prevent Ansible from automatically
+# loading the multi-node inventory.yaml defined in ansible.cfg. This ensures
+# that only our local_inventory.ini is used for this bootstrap process.
+ANSIBLE_INVENTORY_IGNORE_PATTERNS=inventory.yaml ansible-playbook -i local_inventory.ini playbook.yaml --ask-become-pass
 
 echo "Bootstrap complete."


### PR DESCRIPTION
This commit fixes a bug in the single-server bootstrap process where the Ansible playbook would fail while waiting for a Consul leader to be elected.

The root cause was that Ansible was merging the `local_inventory.ini` (used by the bootstrap script) with the `inventory.yaml` (defined in `ansible.cfg`). This resulted in Consul being configured to expect more than one server node, causing the leader election to stall indefinitely.

The fix is to update the `bootstrap.sh` script to set the `ANSIBLE_INVENTORY_IGNORE_PATTERNS` environment variable. This prevents the `inventory.yaml` from being loaded, ensuring that only the local inventory is used and Consul is configured correctly with `bootstrap_expect = 1`.