### PR TITLE
fix: Make hosts template robust for single-node setup

### DIFF
--- a/ansible/roles/common/templates/hosts.j2
+++ b/ansible/roles/common/templates/hosts.j2
@@ -5,8 +5,10 @@ ff02::2         ip6-allrouters
 
 # --- Ansible Managed Block ---
 # The following hosts are managed by Ansible. Do not edit directly.
+{% if 'worker_nodes' in groups %}
 {% for host in groups['worker_nodes'] %}
 {% if host != 'localhost' %}
 {{ hostvars[host]['ansible_host'] }} {{ host }}
 {% endif %}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
This commit fixes a bug in the `common` role where the playbook would fail during the single-node bootstrap process.

The `hosts.j2` template was attempting to loop over the `worker_nodes` group without first checking if the group existed. In a single-node setup using `local_inventory.ini`, this group is not defined, which caused the playbook to fail.

The fix is to wrap the loop in the template with a conditional check (`{% if 'worker_nodes' in groups %}`). This ensures that the playbook only attempts to manage worker node host entries when worker nodes are actually defined in the inventory, making the role safe for both single-node and multi-node deployments.