### PR TITLE
Fix Nomad connection error by correcting config and forcing IPv4

### DIFF
--- a/ansible/roles/nomad/templates/nomad.hcl.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.j2
@@ -25,6 +25,7 @@ server {
   host_volume "models" {
     path      = "{{ nomad_models_dir }}"
     read_only = true
+  }
     
   # Set to 1 for a single-server cluster
   bootstrap_expect = 1

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -4,7 +4,7 @@ expected_cluster_size: "{{ groups['workers'] | length }}"
 # This variable dynamically determines the IP address for Nomad to advertise.
 # It prefers the first non-loopback IPv6 address if available,
 # otherwise it falls back to the default IPv4 address.
-advertise_ip: "{{ (ansible_all_ipv6_addresses | reject('equalto', '::1') | list | first) | default(ansible_default_ipv4.address) }}"
+advertise_ip: "{{ ansible_default_ipv4.address }}"
 
 nomad_models_dir: "/opt/nomad/models"
 


### PR DESCRIPTION
The Ansible playbook was failing to run Nomad jobs due to a "connection refused" error. This was caused by two issues:

1. A syntax error in the `nomad.hcl.j2` template, where a closing brace was missing in the `host_volume` block.
2. The Nomad `advertise_ip` was defaulting to an IPv6 address, which caused connection issues.

This commit fixes the syntax in the template and forces the `advertise_ip` to use the server's default IPv4 address for a more stable configuration.