### PR TITLE
Fix: Remove unexpected keyword argument from AudioToTextRecorder

### DIFF
--- a/ansible/roles/pipecatapp/files/app.py
+++ b/ansible/roles/pipecatapp/files/app.py
@@ -115,7 +115,7 @@ class BenchmarkCollector(FrameProcessor):
 class FasterWhisperSTTService(FrameProcessor):
     def __init__(self, model_path, language="en"):
         super().__init__()
-        self.recorder = AudioToTextRecorder(model=model_path, language=language, local_files_only=True)
+        self.recorder = AudioToTextRecorder(model=model_path, language=language)
 
     async def process_frame(self, frame, direction):
         if not isinstance(frame, AudioRawFrame):


### PR DESCRIPTION
The `AudioToTextRecorder` constructor from the `RealtimeSTT` library was being called with an unexpected `local_files_only` keyword argument, causing a `TypeError` on application startup.

This parameter is no longer supported in the version of the library being used. The library now automatically handles local model loading based on the path provided to the `model` argument. This commit removes the unsupported argument to resolve the error.