### PR TITLE
Fix race condition in llama.cpp Nomad job

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad
+++ b/ansible/jobs/llamacpp-rpc.nomad
@@ -32,6 +32,12 @@ job "llamacpp-rpc-{{ meta.JOB_NAME | default('default') }}" {
       template {
         data = <<EOH
 #!/bin/bash
+# Wait until at least one worker service is available
+while [ -z "$(nomad service discover -address-type=ipv4 {{ meta.RPC_SERVICE_NAME }} 2>/dev/null)" ]; do
+  echo "Waiting for worker services to become available in Consul..."
+  sleep 5
+done
+
 # Discover the IP addresses and ports of the worker services
 WORKER_IPS=$(nomad service discover -address-type=ipv4 {{ meta.RPC_SERVICE_NAME }} | tr '\n' ',' | sed 's/,$//')
 

--- a/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
@@ -14,7 +14,7 @@
   ansible.builtin.command:
     cmd: "nomad job run -detach {{ rendered_nomad_job_path }}"
   register: llama_job_run
-  changed_when: "'Job registration successful' in llama_job_run.stdout"
+  changed_when: "'submitted successfully' in llama_job_run.stdout"
   failed_when: llama_job_run.rc != 0 and 'already running' not in llama_job_run.stderr
 
 - name: Clean up temporary rendered job file


### PR DESCRIPTION
This commit fixes an issue where the `llama.cpp` services would fail to become healthy in Consul.

The root cause was a race condition in the `llamacpp-rpc.nomad` job. The `master` task could start before the `worker` tasks were available and registered in Consul. When the master's startup script tried to discover the workers, it would find none and crash.

The fix is to add a wait loop to the master's startup script. The script now waits until at least one worker service is discoverable in Consul before it proceeds to launch the `llama-server` process. This ensures the master does not start prematurely and resolves the race condition.