### PR TITLE
Fix Ansible error: 'meta' is undefined

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -92,11 +92,6 @@
     mode: '0644'
   become: yes
 
-- name: Copy llama.cpp RPC Nomad job file
-  ansible.builtin.template:
-    src: ../../jobs/llamacpp-rpc.nomad
-    dest: /opt/nomad/jobs/llamacpp-rpc.nomad
-  when: "'controller_nodes' in group_names"
 
 - name: Copy benchmark Nomad job file
   ansible.builtin.template:


### PR DESCRIPTION
This commit fixes a fatal error in the Ansible playbook that occurred during the 'Copy llama.cpp RPC Nomad job file' task within the `llama_cpp` role.

The error was caused by the task trying to render the `llamacpp-rpc.nomad` template without providing the required `meta` variable.

Further analysis revealed that this task was a remnant of an older, static deployment method. The playbook has since been updated to use a more dynamic deployment strategy in the `bootstrap_agent` role, which correctly parameterizes and deploys the Nomad jobs for each model.

The fix involves removing the redundant and broken task from `ansible/roles/llama_cpp/tasks/main.yaml`. This centralizes the deployment logic in the `bootstrap_agent` role and resolves the error.