### PR TITLE
fix: Correct Jinja2 parsing error in llamacpp-rpc job

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad
+++ b/ansible/jobs/llamacpp-rpc.nomad
@@ -111,7 +111,14 @@ EOH
 
       resources {
         cpu    = 1000
-        memory = {% if (llm_models_var | map(attribute='memory_mb') | list | length > 0) %}{{ llm_models_var | map(attribute='memory_mb') | max }}{% else %}2048{% endif %}
+{%- set max_mem = [2048] -%}
+{%- for model in llm_models_var -%}
+{%- if model.memory_mb is defined and model.memory_mb > max_mem[0] -%}
+{%- set _ = max_mem.pop() -%}
+{%- set _ = max_mem.append(model.memory_mb) -%}
+{%- endif -%}
+{%- endfor -%}
+        memory = {{ max_mem[0] }}
       }
 
       volume_mount {
@@ -163,7 +170,14 @@ EOH
 
       resources {
         cpu    = 1000
-        memory = {% if (llm_models_var | map(attribute='memory_mb') | list | length > 0) %}{{ llm_models_var | map(attribute='memory_mb') | max }}{% else %}2048{% endif %}
+{%- set max_mem = [2048] -%}
+{%- for model in llm_models_var -%}
+{%- if model.memory_mb is defined and model.memory_mb > max_mem[0] -%}
+{%- set _ = max_mem.pop() -%}
+{%- set _ = max_mem.append(model.memory_mb) -%}
+{%- endif -%}
+{%- endfor -%}
+        memory = {{ max_mem[0] }}
       }
 
       volume_mount {


### PR DESCRIPTION
This commit fixes an `AnsibleError: template error while templating string: expected name or number` that occurred during deployment.

The error was caused by a Jinja2 filter chain using `| max` that was syntactically ambiguous for the Ansible templating engine. This logic has been replaced with a more robust and explicit `for` loop that manually iterates through the model list to find the maximum memory requirement. This resolves the parsing error.

This commit also includes the previously developed fix for the service discovery mechanism in the `run_master.sh` script, as both fixes are required for the job to be functional.