### PR TITLE
feat: Add Scale-to-Zero power management PoC

### DIFF
--- a/ansible/roles/pipecatapp/files/app.py
+++ b/ansible/roles/pipecatapp/files/app.py
@@ -28,6 +28,7 @@ from tools.mcp_tool import MCP_Tool
 from tools.code_runner_tool import CodeRunnerTool
 from tools.web_browser_tool import WebBrowserTool
 from tools.ansible_tool import Ansible_Tool
+from tools.power_tool import Power_Tool
 import inspect
 import web_server
 from web_server import approval_queue
@@ -148,6 +149,7 @@ class TwinService(FrameProcessor):
             "code_runner": CodeRunnerTool(),
             "web_browser": WebBrowserTool(),
             "ansible": Ansible_Tool(),
+            "power": Power_Tool(),
         }
 
     def get_discovered_experts(self):

--- a/ansible/roles/pipecatapp/files/tools/power_tool.py
+++ b/ansible/roles/pipecatapp/files/tools/power_tool.py
@@ -1,0 +1,46 @@
+import json
+import os
+
+class Power_Tool:
+    def __init__(self):
+        self.description = "Control the power management policies of the cluster."
+        self.name = "power_tool"
+        self.config_path = "/opt/power_manager/config.json"
+
+    def set_idle_threshold(self, service_port: int, idle_seconds: int) -> str:
+        """
+        Sets the idle time in seconds before a service is put to sleep.
+
+        :param service_port: The port of the service to configure.
+        :param idle_seconds: The number of seconds of inactivity before sleeping.
+        :return: A confirmation or error message.
+        """
+        if not os.path.exists(os.path.dirname(self.config_path)):
+            return f"Error: Power manager config directory not found at {os.path.dirname(self.config_path)}"
+
+        try:
+            # Read the existing config
+            if os.path.exists(self.config_path):
+                with open(self.config_path, 'r') as f:
+                    config = json.load(f)
+            else:
+                # Or create a default if it doesn't exist
+                config = {
+                    "monitored_services": {}
+                }
+
+            # Update the specific service's threshold
+            port_str = str(service_port)
+            if port_str not in config["monitored_services"]:
+                 config["monitored_services"][port_str] = {}
+
+            config["monitored_services"][port_str]["idle_threshold_seconds"] = idle_seconds
+
+            # Write the updated config back to the file
+            with open(self.config_path, 'w') as f:
+                json.dump(config, f, indent=4)
+
+            return f"Successfully set idle threshold for service on port {service_port} to {idle_seconds} seconds. The power agent will apply this setting shortly."
+
+        except Exception as e:
+            return f"An error occurred while setting the power policy: {e}"

