### PR TITLE
feat: Rearchitect model and dependency management

### DIFF
--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -6,6 +6,8 @@
     mode: '0644'
   loop: "{{ llm_models }}"
   become: yes
+  loop_control:
+    loop_var: item
 
 - name: Download all Speech-to-Text models
   ansible.builtin.get_url:
@@ -14,6 +16,8 @@
     mode: '0644'
   loop: "{{ stt_models }}"
   become: yes
+  loop_control:
+    loop_var: item
 
 - name: Download all Text-to-Speech models
   ansible.builtin.get_url:
@@ -22,6 +26,8 @@
     mode: '0644'
   loop: "{{ tts_models }}"
   become: yes
+  loop_control:
+    loop_var: item
 
 - name: Download all Vision models (URL-based)
   ansible.builtin.get_url:
@@ -30,15 +36,23 @@
     mode: '0644'
   loop: "{{ vision_models | selectattr('url', 'defined') | list }}"
   become: yes
+  loop_control:
+    loop_var: item
 
 - name: Download all Vision models (Hub-based)
-  ansible.builtin.script:
-    cmd: "/home/{{ target_user }}/.local/bin/python3 download_hf_repo.py {{ item.repo_id }} /opt/nomad/models/vision/{{ item.name }}"
+  ansible.builtin.script: "download_hf_repo.py {{ item.repo_id }} /opt/nomad/models/vision/{{ item.name }}"
+  args:
+    executable: "/home/{{ target_user }}/.local/bin/python3"
   loop: "{{ vision_models | selectattr('repo_id', 'defined') | list }}"
   become: yes
+  loop_control:
+    loop_var: item
 
 - name: Download all Embedding models (Hub-based)
-  ansible.builtin.script:
-    cmd: "/home/{{ target_user }}/.local/bin/python3 download_hf_repo.py {{ item.repo_id }} /opt/nomad/models/embedding/{{ item.name }}"
+  ansible.builtin.script: "download_hf_repo.py {{ item.repo_id }} /opt/nomad/models/embedding/{{ item.name }}"
+  args:
+    executable: "/home/{{ target_user }}/.local/bin/python3"
   loop: "{{ embedding_models | selectattr('repo_id', 'defined') | list }}"
   become: yes
+  loop_control:
+    loop_var: item


### PR DESCRIPTION
This commit introduces a major architectural refactoring of how AI models and Python dependencies are managed across the entire project. This resolves a series of cascading playbook failures and aligns the project with best practices for maintainability and robustness.

Key changes:
- **Username Parameterization:** The playbook is no longer hardcoded for the username 'user'. A new `target_user` variable has been introduced and used throughout all roles and configurations to support different user environments.
- **Model Management:** A new Ansible role, `download_models`, and a central configuration file, `group_vars/models.yaml`, now manage all model downloads to a unified directory structure.
- **LLM Failover:** The `llamacpp-rpc.nomad` job is enhanced with a robust startup script that implements graceful failover, trying a list of prioritized models until one starts successfully.
- **Python Environment:** A single, user-owned virtual environment is now created and used by all services. All Python dependencies have been consolidated into a single `requirements.txt`.
- **Bug Fixes:** This commit resolves numerous bugs, including a persistent `Permission denied` error, a missing system dependency for `PyAudio`, and multiple errors related to Ansible module and path resolution.