### PR TITLE
Fix Ansible playbook error in pipecatapp role

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -118,17 +118,17 @@
     - Reload systemd
     - Enable and start prima-services
 
-- name: Run pipecat-app job
-  ansible.builtin.command:
-    cmd: nomad job run /opt/nomad/jobs/pipecatapp.nomad
-  when: pipecat_job_status.rc != 0
-
 - name: Check if pipecat-app job is running
   ansible.builtin.command:
     cmd: nomad job status pipecat-app
   register: pipecat_job_status
   changed_when: false
   ignore_errors: true
+
+- name: Run pipecat-app job
+  ansible.builtin.command:
+    cmd: nomad job run /opt/nomad/jobs/pipecatapp.nomad
+  when: pipecat_job_status.rc != 0
 
 - name: Ensure start_services.sh is executable
   ansible.builtin.file:


### PR DESCRIPTION
The playbook was failing because the 'Run pipecat-app job' task was attempting to use the `pipecat_job_status` variable before it was defined. This caused a fatal error.

This commit reorders the tasks to ensure that the 'Check if pipecat-app job is running' task, which registers the `pipecat_job_status` variable, is executed before the task that uses it. This resolves the 'undefined variable' error.