### PR TITLE
Fix(ansible): Remove duplicate inclusion of bootstrap_agent role

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -113,10 +113,6 @@
  
     - name: Flush handlers to ensure all services are started
       meta: flush_handlers
-
-    - name: Bootstrap the agent
-      include_role:
-        name: bootstrap_agent   
         
   post_tasks:
     - name: Read rendered Nomad config file

--- a/testing/test_duplicate_role_execution.sh
+++ b/testing/test_duplicate_role_execution.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Test to verify that the bootstrap_agent role is not run twice using static analysis.
+#
+
+# Move to the project root directory
+cd "$(dirname "$0")/.."
+
+echo "Starting test: test_duplicate_role_execution.sh"
+
+# Run the playbook with --list-tasks to get a list of all tasks that would be executed.
+# This is a static check and doesn't require sudo or running any actual commands.
+# We pass a dummy 'target_user' because the playbook requires it.
+playbook_tasks=$(ansible-playbook -i local_inventory.ini playbook.yaml --list-tasks -e "target_user=testuser")
+
+# The task we are looking for is inside the 'bootstrap_agent' role.
+# Ansible formats this as 'role_name : task_name'.
+# We'll check for a task that is unique to the role.
+TASK_NAME="bootstrap_agent : Print Nomad cluster members summary"
+
+# Count the occurrences of the task name in the output.
+# The 'grep -c' command will count the lines containing the task name.
+OCCURRENCE_COUNT=$(echo "$playbook_tasks" | grep -c "Print Nomad cluster members summary")
+
+# The expected count before the fix is 2.
+EXPECTED_COUNT_BEFORE_FIX=2
+
+echo "--------------------------------------------------"
+echo "Checking for duplicate role execution using --list-tasks..."
+echo "Searching for task signature: '${TASK_NAME}'"
+echo "Found ${OCCURRENCE_COUNT} occurrences."
+echo "--------------------------------------------------"
+
+# For the purpose of this test, we are proving the bug exists.
+# So we expect the count to be 2.
+if [ "$OCCURRENCE_COUNT" -eq "$EXPECTED_COUNT_BEFORE_FIX" ]; then
+    echo "✅ SUCCESS: Bug confirmed. The role would be executed twice."
+    exit 0
+else
+    echo "❌ FAILURE: Test did not confirm the bug."
+    echo "Expected ${EXPECTED_COUNT_BEFORE_FIX} occurrences, but found ${OCCURRENCE_COUNT}."
+    echo "This might mean the bug is already fixed or the test logic is flawed."
+    exit 1
+fi


### PR DESCRIPTION
The `bootstrap_agent` role was being included twice in `playbook.yaml`: once as an item in a loop over roles, and again as a standalone `include_role` task immediately after the loop.

This duplication was redundant and inefficient, adding unnecessary time to the playbook execution. This commit removes the second, standalone inclusion, ensuring the role is only run once as intended.