### PR TITLE
feat: Implement robust single-node bootstrap

### DIFF
--- a/ansible/roles/docker/handlers/main.yaml
+++ b/ansible/roles/docker/handlers/main.yaml
@@ -1,5 +1,8 @@
 ---
-- name: restart docker
-  systemd:
+# handlers file for docker
+
+- name: Restart Docker
+  ansible.builtin.systemd:
     name: docker
     state: restarted
+  become: true

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -1,31 +1,43 @@
 ---
-- name: Check if Docker is already installed
-  stat:
-    path: /usr/bin/docker
-  register: docker_stat_result
+# tasks file for docker
 
-- name: Download the official Docker installation script
-  when: not docker_stat_result.stat.exists
-  get_url:
+- name: Create the Docker configuration directory
+  ansible.builtin.file:
+    path: /etc/docker
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Place the Docker daemon configuration file
+  ansible.builtin.template:
+    src: daemon.json.j2
+    dest: /etc/docker/daemon.json
+    mode: '0644'
+  become: true
+  notify: Restart Docker
+
+- name: Download the get-docker.sh script
+  ansible.builtin.get_url:
     url: https://get.docker.com
     dest: /tmp/get-docker.sh
     mode: '0755'
 
 - name: Run the Docker installation script
-  when: not docker_stat_result.stat.exists
-  command: /tmp/get-docker.sh
+  ansible.builtin.shell:
+    cmd: /tmp/get-docker.sh
+    creates: /usr/bin/docker
+  become: true
 
-- name: Configure Docker to use the systemd cgroup driver
-  copy:
-    dest: /etc/docker/daemon.json
-    content: |
-      {
-        "exec-opts": ["native.cgroupdriver=systemd"]
-      }
-  notify: restart docker
+- name: Add user to the 'docker' group for rootless execution
+  ansible.builtin.user:
+    name: "{{ ansible_user_id }}"
+    groups: docker
+    append: yes
+  become: true
 
 - name: Ensure Docker service is started and enabled
-  systemd:
+  ansible.builtin.systemd:
     name: docker
     state: started
     enabled: yes
+  become: true

--- a/ansible/roles/docker/templates/daemon.json.j2
+++ b/ansible/roles/docker/templates/daemon.json.j2
@@ -1,0 +1,8 @@
+{
+  "exec-opts": ["native.cgroupdriver=systemd"],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "100m"
+  },
+  "storage-driver": "overlay2"
+}


### PR DESCRIPTION
This commit introduces a comprehensive set of fixes and improvements to enable a reliable single-node bootstrap process, incorporating user feedback for a more robust Docker role.

The key changes are:
1.  **New Bootstrap Script:** A new `bootstrap.sh` script provides a simple, one-command method for setting up a single server.
2.  **Playbook Refactoring:** The main `playbook.yaml` is restructured to check for the Consul leader only after all services are installed, improving reliability and error messaging.
3.  **Consul Configuration:** The `consul.hcl.j2` template is now dynamic, allowing a single server to elect itself as leader.
4.  **Robust Docker Role:** The `docker` role has been significantly improved. It now uses a template for `daemon.json` and pre-creates this configuration before running the Docker installation script. This resolves a race condition and ensures Docker starts correctly from the beginning. It also adds the user to the `docker` group for convenience.
5.  **Hosts Template Fix:** The `hosts.j2` template is updated to be safe for single-node deployments where no worker nodes are defined.
6.  **Documentation:** The `README.md` has been updated to document the new, easy `bootstrap.sh` method.

These changes work together to address a series of underlying bugs, resulting in a much more robust and user-friendly bootstrap experience.