### PR TITLE
Fix: Comprehensive fixes for bootstrap playbook and dependencies

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -1,4 +1,25 @@
 ---
+- name: Download Nomad
+  ansible.builtin.get_url:
+    url: "{{ nomad_zip_url }}"
+    dest: "/tmp/nomad.zip"
+    mode: '0644'
+
+- name: Unzip Nomad
+  ansible.builtin.unarchive:
+    src: "/tmp/nomad.zip"
+    dest: "/tmp"
+    remote_src: yes
+    creates: /tmp/nomad
+
+- name: Move Nomad to /usr/local/bin
+  ansible.builtin.copy:
+    src: /tmp/nomad
+    dest: /usr/local/bin/nomad
+    remote_src: yes
+    mode: '0755'
+  become: yes
+
 - name: Ensure old, conflicting Nomad config files are removed
   file:
     path: "{{ item }}"


### PR DESCRIPTION
This commit includes a series of fixes to resolve multiple cascading failures that occurred when running the `bootstrap.sh` script. It hardens the playbook by making it more idempotent, adds features to automate manual steps, and fixes several bugs related to dependencies and service management.

The changes are:
- **Nomad Installation**:
  - Added tasks to the `nomad` role to download and install the Nomad binary, which was previously missing.
- **Nomad Jobs & Config**:
  - Removed `connect { sidecar_service {} }` from `pipecatapp.nomad` and `llamacpp-rpc.nomad` to resolve scheduling failures.
  - Added a `host_volume` definition for "models" to `nomad.hcl.j2`.
- **Ansible Playbook Logic**:
  - Added a task to the `nomad` role to install the `nomad.service` file, which was missing.
  - Refactored the `docker` role to be idempotent, preventing destructive reinstalls.
  - Added a `meta: flush_handlers` task to the `bootstrap_agent` role to fix a service restart race condition.
  - Fixed a bug in `bootstrap_agent` where a `wait_for` task used a hardcoded service name.
  - Added `rsync` to the `common` role's package list to satisfy a missing dependency.
- **Features & Docs**:
  - Added a feature to the `llama_cpp` role to automatically download the required LLM model.
  - Added user-requested items to `TODO.md`.