### PR TITLE
Fix multiple deployment and runtime errors

### DIFF
--- a/ansible/jobs/prima-expert.nomad
+++ b/ansible/jobs/prima-expert.nomad
@@ -44,7 +44,7 @@ echo "Starting master server for expert: {{ job_name | default('prima-expert') }
 echo "Discovering worker services from Consul..."
 WORKER_IPS=""
 for i in {1..12}; do
-  WORKER_IPS=$(curl -s "http://127.0.0.1:8500/v1/health/service/{{ job_name }}-worker?passing" | jq -r '.[].Service.Address + ":" + (.Service.Port|tostring)' | tr '\n' ',' | sed 's/,$//')
+  WORKER_IPS=$(curl -s "http://127.0.0.1:8500/v1/health/service/{{ job_name }}-worker?passing" | jq -r '.[].Service.Address, .[].Service.Port' | paste -d: - - | tr '\n' ',' | sed 's/,$//')
   if [ -n "$WORKER_IPS" ]; then
     echo "Discovered Worker IPs: $WORKER_IPS"
     break


### PR DESCRIPTION
This commit addresses several issues that prevented the successful deployment and initialization of the `prima-expert` and `pipecat-app` services.

The following fixes are included:

1.  **Fix Nomad HCL Parsing Error:**
    - The service discovery command in `prima-expert.nomad` used a pipe (`|`) character within a `jq` filter. This was misinterpreted by the Nomad HCL parser, causing job submission to fail.
    - The command has been refactored to use `paste -d:` instead, which avoids the parsing error.

2.  **Fix Pipecat Agent Initialization:**
    - The `pipecat` agent was failing to start because it used a hardcoded `localhost` URL to connect to the main LLM service.
    - This has been fixed by implementing a Consul-based service discovery function in `app.py` and changing the `pipecatapp` job to use `host` networking, allowing it to reach the Consul agent.

3.  **Fix Consul Connection for Master Expert:**
    - The `prima-expert` master task was also running in `bridge` mode, preventing it from connecting to Consul to discover its workers.
    - Its network mode has been changed to `host`.

4.  **Fix Word Wrap in UI:**
    - Long lines in the Mission Control terminal now wrap correctly.