### PR TITLE
Fix pipecat agent initialization failure

### DIFF
--- a/ansible/jobs/pipecatapp.nomad
+++ b/ansible/jobs/pipecatapp.nomad
@@ -6,7 +6,7 @@ job "pipecat-app" {
     count = 1
 
     network {
-      mode = "bridge"
+      mode = "host"
       port "http" {
         to = 8000
       }
@@ -38,6 +38,8 @@ job "pipecat-app" {
       }
 
       env {
+        # This should match the service name of the main prima-expert job
+        PRIMA_API_SERVICE_NAME = "prima-api-main"
         # Set to "true" to enable the summarizer tool
         USE_SUMMARIZER = "false"
         # The vision and embedding models are now hardcoded in the application


### PR DESCRIPTION
The `pipecat` agent was failing to initialize because it could not connect to the main LLM service (`prima-expert`). This was caused by two issues:

1.  The `pipecat` application was using a hardcoded URL (`http://localhost:8080/v1`) to connect to the LLM service.
2.  The `pipecat` Nomad job was running in `bridge` network mode, which prevented it from accessing services on the host's network, including the Consul agent needed for service discovery.

This commit resolves these issues by:

1.  Changing the network mode for the `pipecat-group` in `pipecatapp.nomad` to `host`.
2.  Implementing a `discover_main_llm_service` function in `app.py` that dynamically finds the correct IP address and port of the `prima-api-main` service from Consul.
3.  Adding the `PRIMA_API_SERVICE_NAME` environment variable to `pipecatapp.nomad` to make the service name configurable.