### PR TITLE
Use dynamic paths for static assets in web server

### DIFF
--- a/ansible/roles/pipecatapp/files/web_server.py
+++ b/ansible/roles/pipecatapp/files/web_server.py
@@ -40,16 +40,22 @@ async def websocket_endpoint(websocket: WebSocket):
     except Exception:
         manager.disconnect(websocket)
 
+import os
 from fastapi.staticfiles import StaticFiles
 
 # This will be set by the main application
 twin_service_instance = None
 
-app.mount("/static", StaticFiles(directory="ansible/roles/pipecatapp/files/static"), name="static")
+# Get the absolute path to the directory containing this script
+script_dir = os.path.dirname(os.path.abspath(__file__))
+static_dir = os.path.join(script_dir, "static")
+index_html_path = os.path.join(static_dir, "index.html")
+
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 @app.get("/")
 async def get():
-    with open("ansible/roles/pipecatapp/files/static/index.html") as f:
+    with open(index_html_path) as f:
         return HTMLResponse(f.read())
 
 @app.get("/api/status")

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -123,6 +123,12 @@
     dest: /opt/pipecatapp/web_server.py
   become: yes
 
+- name: Copy static assets
+  ansible.builtin.copy:
+    src: static
+    dest: /opt/pipecatapp/
+  become: yes
+
 - name: Copy pipecatapp Nomad job file
   ansible.builtin.template:
     src: ../../jobs/pipecatapp.nomad


### PR DESCRIPTION
The web_server.py script was using a hardcoded, relative path to locate the static assets directory. This caused a RuntimeError when the application was deployed to a different location.

This change modifies web_server.py to programmatically determine the absolute path to the static directory based on its own file location. This makes the application more portable and robust.