### PR TITLE
fix(ansible): Use command module for iptables rule

### DIFF
--- a/ansible/roles/power_manager/tasks/main.yaml
+++ b/ansible/roles/power_manager/tasks/main.yaml
@@ -54,16 +54,22 @@
     mode: '0644'
   notify: restart power agent
 
+- name: Check for existing iptables rule for Consul health checks
+  become: yes
+  command: iptables-save -t mangle
+  register: iptables_mangle_rules
+  changed_when: false
+  check_mode: no
+  tags:
+    - iptables
+
 - name: Mark Consul health check packets
   become: yes
-  ansible.builtin.iptables:
-    chain: PREROUTING
-    table: mangle
-    protocol: tcp
-    source: '127.0.0.1' # Assuming local consul agent
-    jump: MARK
-    set_mark: '0x1'
-    comment: "Mark packets from local Consul agent for health checks"
+  ansible.builtin.command:
+    cmd: "iptables -t mangle -A PREROUTING -s 127.0.0.1 -p tcp -j MARK --set-mark 0x1 -m comment --comment \"Mark packets from local Consul agent for health checks\""
+  when: "'Mark packets from local Consul agent for health checks' not in iptables_mangle_rules.stdout"
+  tags:
+    - iptables
 
 - name: Enable and start the power agent service
   become: yes


### PR DESCRIPTION
The `ansible.builtin.iptables` module in the version of Ansible being used does not support the `set_mark` parameter, causing the playbook to fail.

This change replaces the failing `iptables` task with a task that uses the `command` module to execute the `iptables` command directly.

To ensure idempotency, the new task first checks if the rule already exists by inspecting the output of `iptables-save`, and only adds the rule if it is not present.