### PR TITLE
Fix Nomad service startup failure

### DIFF
--- a/ansible/roles/nomad/handlers/main.yaml
+++ b/ansible/roles/nomad/handlers/main.yaml
@@ -1,9 +1,6 @@
 ---
-- name: Reload systemd
-  systemd:
-    daemon_reload: yes
-
 - name: Restart Nomad
   systemd:
     name: nomad
     state: restarted
+    daemon_reload: yes

--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -65,7 +65,7 @@
       [Unit]
       Wants=consul.service docker.service
       After=consul.service docker.service
-  notify: Reload systemd
+  notify: Restart Nomad
 
 - name: Set NOMAD_ADDR environment variable for all users
   copy:


### PR DESCRIPTION
The Nomad service was failing to start because of a race condition in the Ansible handlers. When the Nomad systemd unit file was changed, the service was sometimes restarted before `systemd` was reloaded, causing the old configuration to be used.

This change fixes the issue by combining the `daemon_reload` and `restart` operations into a single handler. This ensures that `systemd` is always reloaded before the Nomad service is restarted.