### PR TITLE
Fix ModuleNotFoundError for tools module

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -129,6 +129,12 @@
     dest: /opt/pipecatapp/
   become: yes
 
+- name: Copy tools directory
+  ansible.builtin.copy:
+    src: tools
+    dest: /opt/pipecatapp/
+  become: yes
+
 - name: Copy pipecatapp Nomad job file
   ansible.builtin.template:
     src: ../../jobs/pipecatapp.nomad


### PR DESCRIPTION
The application was failing with a `ModuleNotFoundError` because the `tools` directory was not being copied to the application's runtime environment.

This change updates the Ansible playbook to copy the `tools` directory to `/opt/pipecatapp/`, making it available to the application and resolving the error.