### PR TITLE
feat(debug): Add tasks to get Nomad service status and logs

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -119,15 +119,27 @@
         name: bootstrap_agent   
         
   post_tasks:
-    - name: Get Nomad node status
+    - name: Check Nomad service status
       ansible.builtin.command:
-        cmd: nomad node status -self
-      register: nomad_node_status
+        cmd: systemctl status nomad.service --no-pager
+      register: nomad_service_status
       ignore_errors: true
+      changed_when: false
 
-    - name: Display Nomad node status
+    - name: Display Nomad service status
       ansible.builtin.debug:
-        var: nomad_node_status.stdout_lines
+        var: nomad_service_status.stdout_lines
+
+    - name: Get Nomad service logs
+      ansible.builtin.command:
+        cmd: journalctl -u nomad.service --no-pager -n 50
+      register: nomad_service_logs
+      ignore_errors: true
+      changed_when: false
+
+    - name: Display Nomad service logs
+      ansible.builtin.debug:
+        var: nomad_service_logs.stdout_lines
 
     - name: Discover and save the MAC address for future use
       ansible.builtin.blockinfile:


### PR DESCRIPTION
The Nomad agent is not running, causing "Connection Refused" errors when trying to manage jobs. This commit adds temporary debugging tasks to the main playbook to run `systemctl status nomad.service` and `journalctl -u nomad.service`. This will provide the necessary information to diagnose why the Nomad agent service is failing to start.