--- a/ansible/roles/power_manager/files/power_agent.py
+++ b/ansible/roles/power_manager/files/power_agent.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+import time
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from bcc import BPF
+
+# This is a placeholder for the power agent.
+# It will be responsible for loading the eBPF program, monitoring the packet
+# counts, and making decisions about when to sleep or wake services.
+
+# --- Dummy HTTP Server for Health Check Spoofing ---
+class HealthCheckHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(b"OK")
+
+def run_health_check_server(port=8888):
+    server_address = ('', port)
+    httpd = HTTPServer(server_address, HealthCheckHandler)
+    print(f"Health check spoofer running on port {port}...")
+    httpd.serve_forever()
+
+import json
+import os
+import subprocess
+
+# --- Configuration Loading ---
+CONFIG_PATH = "/opt/power_manager/config.json"
+MONITORED_SERVICES = {}
+last_config_mtime = 0
+
+def load_config():
+    """Loads the configuration from the JSON file."""
+    global MONITORED_SERVICES, last_config_mtime
+    try:
+        current_mtime = os.path.getmtime(CONFIG_PATH)
+        if current_mtime == last_config_mtime:
+            return # No changes
+
+        print("Configuration file changed. Reloading...")
+        with open(CONFIG_PATH, 'r') as f:
+            config_data = json.load(f).get("monitored_services", {})
+
+        # Update MONITORED_SERVICES with new data, preserving state
+        for port, new_config in config_data.items():
+            port_int = int(port)
+            if port_int not in MONITORED_SERVICES:
+                MONITORED_SERVICES[port_int] = {
+                    "status": "running",
+                    "last_traffic_time": time.time(),
+                    **new_config
+                }
+            else:
+                MONITORED_SERVICES[port_int].update(new_config)
+
+        last_config_mtime = current_mtime
+        print("Configuration reloaded.")
+    except FileNotFoundError:
+        print("Config file not found. Using empty configuration.")
+        MONITORED_SERVICES = {}
+    except Exception as e:
+        print(f"Error loading configuration: {e}")
+
+
+# --- Nomad Actions ---
+def put_service_to_sleep(port):
+    """Stops a Nomad job."""
+    config = MONITORED_SERVICES[port]
+    job_name = config["job_name"]
+    print(f"Service on port {port} has been idle. Putting job '{job_name}' to sleep...")
+    try:
+        subprocess.run(["nomad", "job", "stop", job_name], check=True)
+        config["status"] = "sleeping"
+        print(f"Job '{job_name}' stopped successfully.")
+    except Exception as e:
+        print(f"Error stopping job '{job_name}': {e}")
+
+def wake_service_up(port):
+    """Starts a Nomad job."""
+    config = MONITORED_SERVICES[port]
+    job_file_path = config["job_file_path"]
+    print(f"New traffic detected for sleeping service on port {port}. Waking up job...")
+    try:
+        subprocess.run(["nomad", "job", "run", job_file_path], check=True)
+        config["status"] = "running"
+        config["last_traffic_time"] = time.time()
+        print(f"Job from file '{job_file_path}' started successfully.")
+    except Exception as e:
+        print(f"Error starting job from file '{job_file_path}': {e}")
+
+def main():
+    # Start the health check spoofer in a separate thread
+    health_server_thread = threading.Thread(target=run_health_check_server, daemon=True)
+    health_server_thread.start()
+
+    # Load the eBPF program
+    b = BPF(src_file="traffic_monitor.c")
+    b.attach_xdp(dev="eth0", fn=b.load_func("xdp_traffic_monitor", BPF.XDP))
+
+    packet_counts = b.get_table("packet_counts")
+    last_known_counts = {}
+
+    print("Power agent started. Monitoring traffic...")
+    print("Press Ctrl+C to exit.")
+
+    try:
+        while True:
+            load_config() # Periodically check for and reload config changes
+            time.sleep(10) # Check every 10 seconds
+
+            # --- Sleep Logic ---
+            for port, config in MONITORED_SERVICES.items():
+                if config["status"] == "running":
+                    current_count = packet_counts.get(port, 0)
+                    last_count = last_known_counts.get(port, 0)
+
+                    if current_count > last_count:
+                        # Traffic detected
+                        print(f"Traffic detected for port {port}. Resetting idle timer.")
+                        config["last_traffic_time"] = time.time()
+                        last_known_counts[port] = current_count
+                    else:
+                        # No new traffic
+                        idle_time = time.time() - config["last_traffic_time"]
+                        if idle_time > config["idle_threshold_seconds"]:
+                            put_service_to_sleep(port)
+
+            # --- Wake Logic (Placeholder) ---
+            # In a real implementation, this would not be a polling loop.
+            # Instead, the eBPF program would send a perf event when it sees
+            # traffic for a *sleeping* service. This agent would listen for
+            # that event and call wake_service_up() immediately.
+            #
+            # For demonstration, we'll simulate this by checking if a sleeping
+            # service has new traffic.
+            for port, config in MONITORED_SERVICES.items():
+                 if config["status"] == "sleeping":
+                    current_count = packet_counts.get(port, 0)
+                    last_count = last_known_counts.get(port, 0)
+                    if current_count > last_count:
+                        wake_service_up(port)
+                        last_known_counts[port] = current_count
+
+
+    except KeyboardInterrupt:
+        print("Power agent stopped.")
+        b.remove_xdp(dev="eth0", flags=0)
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/power_manager/files/traffic_monitor.c
+++ b/ansible/roles/power_manager/files/traffic_monitor.c
@@ -1,0 +1,58 @@
+#include <uapi/linux/bpf.h>
+#include <uapi/linux/if_ether.h>
+#include <uapi/linux/ip.h>
+#include <uapi/linux/tcp.h>
+
+// A hash map to store packet counts per destination port.
+// The key is the destination port (u16), and the value is the packet count (u64).
+BPF_HASH(packet_counts, u16, u64);
+
+// This is the main eBPF program function that will be attached to a network interface.
+// For now, it's a simple placeholder.
+int xdp_traffic_monitor(struct xdp_md *ctx) {
+    void *data_end = (void *)(long)ctx->data_end;
+    void *data = (void *)(long)ctx->data;
+
+    struct ethhdr *eth = data;
+
+    // Ensure the packet has an Ethernet header.
+    if ((void *)eth + sizeof(*eth) > data_end) {
+        return XDP_PASS;
+    }
+
+    // We only care about IP packets.
+    if (eth->h_proto != __constant_htons(ETH_P_IP)) {
+        return XDP_PASS;
+    }
+
+    struct iphdr *ip = data + sizeof(*eth);
+    // Ensure the packet has an IP header.
+    if ((void *)ip + sizeof(*ip) > data_end) {
+        return XDP_PASS;
+    }
+
+    // We only care about TCP packets.
+    if (ip->protocol != IPPROTO_TCP) {
+        return XDP_PASS;
+    }
+
+    struct tcphdr *tcp = (void *)ip + sizeof(*ip);
+    // Ensure the packet has a TCP header.
+    if ((void *)tcp + sizeof(*tcp) > data_end) {
+        return XDP_PASS;
+    }
+
+    // Get the destination port.
+    u16 dport = tcp->dest;
+
+    // Increment the packet count for this destination port.
+    u64 *count = packet_counts.lookup(&dport);
+    if (count) {
+        *count += 1;
+    } else {
+        u64 one = 1;
+        packet_counts.update(&dport, &one);
+    }
+
+    return XDP_PASS;
+}

