### PR TITLE
feat: Add support for EmbeddingGemma-300m model

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ You can save and load the agent's complete memory state (both short-term and lon
 - **STT/TTS Service Selection:** You can choose which Speech-to-Text and Text-to-Speech services to use by setting environment variables in the `pipecatapp.nomad` job file.
   - `STT_SERVICE`: Set to `faster-whisper` for high-performance local transcription, or `deepgram` (default) to use the Deepgram API.
   - `TTS_SERVICE`: Set to `kittentts` for a fast, local TTS, or `elevenlabs` (default) to use the ElevenLabs API.
+  - `EMBEDDING_MODEL_NAME`: Selects the sentence transformer model for the agent's long-term memory. Defaults to `all-MiniLM-L6-v2`. A good alternative is `google/embeddinggemma-300m`.
 
 ## 9. Benchmarking
 This project includes two types of benchmarks.

--- a/ansible/jobs/pipecatapp.nomad
+++ b/ansible/jobs/pipecatapp.nomad
@@ -32,6 +32,8 @@ job "pipecat-app" {
         USE_SUMMARIZER = "false"
         # Selects the vision model. Options: "yolo", "moondream"
         VISION_MODEL = "yolo"
+        # Selects the sentence embedding model.
+        EMBEDDING_MODEL_NAME = "google/embeddinggemma-300m"
       }
 
       resources {

--- a/ansible/roles/pipecatapp/files/memory.py
+++ b/ansible/roles/pipecatapp/files/memory.py
@@ -5,7 +5,8 @@ from sentence_transformers import SentenceTransformer
 import os
 
 class MemoryStore:
-    def __init__(self, embedding_model_name='all-MiniLM-L6-v2', index_file="long_term_memory.faiss", store_file="long_term_memory.json"):
+    def __init__(self, index_file="long_term_memory.faiss", store_file="long_term_memory.json"):
+        embedding_model_name = os.getenv("EMBEDDING_MODEL_NAME", 'all-MiniLM-L6-v2')
         self.embedding_model = SentenceTransformer(embedding_model_name)
         self.dimension = self.embedding_model.get_sentence_embedding_dimension()
         self.index_file = index_file


### PR DESCRIPTION
This commit introduces support for the `google/embeddinggemma-300m` sentence embedding model.

The `MemoryStore` class has been updated to use the `EMBEDDING_MODEL_NAME` environment variable to determine which sentence transformer model to load. This makes the embedding model configurable.

The `pipecatapp.nomad` job file has been updated to set this environment variable to `google/embeddinggemma-300m`.

The `README.md` has been updated to document this new configuration option.