### PR TITLE
fix: Refactor variables and paths to fix bootstrap

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -1,0 +1,9 @@
+---
+# Global variables for all hosts
+meta:
+  NAMESPACE: "default"
+  JOB_NAME: "phi-3-mini-instruct"
+  API_SERVICE_NAME: "llama-api-phi-3-mini-instruct"
+  RPC_SERVICE_NAME: "llama-rpc-worker-phi-3-mini-instruct"
+  MODEL_PATH: "/opt/nomad/models/Phi-3-mini-4k-instruct-Q4_K_M.gguf"
+  WORKER_COUNT: "1"

--- a/ansible/roles/bootstrap_agent/defaults/main.yaml
+++ b/ansible/roles/bootstrap_agent/defaults/main.yaml
@@ -1,9 +1,3 @@
 ---
-# Default variables for the bootstrap_agent role
-meta:
-  NAMESPACE: "default"
-  JOB_NAME: "phi-3-mini-instruct"
-  API_SERVICE_NAME: "llama-api-phi-3-mini-instruct"
-  RPC_SERVICE_NAME: "llama-rpc-worker-phi-3-mini-instruct"
-  MODEL_PATH: "/opt/nomad/models/Phi-3-mini-4k-instruct-Q4_K_M.gguf"
-  WORKER_COUNT: "1"
+# No default variables needed for this role.
+# Variables are defined in group_vars/all.yaml


### PR DESCRIPTION
This commit provides a comprehensive fix for a series of cascading failures that prevented the single-node bootstrap process from completing successfully. The changes address race conditions, incorrect file paths, inconsistent variables, and overly high default resource usage.

The following changes have been made:
- **Centralize Variables:** The `meta` variables for the `llamacpp-rpc` job have been moved to `group_vars/all.yaml` to provide a single source of truth for all roles, fixing an 'undefined variable' error.
- **Fix Job Paths:** The `llamacpp-rpc.nomad` job template has been updated to use the correct, absolute paths for the `llama-server` executable (`/usr/local/bin/llama-server`) and the host model volume (`/opt/nomad/models`).
- **Correct Model Directory:** The `llama_cpp` role has been updated to create and download models to `/opt/nomad/models`, matching the path used by the Nomad job.
- **Reduce Default Resources:** In response to user feedback, the default configuration for the bootstrap has been made lighter. The worker count is now 1, and the default model is the smaller `Phi-3-mini-4k-instruct`.
- **Add Verification:** Added tasks to the Ansible roles to verify that binaries and directories exist before they are used, making the playbook more robust.
- **Add UI Enhancement:** Includes a user-requested cosmetic change to display ASCII art in the web UI.