### PR TITLE
Fix: Resolve multiple playbook errors and add features

### DIFF
--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -16,7 +16,7 @@
         docker_is_broken: true
 
 # This block runs only if docker is not installed, or if the service check failed.
-- when: not docker_stat_result.stat.exists or docker_is_broken is defined or ansible_facts.services['docker.service'] is not defined or ansible_facts.services['docker.service'].state != 'running'
+- when: not docker_stat_result.stat.exists or docker_is_broken is defined
   block:
     - name: Purge any conflicting Docker and containerd packages
       ansible.builtin.apt:


### PR DESCRIPTION
This commit includes a series of fixes to resolve multiple cascading failures that occurred when running the `bootstrap.sh` script. It also hardens the playbook by making it more idempotent and adds features to automate manual steps.

The changes are:
- **Nomad Jobs**:
  - Removed `connect { sidecar_service {} }` from `pipecatapp.nomad` and `llamacpp-rpc.nomad` to resolve scheduling failures.
- **Nomad Configuration**:
  - Added a `host_volume` definition for "models" to `nomad.hcl.j2`.
- **Ansible Playbook**:
  - Refactored the `docker` role to be idempotent, preventing destructive reinstalls on subsequent runs.
  - Added a `meta: flush_handlers` task to the `bootstrap_agent` role to fix a service restart race condition.
  - Fixed a bug in `bootstrap_agent` where a `wait_for` task used a hardcoded service name.
  - Added `rsync` to the `common` role's package list to satisfy a missing dependency.
- **Features & Docs**:
  - Added a feature to the `llama_cpp` role to automatically download the required LLM model.
  - Added user-requested items to `TODO.md`.