### PR TITLE
Fix Nomad PATH issue and refactor playbook

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad
+++ b/ansible/jobs/llamacpp-rpc.nomad
@@ -40,12 +40,12 @@ job "llamacpp-rpc" {
 set -e
 
 # Wait until at least one worker service is available
-while [ -z "$(nomad service discover -address-type=ipv4 llama-cpp-rpc-worker 2>/dev/null)" ]; do
+while [ -z "$(/usr/local/bin/nomad service discover -address-type=ipv4 llama-cpp-rpc-worker 2>/dev/null)" ]; do
   echo "Waiting for worker services to become available in Consul..."
   sleep 5
 done
 
-WORKER_IPS=$(nomad service discover -address-type=ipv4 llama-cpp-rpc-worker | tr '\n' ',' | sed 's/,$//')
+WORKER_IPS=$(/usr/local/bin/nomad service discover -address-type=ipv4 llama-cpp-rpc-worker | tr '\n' ',' | sed 's/,$//')
 HEALTH_CHECK_URL="http://127.0.0.1:{{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }}/"
 
 # Loop through the provided models and try to start the server


### PR DESCRIPTION
This commit fixes a bug where the `llama.cpp` service was failing to start because the `nomad` binary was not in the `PATH` of the execution environment. It also includes a number of other improvements to the Ansible playbook to make it more robust, configurable, and easier to debug.

The following changes were made:
- The `run_master.sh` script in the `llamacpp-rpc.nomad` job file has been modified to use the full path to the `nomad` binary (`/usr/local/bin/nomad`).
- The `nomad_models_dir` variable has been moved to `group_vars/all.yaml` to fix a variable scope issue.
- Loop variable collisions have been fixed in `playbook.yaml` and the `docker`, `nomad`, and `whisper_cpp` roles.
- The playbook has been refactored to use Ansible best practices, such as using the `wait_for` and `community.general.nomad_job` modules.
- The health check path for the `llama.cpp` service in the `llamacpp-rpc.nomad` job file has been changed from `/health` to `/`.
- Logging has been added to the `llama.cpp` job to aid in debugging.