### PR TITLE
Fix: Correct placement of check block in Nomad job file

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad
+++ b/ansible/jobs/llamacpp-rpc.nomad
@@ -14,13 +14,13 @@ job "llamacpp-rpc" {
       name     = "llama-cpp-api"
       provider = "consul"
       port     = "http"
-    }
 
-    check {
-        type     = "http"
-        path     = "/health"
-        interval = "10s"
-        timeout  = "2s"
+      check {
+          type     = "http"
+          path     = "/health"
+          interval = "10s"
+          timeout  = "2s"
+      }
     }
 
     volume "models" {


### PR DESCRIPTION
The `check` block in the `llamacpp-rpc.nomad` job file was incorrectly placed outside the `service` block. This caused the Nomad job to fail with an "Unsupported block type" error.

This commit moves the `check` block inside the `service` block, which is the correct placement according to the Nomad job specification.