### PR TITLE
Fix: Correct Nomad host volume and Ansible meta variable errors

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad
+++ b/ansible/jobs/llamacpp-rpc.nomad
@@ -60,7 +60,7 @@ EOH
     volume "models" {
       type      = "host"
       read_only = true
-      source    = "/opt/nomad/models"
+      source    = "models"
     }
   }
 
@@ -101,7 +101,7 @@ EOH
     volume "models" {
       type      = "host"
       read_only = true
-      source    = "/opt/nomad/models"
+      source    = "models"
     }
   }
 }

--- a/ansible/roles/nomad/templates/nomad.hcl.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.j2
@@ -24,7 +24,7 @@ client {
   enabled = true
 
   host_volume "models" {
-    path      = "/models"
+    path      = "/opt/nomad/models"
     read_only = true
   }
 }


### PR DESCRIPTION
This commit fixes two issues:
1. The ansible playbook was failing with the error `'meta' is undefined'. This was because the `meta` variable was defined in `ansible/group_vars/all.yaml`, which was not being loaded by ansible. This change merges the contents of `ansible/group_vars/all.yaml` into `group_vars/all.yaml` and deletes the now-redundant `ansible/group_vars` directory.

2. The Nomad jobs were failing with the error `"Constraint "missing compatible host volumes""`. This was because of a mismatch between the `host_volume` definition in the Nomad client configuration and the `volume` stanza in the job files. This change corrects the `host_volume` path in `ansible/roles/nomad/templates/nomad.hcl.j2` to point to `/opt/nomad/models` and updates the `volume` stanzas in `ansible/jobs/llamacpp-rpc.nomad` to use the named host volume `models`.