### PR TITLE
Fix multiple issues in Ansible playbook

### DIFF
--- a/ansible/jobs/pipecatapp.nomad
+++ b/ansible/jobs/pipecatapp.nomad
@@ -30,8 +30,11 @@ job "pipecat-app" {
       driver = "raw_exec"
 
       config {
-        command = "/opt/pipecatapp/venv/bin/python3"
-        args    = ["/opt/pipecatapp/app.py"]
+        command = "/bin/bash"
+        args = [
+          "-c",
+          "/opt/pipecatapp/venv/bin/python3 /opt/pipecatapp/app.py &> /tmp/pipecat.log"
+        ]
       }
 
       env {


### PR DESCRIPTION
This commit addresses a cascade of issues that were preventing the Ansible playbook from running successfully.

The fixes include:

1.  **Fix initial `timeout` error:** Removed the unsupported `timeout` parameter from `ansible.builtin.apt` tasks in the `pipecatapp` role.

2.  **Correct Nomad `raw_exec` driver enablement:** Modified the Nomad client configuration to correctly enable the `raw_exec` driver using the `options` syntax.

3.  **Implement robust Nomad state management:**
    *   Added a version check to the `nomad` role. The role now compares the installed Nomad version with the version being deployed and only clears the server/client state directories if the version has changed. This prevents the "duplicate ID" error on upgrades without unnecessarily deleting state on every run.
    *   This change also prevents the accidental deletion of the `/opt/nomad/models` directory.

4.  **Ensure proper service restarts:** Added a `notify` handler to the Nomad configuration task to ensure the `nomad` service is correctly restarted when its configuration changes.

5.  **Fix model directory creation logic:** Added a task to the `common` role to create the parent `/opt/nomad/models` directory. This ensures the directory exists before the `download_models` role attempts to download files into its subdirectories, resolving a race condition.

6.  **Add log capture for pipecat-app:** Modified the `pipecatapp.nomad` job to redirect the application's stdout and stderr to `/tmp/pipecat.log` to allow for debugging of runtime errors.