### PR TITLE
Fix: Correct location of group_vars for ansible playbook

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -1,9 +1,0 @@
----
-# Global variables for all hosts
-meta:
-  NAMESPACE: "default"
-  JOB_NAME: "phi-3-mini-instruct"
-  API_SERVICE_NAME: "llama-api-phi-3-mini-instruct"
-  RPC_SERVICE_NAME: "llama-rpc-worker-phi-3-mini-instruct"
-  MODEL_PATH: "/opt/nomad/models/Phi-3-mini-4k-instruct-Q4_K_M.gguf"
-  WORKER_COUNT: "1"

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -3,3 +3,12 @@
 # It prefers the first non-loopback IPv6 address if available,
 # otherwise it falls back to the default IPv4 address.
 advertise_ip: "{{ ansible_all_ipv6_addresses[0] | default(ansible_default_ipv4.address) }}"
+
+# Global variables for all hosts
+meta:
+  NAMESPACE: "default"
+  JOB_NAME: "phi-3-mini-instruct"
+  API_SERVICE_NAME: "llama-api-phi-3-mini-instruct"
+  RPC_SERVICE_NAME: "llama-rpc-worker-phi-3-mini-instruct"
+  MODEL_PATH: "/opt/nomad/models/Phi-3-mini-4k-instruct-Q4_K_M.gguf"
+  WORKER_COUNT: "1"


### PR DESCRIPTION
The ansible playbook was failing with the error `'meta' is undefined`. This was because the `meta` variable was defined in `ansible/group_vars/all.yaml`, which was not being loaded by ansible.

This change merges the contents of `ansible/group_vars/all.yaml` into `group_vars/all.yaml` and deletes the now-redundant `ansible/group_vars` directory. This ensures that the `meta` variable is correctly loaded by the playbook.