### PR TITLE
feat: Centralize model management and implement failover

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -40,6 +40,13 @@
   become: yes # Now we use the sudo privileges we just created
 
   pre_tasks:
+    - name: Ensure required Ansible collections are installed on the control node
+      ansible.builtin.command:
+        cmd: "ansible-galaxy collection install community.general"
+      delegate_to: localhost
+      run_once: true
+      changed_when: false # The command itself reports changes, no need for Ansible to guess
+
     - name: Check connectivity to all nodes
       ansible.builtin.ping:
 


### PR DESCRIPTION
This commit introduces a major architectural refactoring of how AI models are managed and deployed. It addresses the user's goals of consolidating all models into a single, organized directory and implementing a graceful failover mechanism for the LLM service.

Key changes:
- A new Ansible role, `download_models`, is created to handle the download of all models.
- A new configuration file, `group_vars/models.yaml`, centralizes the definition of all models (LLM, STT, TTS, Vision, Embedding).
- A unified directory structure under `/opt/nomad/models` is created and used by all services.
- The `llama_cpp` and `whisper_cpp` roles are refactored to remove their individual download logic.
- The `pipecatapp` Python application is modified to load models from the new, predictable, persistent paths, removing the need for runtime downloads and environment variable-based selection.
- The `llamacpp-rpc.nomad` job is enhanced with a startup script that implements graceful failover. It now iterates through a prioritized list of LLMs, trying the next one if the previous one fails to load.
- A pre-task is added to the main playbook to install the `community.general` Ansible collection, which is a required dependency for the new `download_models` role.