### PR TITLE
Fix multiple issues in Ansible playbook and pipecat application

### DIFF
--- a/ansible/roles/pipecatapp/files/app.py
+++ b/ansible/roles/pipecatapp/files/app.py
@@ -13,7 +13,7 @@ import inspect
 import threading
 
 from pipecat.frames.frames import (
-    AudioFrame,
+    AudioRawFrame,
     EndFrame,
     TextFrame,
     VisionImageFrame,
@@ -84,7 +84,7 @@ class BenchmarkCollector(FrameProcessor):
             self.stt_end_time = time.time()
         elif isinstance(frame, TextFrame) and self.llm_first_token_time == 0:
             self.llm_first_token_time = time.time()
-        elif isinstance(frame, AudioFrame) and self.tts_first_audio_time == 0:
+        elif isinstance(frame, AudioRawFrame) and self.tts_first_audio_time == 0:
             self.tts_first_audio_time = time.time()
             self.log_benchmarks()
             self.reset()
@@ -122,7 +122,7 @@ class FasterWhisperSTTService(FrameProcessor):
         self.audio_to_text = AudioToText(model=self.model, language="en")
 
     async def process_frame(self, frame, direction):
-        if not isinstance(frame, AudioFrame):
+        if not isinstance(frame, AudioRawFrame):
             await self.push_frame(frame, direction)
             return
 
@@ -181,7 +181,7 @@ class PiperTTSService(FrameProcessor):
             # For now, we assume it matches what pipecat expects.
             audio_bytes = wf.readframes(wf.getnframes())
 
-        await self.push_frame(AudioFrame(audio_bytes))
+        await self.push_frame(AudioRawFrame(audio_bytes))
 
 
 class TwinService(FrameProcessor):


### PR DESCRIPTION
This commit addresses a cascade of issues, from infrastructure configuration to application code, that were preventing the successful deployment of the pipecat-app.

The fixes include:

1.  **Fix initial `timeout` error:** Removed the unsupported `timeout` parameter from `ansible.builtin.apt` tasks in the `pipecatapp` role.

2.  **Correct Nomad `raw_exec` driver enablement:** Modified the Nomad client configuration to correctly enable the `raw_exec` driver using the `options` syntax.

3.  **Implement robust Nomad state management:**
    *   Added a version check to the `nomad` role. The role now compares the installed Nomad version with the version being deployed and only clears the server/client state directories if the version has changed. This prevents the "duplicate ID" error on upgrades without unnecessarily deleting state on every run.
    *   This change also prevents the accidental deletion of the `/opt/nomad/models` directory.

4.  **Ensure proper service restarts:** Added a `notify` handler to the Nomad configuration task to ensure the `nomad` service is correctly restarted when its configuration changes.

5.  **Fix model directory creation logic:** Added a task to the `common` role to create the parent `/opt/nomad/models` directory. This ensures the directory exists before the `download_models` role attempts to download files into its subdirectories, resolving a race condition.

6.  **Add log capture for pipecat-app:** Modified the `pipecatapp.nomad` job to redirect the application's stdout and stderr to `/tmp/pipecat.log` to allow for debugging of runtime errors.

7.  **Fix application `ImportError`:** Corrected an import error in `app.py` by replacing all instances of the outdated `AudioFrame` class with the correct `AudioRawFrame`.