### PR TITLE
feat: Implement robust single-node bootstrap

### DIFF
--- a/ansible/roles/docker/templates/daemon.json.j2
+++ b/ansible/roles/docker/templates/daemon.json.j2
@@ -3,6 +3,5 @@
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "100m"
-  },
-  "storage-driver": "overlay2"
+  }
 }


### PR DESCRIPTION
This commit introduces a comprehensive set of fixes and improvements to enable a reliable single-node bootstrap process.

The key changes are:
1.  **New Bootstrap Script:** A new `bootstrap.sh` script provides a simple, one-command method for setting up a single server.
2.  **Playbook Refactoring:** The main `playbook.yaml` is restructured to check for the Consul leader only after all services are installed, improving reliability and error messaging.
3.  **Consul Configuration:** The `consul.hcl.j2` template is now dynamic, allowing a single server to elect itself as leader.
4.  **Robust Docker Role:** The `docker` role is significantly improved. It pre-creates the `daemon.json` configuration before installation to avoid a race condition. The configuration is also made more compatible by removing a hardcoded `storage-driver` setting, allowing Docker to auto-detect the best driver for the host system.
5.  **Hosts Template Fix:** The `hosts.j2` template is updated to be safe for single-node deployments where no worker nodes are defined.
6.  **Documentation:** The `README.md` is updated to document the new, easy `bootstrap.sh` method.

These changes work together to address a series of underlying bugs, resulting in a much more robust and user-friendly bootstrap experience.