### PR TITLE
Fix Ansible playbook errors

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -87,7 +87,7 @@
 
 - name: Download Llama-3-8B-Instruct model
   ansible.builtin.get_url:
-    url: "https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF-v2/resolve/main/Meta-Llama-3-8B-Instruct-Q4_K_M.gguf"
+    url: "https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF-v2/resolve/main/Meta-Llama-3-8B-Instruct-v2.Q4_K_M.gguf"
     dest: "/opt/nomad/models/Meta-Llama-3-8B-Instruct-Q4_K_M.gguf"
     mode: '0644'
   become: yes


### PR DESCRIPTION
This commit addresses two separate errors encountered during the Ansible playbook execution.

1.  **Unexpected parameter type in action:** Refactored the Ansible playbook to fix an error that occurs when using a loop directly on a block of tasks. The error `unexpected parameter type in action: <class 'ansible.module_utils._internal._datatag._AnsibleTaggedList'>` is a known issue in Ansible. The solution involves moving the tasks from the block into a new file and using `ansible.builtin.include_tasks` with a loop.

2.  **HTTP Error 404 on model download:** Updated the hardcoded URL for the Llama-3-8B-Instruct model in the `llama_cpp` role. The original URL was returning a 404 Not Found error. The new URL points to the correct location of the model file on Hugging Face.