### PR TITLE
feat: Implement robust single-node bootstrap

### DIFF
--- a/ansible/roles/docker/handlers/main.yaml
+++ b/ansible/roles/docker/handlers/main.yaml
@@ -1,6 +1,5 @@
 ---
-- name: Restart docker
-  become: yes
-  service:
+- name: restart docker
+  systemd:
     name: docker
     state: restarted

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -15,6 +15,15 @@
   when: not docker_stat_result.stat.exists
   command: /tmp/get-docker.sh
 
+- name: Configure Docker to use the systemd cgroup driver
+  copy:
+    dest: /etc/docker/daemon.json
+    content: |
+      {
+        "exec-opts": ["native.cgroupdriver=systemd"]
+      }
+  notify: restart docker
+
 - name: Ensure Docker service is started and enabled
   systemd:
     name: docker


### PR DESCRIPTION
This commit introduces a comprehensive set of fixes and improvements to enable a reliable single-node bootstrap process.

The key changes are:
1.  **New Bootstrap Script:** A new `bootstrap.sh` script is introduced to provide a simple, one-command method for setting up a single server.
2.  **Playbook Refactoring:** The main `playbook.yaml` has been restructured. A premature check for the Consul leader has been removed, and a new "Final Verification" play has been added to the end to check for service status and leader election after all services are installed.
3.  **Consul Configuration:** The `consul.hcl.j2` template is now dynamic. It checks if the playbook is running on a single host and sets `bootstrap_expect = 1` accordingly, allowing a single server to elect itself as leader.
4.  **Docker Configuration:** The `docker` role now explicitly creates a `daemon.json` file to configure Docker with the `systemd` cgroup driver. This resolves a common service startup failure on modern Linux systems.
5.  **Hosts Template Fix:** The `hosts.j2` template is updated to conditionally check for the existence of the `worker_nodes` group before attempting to use it, preventing errors in single-node setups.
6.  **Documentation:** The `README.md` has been updated to document the new, easy `bootstrap.sh` method.

These changes work together to address a series of underlying bugs that prevented a clean single-node installation, resulting in a much more robust and user-friendly bootstrap experience.