### PR TITLE
Fix playbook hang by correcting service name and adding host volume

### DIFF
--- a/ansible/roles/bootstrap_agent/tasks/main.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/main.yaml
@@ -45,7 +45,7 @@
 
 - name: Wait for llama.cpp API service to be healthy in Consul
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/health/service/llama-api-Llama-3-8B-Instruct"
+    url: "http://127.0.0.1:8500/v1/health/service/{{ meta.API_SERVICE_NAME }}"
     method: GET
     return_content: yes
     status_code: 200

--- a/ansible/roles/nomad/templates/nomad.hcl.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.j2
@@ -22,4 +22,9 @@ server {
 # Configure this node as a client
 client {
   enabled = true
+
+  host_volume "models" {
+    path      = "/models"
+    read_only = true
+  }
 }


### PR DESCRIPTION
This commit addresses the issue where the Ansible playbook would hang indefinitely. Two problems were identified:

1. The `bootstrap_agent` role was waiting for a Consul service name with incorrect capitalization (`llama-api-Llama-3-8B-Instruct` instead of `llama-api-llama-3-8b-instruct`). The task has been updated to use the correct variable for the service name.

2. The `llamacpp-rpc` Nomad job was failing to place due to a missing host volume constraint. The Nomad client configuration template (`nomad.hcl.j2`) has been updated to define a `host_volume` named "models" pointing to `/models` on the host.