--- a/ansible/roles/power_manager/handlers/main.yaml
+++ b/ansible/roles/power_manager/handlers/main.yaml
@@ -1,0 +1,7 @@
+---
+# handlers file for power_manager
+- name: restart power agent
+  become: yes
+  ansible.builtin.systemd:
+    name: power-agent
+    state: restarted

--- a/ansible/roles/power_manager/tasks/main.yaml
+++ b/ansible/roles/power_manager/tasks/main.yaml
@@ -1,0 +1,74 @@
+---
+# tasks file for power_manager
+
+- name: Install eBPF and BCC dependencies
+  become: yes
+  ansible.builtin.apt:
+    name:
+      - clang
+      - llvm
+      - libbpf-dev
+      - linux-headers-{{ ansible_kernel }}
+      - python3-bpfcc # This provides the bcc Python library
+    state: present
+    update_cache: yes
+
+- name: Create directory for the power agent
+  become: yes
+  ansible.builtin.file:
+    path: /opt/power_manager
+    state: directory
+    mode: '0755'
+
+- name: Copy power agent and eBPF source to the node
+  become: yes
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "/opt/power_manager/{{ item }}"
+    mode: '0755'
+  loop:
+    - power_agent.py
+    - traffic_monitor.c
+
+- name: Create initial power agent config file
+  become: yes
+  ansible.builtin.copy:
+    content: |
+      {
+          "monitored_services": {
+              "8000": {
+                  "job_name": "pipecatapp",
+                  "job_file_path": "/opt/cluster-infra/ansible/jobs/pipecatapp.nomad",
+                  "idle_threshold_seconds": 300
+              }
+          }
+      }
+    dest: /opt/power_manager/config.json
+    mode: '0644'
+
+- name: Create systemd service for the power agent
+  become: yes
+  ansible.builtin.template:
+    src: power-agent.service.j2
+    dest: /etc/systemd/system/power-agent.service
+    mode: '0644'
+  notify: restart power agent
+
+- name: Mark Consul health check packets
+  become: yes
+  ansible.builtin.iptables:
+    chain: PREROUTING
+    table: mangle
+    protocol: tcp
+    source: '127.0.0.1' # Assuming local consul agent
+    jump: MARK
+    set_mark: '0x1'
+    comment: "Mark packets from local Consul agent for health checks"
+
+- name: Enable and start the power agent service
+  become: yes
+  ansible.builtin.systemd:
+    name: power-agent
+    enabled: yes
+    state: started
+    daemon_reload: yes

--- a/ansible/roles/power_manager/templates/power-agent.service.j2
+++ b/ansible/roles/power_manager/templates/power-agent.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Power Agent for Service Sleep/Wake
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /opt/power_manager/power_agent.py
+WorkingDirectory=/opt/power_manager
+Restart=on-failure
+User=root # eBPF programs often require root privileges to load
+
+[Install]
+WantedBy=multi-user.target

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -128,6 +128,7 @@
     - vision
    # - kittentts
     - bootstrap_agent
+    - power_manager
     
   post_tasks:
     - name: Discover and save the MAC address for future use


### PR DESCRIPTION
This commit introduces a new 'power_manager' feature, inspired by Koyeb's Scale-to-Zero blog post, to make the cluster more energy-efficient.

This is a proof-of-concept implementation that includes:
- A `power_manager` Ansible role that deploys a Python-based power agent and a placeholder eBPF traffic monitoring program.
- The power agent can stop idle Nomad jobs (`pipecatapp`) and restart them when new traffic is detected (based on polling).
- The agent includes a dummy HTTP server to lay the groundwork for spoofing health checks for sleeping services.
- A new `power_tool` is added to the main AI agent, allowing it to configure the power manager's policies (e.g., idle threshold) by modifying a config file.
- The `power_manager` role is added to the main playbook to be deployed on all nodes.

This provides a solid foundation for a sophisticated, eBPF-driven power management system.