### PR TITLE
feat(debug): Add task to get Nomad node status

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -119,6 +119,16 @@
         name: bootstrap_agent   
         
   post_tasks:
+    - name: Get Nomad node status
+      ansible.builtin.command:
+        cmd: nomad node status -self
+      register: nomad_node_status
+      ignore_errors: true
+
+    - name: Display Nomad node status
+      ansible.builtin.debug:
+        var: nomad_node_status.stdout_lines
+
     - name: Discover and save the MAC address for future use
       ansible.builtin.blockinfile:
         path: "host_vars/{{ inventory_hostname }}.yaml"


### PR DESCRIPTION
The `pipecat-app` job is not being scheduled, likely due to insufficient resources on the node. This commit adds a temporary debugging task to the main playbook to run `nomad node status -self` and display the output. This will provide information about the node's available resources, which is needed to diagnose the scheduling failure.