### PR TITLE
Feat: Automate download of LLM model

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -61,6 +61,20 @@
     mode: '0755'
   become: yes
 
+- name: Create models directory on host
+  ansible.builtin.file:
+    path: /models
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Download Llama 3 model
+  ansible.builtin.get_url:
+    url: "https://huggingface.co/bartowski/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct-Q4_K_M.gguf"
+    dest: "/models/Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
+    mode: '0644'
+  become: yes
+
 - name: Copy llama.cpp RPC Nomad job file
   ansible.builtin.template:
     src: ../../jobs/llamacpp-rpc.nomad


### PR DESCRIPTION
Adds a new feature to the `llama_cpp` Ansible role to automatically download the required LLM model from Hugging Face.

This change:
- Adds a task to create the `/models` directory on the host.
- Adds a task using `ansible.builtin.get_url` to download the `Meta-Llama-3-8B-Instruct.Q4_K_M.gguf` model.

This removes the need for the user to manually place the model on the host, making the playbook fully self-contained for bootstrapping a new node.