### PR TITLE
fix(ansible): Use set_fact to define meta variable for nomad job

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -85,12 +85,8 @@
     mode: '0644'
   become: yes
 
-- name: Copy llama.cpp RPC Nomad job file
-  ansible.builtin.template:
-    src: ../../jobs/llamacpp-rpc.nomad
-    dest: /opt/nomad/jobs/llamacpp-rpc.nomad
-  when: "'controller_nodes' in group_names"
-  vars:
+- name: Set llama.cpp RPC job facts
+  ansible.builtin.set_fact:
     meta:
       NAMESPACE: "default"
       JOB_NAME: "llama-3-8b-instruct"
@@ -98,6 +94,13 @@
       RPC_SERVICE_NAME: "llama-rpc-worker-llama-3-8b-instruct"
       MODEL_PATH: "/models/Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
       WORKER_COUNT: 2
+  when: "'controller_nodes' in group_names"
+
+- name: Copy llama.cpp RPC Nomad job file
+  ansible.builtin.template:
+    src: ../../jobs/llamacpp-rpc.nomad
+    dest: /opt/nomad/jobs/llamacpp-rpc.nomad
+  when: "'controller_nodes' in group_names"
 
 - name: Copy benchmark Nomad job file
   ansible.builtin.template:


### PR DESCRIPTION
This commit fixes a bug in the `llama_cpp` Ansible role that caused the playbook to fail with an "'meta' is undefined" error.

The `meta` variable, used for templating the `llamacpp-rpc.nomad` job file, was previously defined in a `vars` block within the `template` task. This was not being correctly picked up by the templating engine.

The fix refactors the task to use `ansible.builtin.set_fact` to define the `meta` variable explicitly before the `template` task is run. This ensures the variable is available in the host facts and resolves the templating error.