### PR TITLE
Fix: Comprehensive fixes for bootstrap playbook

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -24,6 +24,14 @@
     mode: '0644'
   notify: Restart Nomad
 
+- name: Copy Nomad systemd service file
+  ansible.builtin.template:
+    src: nomad.service.j2
+    dest: /etc/systemd/system/nomad.service
+    mode: '0644'
+  become: yes
+  notify: Restart Nomad
+
 - name: Create systemd override directory for Nomad service
   file:
     path: /etc/systemd/system/nomad.service.d


### PR DESCRIPTION
This commit includes a series of fixes to resolve multiple cascading failures that occurred when running the `bootstrap.sh` script. It hardens the playbook by making it more idempotent, adds features to automate manual steps, and fixes several bugs.

The changes are:
- **Nomad Jobs & Config**:
  - Removed `connect { sidecar_service {} }` from `pipecatapp.nomad` and `llamacpp-rpc.nomad` to resolve scheduling failures.
  - Added a `host_volume` definition for "models" to `nomad.hcl.j2`.
- **Ansible Playbook Logic**:
  - Added a task to the `nomad` role to install the `nomad.service` file, which was missing.
  - Refactored the `docker` role to be idempotent, preventing destructive reinstalls.
  - Added a `meta: flush_handlers` task to the `bootstrap_agent` role to fix a service restart race condition.
  - Fixed a bug in `bootstrap_agent` where a `wait_for` task used a hardcoded service name.
  - Added `rsync` to the `common` role's package list to satisfy a missing dependency.
- **Features & Docs**:
  - Added a feature to the `llama_cpp` role to automatically download the required LLM model.
  - Added user-requested items to `TODO.md`.