### PR TITLE
fix(power-agent): Use UID/GID 0 for power-agent.service

### DIFF
--- a/ansible/roles/power_manager/templates/power-agent.service.j2
+++ b/ansible/roles/power_manager/templates/power-agent.service.j2
@@ -7,7 +7,8 @@ Type=simple
 ExecStart=/usr/bin/python3 /opt/power_manager/power_agent.py
 WorkingDirectory=/opt/power_manager
 Restart=on-failure
-User=root # eBPF programs often require root privileges to load
+User=0
+Group=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The power-agent.service was failing to start with a `217/USER` error, indicating that systemd could not resolve the `root` user. This can happen in minimal or sandboxed environments where user name lookup is not available.

This commit changes the service configuration to use `User=0` and `Group=0` to bypass the name lookup and refer to the root user and group by their numeric IDs directly.