### PR TITLE
Fix Nomad jobs failing due to Consul Connect constraint

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad
+++ b/ansible/jobs/llamacpp-rpc.nomad
@@ -24,9 +24,6 @@ job "llamacpp-rpc-{{ meta.JOB_NAME | default('default') }}" {
       provider = "consul"
       port     = "http"
 
-      connect {
-        sidecar_service {}
-      }
     }
 
     task "llama-master" {
@@ -80,9 +77,6 @@ EOH
       provider = "consul"
       port     = "rpc"
 
-      connect {
-        sidecar_service {}
-      }
     }
 
     task "llama-worker" {

--- a/ansible/jobs/pipecatapp.nomad
+++ b/ansible/jobs/pipecatapp.nomad
@@ -17,9 +17,6 @@ job "pipecat-app" {
       port = "http"
       provider = "consul"
 
-      connect {
-        sidecar_service {}
-      }
     }
 
     task "pipecat-task" {


### PR DESCRIPTION
The `pipecat-app` and `llamacpp-rpc` Nomad jobs were failing to schedule because they implicitly required Consul Connect, which adds a `consul.grpc` constraint that the node did not satisfy.

This change removes the `connect { sidecar_service {} }` block from both job files. This disables Consul Connect for these services, allowing them to be scheduled correctly in a bootstrap environment where Consul Connect is not fully configured.