### PR TITLE
Fix moondream_detector ModuleNotFoundError and OpenAI deprecation

### DIFF
--- a/ansible/roles/pipecatapp/files/app.py
+++ b/ansible/roles/pipecatapp/files/app.py
@@ -25,7 +25,7 @@ from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineTask
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
-from pipecat.services.openai import OpenAILLMService
+from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.local.audio import LocalAudioTransport
 from RealtimeSTT import AudioToTextRecorder
 

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -135,6 +135,12 @@
     dest: /opt/pipecatapp/
   become: yes
 
+- name: Copy moondream_detector module
+  ansible.builtin.copy:
+    src: moondream_detector.py
+    dest: /opt/pipecatapp/moondream_detector.py
+  become: yes
+
 - name: Copy pipecatapp Nomad job file
   ansible.builtin.template:
     src: ../../jobs/pipecatapp.nomad


### PR DESCRIPTION
This commit addresses two issues:

1.  A `ModuleNotFoundError` for the `moondream_detector` module. This is resolved by adding a task to the Ansible playbook to copy the `moondream_detector.py` file to the application directory.

2.  A `DeprecationWarning` for `pipecat.services.openai`. The import statement in `app.py` has been updated to use the new, more specific path `pipecat.services.openai.llm`, as recommended by the warning.