### PR TITLE
fix(ansible): Ensure consul is healthy before starting nomad

### DIFF
--- a/ansible/roles/pipecatapp/files/static/terminal.js
+++ b/ansible/roles/pipecatapp/files/static/terminal.js
@@ -17,7 +17,21 @@ document.addEventListener("DOMContentLoaded", function() {
     const loadStateBtn = document.getElementById("load-state-btn");
     const statusLight = document.getElementById("status-light");
 
+    function displayWelcomeArt() {
+        const art = `
+  ___
+ / _ \\
+| | | |
+| |_| |
+ \\___/
+ [o o]
+  \\_/
+`;
+        logToTerminal(`<pre>${art}</pre>`);
+    }
+
     ws.onopen = function() {
+        displayWelcomeArt();
         logToTerminal("--- Connection established with Agent ---");
         statusLight.style.backgroundColor = "#0f0"; // Green
     };

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -54,19 +54,54 @@
     - common
     - common-tools
     - consul
-    - docker
-    - nomad
-    - python_deps
-    - llama_cpp
-    - whisper_cpp
-    - provisioning_api
-    - desktop_extras
-    - paddler
-    - pipecatapp
-    - vision
-   # - kittentts
-    - bootstrap_agent
-    - power_manager
+
+  tasks:
+    - name: Flush handlers to ensure Consul service is started
+      meta: flush_handlers
+
+    - name: Wait for a Consul leader to be elected
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:8500/v1/status/leader"
+        return_content: yes
+      register: consul_leader_status
+      until: consul_leader_status.content != '""' and consul_leader_status.status == 200
+      retries: 12
+      delay: 5
+      ignore_errors: yes
+
+    - name: Fail gracefully if no Consul leader is found
+      ansible.builtin.fail:
+        msg: |
+          The Consul service is running, but it has not elected a leader after 60 seconds.
+          This usually means the `bootstrap_expect` value in your Consul configuration is
+          higher than the number of server nodes available.
+      when: consul_leader_status.failed or consul_leader_status.content == '""'
+
+    - name: Run roles that depend on Consul
+      include_role:
+        name: "{{ item }}"
+      loop:
+        - docker
+        - nomad
+
+    - name: Flush handlers to ensure Nomad service is started
+      meta: flush_handlers
+
+    - name: Run remaining roles
+      include_role:
+        name: "{{ item }}"
+      loop:
+        - python_deps
+        - llama_cpp
+        - whisper_cpp
+        - provisioning_api
+        - desktop_extras
+        - paddler
+        - pipecatapp
+        - vision
+        # - kittentts
+        - bootstrap_agent
+        - power_manager
     
   post_tasks:
     - name: Discover and save the MAC address for future use


### PR DESCRIPTION
This commit fixes a race condition in the Ansible playbook that caused the `bootstrap.sh` script to fail. The `nomad` service was being started before the `consul` service had elected a leader, causing Nomad to fail to start and resulting in a "Connection refused" error in the `bootstrap_agent` role.

The playbook is restructured to enforce a strict startup order:
1.  Start Consul.
2.  Wait for a Consul leader to be elected.
3.  Start Nomad.

This ensures that all service dependencies are met, making the bootstrap process more robust.

Additionally, this commit adds a friendly ASCII art robot face to the web UI, as requested by the user.