### PR TITLE
feat: Rearchitect model and dependency management

### DIFF
--- a/ansible/roles/pipecatapp/files/memory.py
+++ b/ansible/roles/pipecatapp/files/memory.py
@@ -7,7 +7,7 @@ import os
 class MemoryStore:
     def __init__(self, index_file="long_term_memory.faiss", store_file="long_term_memory.json"):
         # The embedding model is now managed by Ansible and placed in a predictable location.
-        embedding_model_path = "/opt/nomad/models/embedding/embedding-gemma-300m"
+        embedding_model_path = "/opt/nomad/models/embedding/bge-large-en-v1.5"
         self.embedding_model = SentenceTransformer(embedding_model_path)
         self.dimension = self.embedding_model.get_sentence_embedding_dimension()
         self.index_file = index_file

--- a/group_vars/models.yaml
+++ b/group_vars/models.yaml
@@ -29,8 +29,8 @@ tts_models:
 
 # Embedding models
 embedding_models:
-  - name: "embedding-gemma-300m"
-    repo_id: "google/embedding-gemma-300m"
+  - name: "bge-large-en-v1.5"
+    repo_id: "BAAI/bge-large-en-v1.5"
     # This model will be downloaded using the huggingface_hub module, which handles the whole repository.
 
 # Vision models


### PR DESCRIPTION
This commit introduces a major architectural refactoring of how AI models and Python dependencies are managed across the entire project. This resolves a series of cascading playbook failures and aligns the project with best practices for maintainability and robustness.

Key changes:
- **Username Parameterization:** The playbook is no longer hardcoded for the username 'user'. A new `target_user` variable has been introduced and used throughout all roles and configurations to support different user environments.
- **Model Management:** A new Ansible role, `download_models`, and a central configuration file, `group_vars/models.yaml`, now manage all model downloads to a unified directory structure. A non-gated embedding model (`BAAI/bge-large-en-v1.5`) is now used to avoid authentication issues.
- **LLM Failover:** The `llamacpp-rpc.nomad` job is enhanced with a robust startup script that implements graceful failover, trying a list of prioritized models until one starts successfully.
- **Python Environment:** A single, user-owned virtual environment is now created and used by all services. All Python dependencies have been consolidated into a single `requirements.txt`.
- **Bug Fixes:** This commit resolves numerous bugs, including a persistent `Permission denied` error, a missing system dependency for `PyAudio`, and multiple errors related to Ansible module and path resolution.