### PR TITLE
Fix Nomad jobs failing due to memory allocation and other issues

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad
+++ b/ansible/jobs/llamacpp-rpc.nomad
@@ -43,7 +43,7 @@ WORKER_IPS=$(nomad service discover -address-type=ipv4 {{ meta.RPC_SERVICE_NAME 
 
 # Launch the llama-server with the discovered worker IPs
 /usr/local/bin/llama-server \
-  --model {{ meta.MODEL_PATH }} \
+  --model "/models/{{ meta.MODEL_FILENAME }}" \
   --host 0.0.0.0 \
   --port {% raw %}{{ env "NOMAD_PORT_http" }}{% endraw %} \
   --rpc-servers $WORKER_IPS
@@ -96,7 +96,7 @@ EOH
       config {
         command = "/usr/local/bin/llama-server"
         args = [
-          "--model", "{{ meta.MODEL_PATH }}",
+          "--model", "/models/{{ meta.MODEL_FILENAME }}",
           "--host", "0.0.0.0",
           "--port", "{% raw %}{{ env \"NOMAD_PORT_rpc\" }}{% endraw %}",
         ]

--- a/ansible/jobs/llamacpp-rpc.nomad
+++ b/ansible/jobs/llamacpp-rpc.nomad
@@ -56,6 +56,11 @@ EOH
         command = "local/run_master.sh"
       }
 
+      resources {
+        cpu    = 1000
+        memory = {{ meta.MEMORY_MB | default(2048) }}
+      }
+
       volume_mount {
         volume      = "models"
         destination = "/models"
@@ -95,6 +100,11 @@ EOH
           "--host", "0.0.0.0",
           "--port", "{% raw %}{{ env \"NOMAD_PORT_rpc\" }}{% endraw %}",
         ]
+      }
+
+      resources {
+        cpu    = 1000
+        memory = {{ meta.MEMORY_MB | default(2048) }}
       }
 
       volume_mount {

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -11,6 +11,7 @@ llama_cpp_models:
     API_SERVICE_NAME: "llama-api-Llama-3-8B-Instruct"
     RPC_SERVICE_NAME: "llama-rpc-worker-Llama-3-8B-Instruct"
     MODEL_PATH: "/opt/nomad/models/Meta-Llama-3-8B-Instruct-Q4_K_M.gguf"
+    MODEL_FILENAME: "Meta-Llama-3-8B-Instruct-Q4_K_M.gguf"
     WORKER_COUNT: "1"
     MEMORY_MB: 8192
 
@@ -19,5 +20,6 @@ llama_cpp_models:
     API_SERVICE_NAME: "llama-api-phi-3-mini-instruct"
     RPC_SERVICE_NAME: "llama-rpc-worker-phi-3-mini-instruct"
     MODEL_PATH: "/opt/nomad/models/Phi-3-mini-4k-instruct-Q4_K_M.gguf"
+    MODEL_FILENAME: "Phi-3-mini-4k-instruct-Q4_K_M.gguf"
     WORKER_COUNT: "1"
     MEMORY_MB: 4096

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -12,6 +12,7 @@ llama_cpp_models:
     RPC_SERVICE_NAME: "llama-rpc-worker-Llama-3-8B-Instruct"
     MODEL_PATH: "/opt/nomad/models/Meta-Llama-3-8B-Instruct-Q4_K_M.gguf"
     WORKER_COUNT: "1"
+    MEMORY_MB: 8192
 
   - NAMESPACE: "default"
     JOB_NAME: "phi-3-mini-instruct"
@@ -19,3 +20,4 @@ llama_cpp_models:
     RPC_SERVICE_NAME: "llama-rpc-worker-phi-3-mini-instruct"
     MODEL_PATH: "/opt/nomad/models/Phi-3-mini-4k-instruct-Q4_K_M.gguf"
     WORKER_COUNT: "1"
+    MEMORY_MB: 4096


### PR DESCRIPTION
This commit addresses a series of failures in the Ansible playbook, with the root cause being that the Nomad jobs for `llama.cpp` were not allocated sufficient memory.

The `llama-server` tasks were likely being terminated by Nomad for exceeding their default memory limits when trying to load the large AI models. This commit introduces a `MEMORY_MB` variable to the model definitions in `group_vars/all.yaml` and adds a `resources` block to the Nomad job template to ensure enough memory is requested.

This commit also includes the preceding incremental fixes made during the debugging session:
- Refactored a `block` with a `loop` to use `include_tasks`.
- Fixed a broken model download URL.
- Added a `-detach` flag and corrected the `changed_when` condition for `nomad job run`.
- Removed a redundant and broken task from the `llama_cpp` role.
- Added a wait loop to the master task's startup script to prevent a race condition with the workers.