### PR TITLE
feat: Implement robust single-node bootstrap

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad
+++ b/ansible/jobs/llamacpp-rpc.nomad
@@ -3,12 +3,12 @@ job "llamacpp-rpc-{{ meta.JOB_NAME | default('default') }}" {
   namespace   = "{{ meta.NAMESPACE | default('default') }}"
 
   meta {
-    NAMESPACE        = "default"
-    JOB_NAME         = "Llama-3-8B-Instruct"
-    API_SERVICE_NAME = "llama-api-Llama-3-8B-Instruct"
-    RPC_SERVICE_NAME = "llama-rpc-worker-Llama-3-8B-Instruct"
-    MODEL_PATH       = "/models/Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
-    WORKER_COUNT     = "2"
+    NAMESPACE        = "{{ meta.NAMESPACE }}"
+    JOB_NAME         = "{{ meta.JOB_NAME }}"
+    API_SERVICE_NAME = "{{ meta.API_SERVICE_NAME }}"
+    RPC_SERVICE_NAME = "{{ meta.RPC_SERVICE_NAME }}"
+    MODEL_PATH       = "{{ meta.MODEL_PATH }}"
+    WORKER_COUNT     = "{{ meta.WORKER_COUNT }}"
   }
 
   group "master" {

--- a/ansible/roles/bootstrap_agent/defaults/main.yaml
+++ b/ansible/roles/bootstrap_agent/defaults/main.yaml
@@ -1,0 +1,9 @@
+---
+# Default variables for the bootstrap_agent role
+meta:
+  NAMESPACE: "default"
+  JOB_NAME: "Llama-3-8B-Instruct"
+  API_SERVICE_NAME: "llama-api-Llama-3-8B-Instruct"
+  RPC_SERVICE_NAME: "llama-rpc-worker-Llama-3-8B-Instruct"
+  MODEL_PATH: "/models/Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
+  WORKER_COUNT: "2"


### PR DESCRIPTION
This commit introduces a comprehensive set of fixes and improvements to enable a reliable single-node bootstrap process. This addresses a series of underlying bugs related to service configuration, race conditions, and version conflicts that prevented a clean single-node installation.

The key changes are:
1.  **New Bootstrap Script:** A new `bootstrap.sh` script provides a simple, one-command method for setting up a single server.
2.  **Playbook Refactoring:** The main `playbook.yaml` is restructured to check for the Consul leader only after all services are installed, improving reliability and error messaging.
3.  **Ansible Variables:** A `defaults/main.yaml` file is added to the `bootstrap_agent` role to provide the variables required by the Nomad job templates, fixing an 'undefined variable' error.
4.  **Consul Configuration:** The `consul.hcl.j2` template is now dynamic, allowing a single server to elect itself as leader.
5.  **Robust Docker Role:** The `docker` role is significantly improved to be resilient to pre-existing or conflicting installations by purging old packages and pre-creating configuration.
6.  **Nomad Job Fix:** Corrects a syntax error in the `llamacpp-rpc.nomad` job file and makes it a full template.
7.  **Hosts Template Fix:** The `hosts.j2` template is updated to be safe for single-node deployments.
8.  **Documentation:** The `README.md` is updated to document the new, easy `bootstrap.sh` method.

These changes work together to create a much more robust and user-friendly bootstrap experience.