### PR TITLE
fix: Update download_models role for new model structure

### DIFF
--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -1,10 +1,24 @@
 ---
-- name: Download all LLM models
+- name: Aggregate all unique LLM models from different expert lists
+  ansible.builtin.set_fact:
+    unique_llm_models: >
+      {% set processed_urls = [] %}
+      {% set unique_models = [] %}
+      {% for model in main_expert_models + coding_expert_models %}
+        {% if model.url not in processed_urls %}
+          {% set _ = unique_models.append(model) %}
+          {% set _ = processed_urls.append(model.url) %}
+        {% endif %}
+      {% endfor %}
+      {{ unique_models }}
+  become: yes
+
+- name: Download all unique LLM models
   ansible.builtin.get_url:
     url: "{{ item.url }}"
     dest: "/opt/nomad/models/llm/{{ item.filename }}"
     mode: '0644'
-  loop: "{{ llm_models }}"
+  loop: "{{ unique_llm_models }}"
   become: yes
   loop_control:
     loop_var: item


### PR DESCRIPTION
This commit fixes a bug where the `download_models` Ansible role was failing due to an undefined `llm_models` variable. The role has been updated to aggregate all model lists (e.g., `main_expert_models`, `coding_expert_models`) and download each unique model.

feat: Finalize MoE deployment workflow

This commit also completes the implementation of the Mixture-of-Experts deployment workflow. This includes:
- A new `prima-expert.nomad` job template for deploying distributed experts.
- A new `deploy_expert.yaml` playbook for launching custom experts.
- Restructured `group_vars/models.yaml` to support multiple expert configurations.
- Updated `README.md` to document the new workflow.
- Removal of obsolete job files.