### PR TITLE
Fix Ansible playbook hanging on 'nomad job run'

### DIFF
--- a/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
@@ -12,7 +12,7 @@
 
 - name: Deploy rendered llama.cpp RPC service to Nomad
   ansible.builtin.command:
-    cmd: "nomad job run {{ rendered_nomad_job_path }}"
+    cmd: "nomad job run -detach {{ rendered_nomad_job_path }}"
   register: llama_job_run
   changed_when: "'Job registration successful' in llama_job_run.stdout"
   failed_when: llama_job_run.rc != 0 and 'already running' not in llama_job_run.stderr


### PR DESCRIPTION
This commit fixes an issue where the Ansible playbook would hang at the 'Deploy rendered llama.cpp RPC service to Nomad' task.

By default, the deployment command waits for the job to be stable before exiting. This caused the playbook to block indefinitely.

The fix is to modify the deployment command to submit the job and exit immediately, allowing the playbook to continue. The subsequent tasks in the playbook are already responsible for checking the health and status of the service, so this change is safe.