### PR TITLE
Debug llama.cpp startup by simplifying run script

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad
+++ b/ansible/jobs/llamacpp-rpc.nomad
@@ -37,61 +37,7 @@ job "llamacpp-rpc" {
       template {
         data = <<EOH
 #!/bin/bash
-exec > /tmp/master-script.log 2>&1
-set -x
-
-echo "Starting run_master.sh script..."
-
-# Wait until at least one worker service is available
-echo "Waiting for worker services to become available in Consul..."
-while [ -z "$(/usr/local/bin/nomad service discover -address-type=ipv4 llama-cpp-rpc-worker 2>/dev/null)" ]; do
-  echo "Still waiting for worker services..."
-  sleep 5
-done
-echo "Worker services are available."
-
-echo "Discovering worker IPs..."
-WORKER_IPS=$(/usr/local/bin/nomad service discover -address-type=ipv4 llama-cpp-rpc-worker | tr '\n' ',' | sed 's/,$//')
-echo "Worker IPs: $WORKER_IPS"
-HEALTH_CHECK_URL="http://127.0.0.1:{{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }}/"
-
-# Loop through the provided models and try to start the server
-{% for model in llm_models_var %}
-  echo "Attempting to start llama-server with model: {{ model.name }}"
-  /usr/local/bin/llama-server \
-    --model "/opt/nomad/models/llm/{{ model.filename }}" \
-    --host 0.0.0.0 \
-    --port {{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }} \
-    --rpc-servers $WORKER_IPS > /tmp/llama-server.log 2>&1 &
-
-  SERVER_PID=$!
-  echo "Server process started with PID $SERVER_PID. Waiting for it to become healthy..."
-
-  # Health check loop
-  HEALTHY=false
-  for i in $(seq 1 12); do
-    sleep 10
-    if curl -s --fail $HEALTH_CHECK_URL > /dev/null; then
-      echo "Server is healthy with model {{ model.name }}!"
-      HEALTHY=true
-      break
-    else
-      echo "Health check failed (attempt $i/12)..."
-    fi
-  done
-
-  if [ "$HEALTHY" = true ]; then
-    echo "Successfully started and health-checked llama-server with model: {{ model.name }}"
-    wait $SERVER_PID # Keep the script running with the successful server
-    exit 0
-  else
-    echo "Server failed to become healthy with model: {{ model.name }}. Killing process and trying next model."
-    kill $SERVER_PID
-    wait $SERVER_PID 2>/dev/null
-  fi
-{% endfor %}
-
-echo "All models failed to start. Exiting."
+echo "Hello from run_master.sh" > /tmp/master-script.log
 exit 1
 EOH
         destination = "local/run_master.sh"


### PR DESCRIPTION
This commit is a debugging step to diagnose a persistent health check failure in the `llama.cpp` service. The `run_master.sh` script in the `llamacpp-rpc.nomad` job file has been simplified to a single `echo` command to test if the Nomad task can write to a file.

This commit also includes a number of other improvements and fixes to the Ansible playbook to make it more robust, configurable, and easier to debug.