### PR TITLE
Add debugging for llama.cpp and apply various fixes

### DIFF
--- a/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
@@ -42,6 +42,18 @@
     var: llama_server_log.stdout_lines
   when: llama_server_log.stdout is defined and llama_server_log.stdout != ""
 
+- name: Read master script log if health check failed
+  ansible.builtin.command:
+    cmd: "cat /tmp/master-script.log"
+  register: master_script_log
+  changed_when: false
+  when: service_health.json is not defined or service_health.json | length == 0 or not (service_health.json[0].Checks | selectattr('Status', 'equalto', 'passing') | list | length > 0)
+
+- name: Display master script log
+  ansible.builtin.debug:
+    var: master_script_log.stdout_lines
+  when: master_script_log.stdout is defined and master_script_log.stdout != ""
+
 - name: Fail if llama.cpp service did not become healthy
   ansible.builtin.fail:
     msg: "The llama.cpp API service did not become healthy in Consul after waiting. Cannot deploy pipecat app."


### PR DESCRIPTION
This commit adds detailed logging to the `llama.cpp` service to help debug a persistent health check failure. It also includes a number of other improvements and fixes to the Ansible playbook.

The following changes were made:
- The `run_master.sh` script in the `llamacpp-rpc.nomad` job file has been modified to redirect its output to `/tmp/master-script.log` for debugging.
- A debug task has been added to the `bootstrap_agent` role to print the contents of this log file if the health check fails.
- Loop variable collisions have been fixed in the `whisper_cpp`, `docker`, and `nomad` roles, and in `playbook.yaml`.
- The `nomad_models_dir` variable has been moved to `group_vars/all.yaml` to fix a variable scope issue.
- The playbook has been refactored to use Ansible best practices, such as using the `wait_for` and `community.general.nomad_job` modules.
- The health check path for the `llama.cpp` service in the `llamacpp-rpc.nomad` job file has been changed from `/health` to `/`.