### PR TITLE
Fix multiple runtime errors in pipecat application

### DIFF
--- a/ansible/roles/pipecatapp/files/web_server.py
+++ b/ansible/roles/pipecatapp/files/web_server.py
@@ -40,22 +40,16 @@ async def websocket_endpoint(websocket: WebSocket):
     except Exception:
         manager.disconnect(websocket)
 
-import os
 from fastapi.staticfiles import StaticFiles
 
 # This will be set by the main application
 twin_service_instance = None
 
-# Get the absolute path to the directory containing this script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-static_dir = os.path.join(script_dir, "static")
-index_html_path = os.path.join(static_dir, "index.html")
-
-app.mount("/static", StaticFiles(directory=static_dir), name="static")
+app.mount("/static", StaticFiles(directory="ansible/roles/pipecatapp/files/static"), name="static")
 
 @app.get("/")
 async def get():
-    with open(index_html_path) as f:
+    with open("ansible/roles/pipecatapp/files/static/index.html") as f:
         return HTMLResponse(f.read())
 
 @app.get("/api/status")

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -141,6 +141,34 @@
     dest: /opt/pipecatapp/moondream_detector.py
   become: yes
 
+- name: Create STT model directory
+  ansible.builtin.file:
+    path: /opt/nomad/models/stt
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Clone faster-whisper model
+  ansible.builtin.git:
+    repo: 'https://huggingface.co/Systran/faster-whisper-tiny.en'
+    dest: /opt/nomad/models/stt/faster-whisper-tiny.en
+    version: main
+  become: yes
+
+- name: Create VAD model directory
+  ansible.builtin.file:
+    path: /opt/pipecatapp/.cache/torch/hub/snakers4_silero-vad_master
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Clone silero-vad model
+  ansible.builtin.git:
+    repo: 'https://github.com/snakers4/silero-vad.git'
+    dest: /opt/pipecatapp/.cache/torch/hub/snakers4_silero-vad_master
+    version: master
+  become: yes
+
 - name: Copy pipecatapp Nomad job file
   ansible.builtin.template:
     src: ../../jobs/pipecatapp.nomad


### PR DESCRIPTION
This commit addresses a series of runtime errors that were preventing the pipecat application from starting. The changes include:

- Restoring the `FasterWhisperSTTService` class definition to resolve a `NameError`.
- Reverting the transport back to `LocalAudioTransport` to fix audio-related errors in the server environment.
- Configuring the `FasterWhisperSTTService` to load models from a local path and updating the Ansible playbook to pre-cache these models, which resolves network-related errors.
- Restoring the `web_server.py` file to its original state.