### PR TITLE
feat: Rearchitect model and dependency management

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -39,6 +39,9 @@
   remote_user: "{{ target_user }}"
   become: yes # Now we use the sudo privileges we just created
 
+  vars_files:
+    - group_vars/models.yaml
+
   pre_tasks:
     - name: Check connectivity to all nodes
       ansible.builtin.ping:


### PR DESCRIPTION
This commit introduces a major architectural refactoring of how AI models and Python dependencies are managed across the entire project. This resolves a series of cascading playbook failures and aligns the project with best practices for maintainability and robustness.

Key changes:
- **Username Parameterization:** The playbook is no longer hardcoded for the username 'user'. A new `target_user` variable has been introduced and used throughout all roles and configurations to support different user environments.
- **Model Management:** A new Ansible role, `download_models`, and a central configuration file, `group_vars/models.yaml`, now manage all model downloads to a unified directory structure.
- **LLM Failover:** The `llamacpp-rpc.nomad` job is enhanced with a robust startup script that implements graceful failover, trying a list of prioritized models until one starts successfully.
- **Python Environment:** A single, user-owned virtual environment is now created and used by all services. All Python dependencies have been consolidated into a single `requirements.txt`.
- **Bug Fixes:** This commit resolves numerous bugs, including a persistent `Permission denied` error, a missing system dependency for `PyAudio` (`portaudio19-dev`), and an error caused by a non-existent Ansible module.