### PR TITLE
fix: Use unquoted Jinja2 conditional for worker count

### DIFF
--- a/ansible/jobs/prima-expert.nomad
+++ b/ansible/jobs/prima-expert.nomad
@@ -126,7 +126,7 @@ EOH
   }
 
   group "workers" {
-    count = "{{ worker_count | default(1) }}"
+    count = {{ worker_count if worker_count is defined else 1 }}
 
     network {
       mode = "host"


### PR DESCRIPTION
This commit fixes a Nomad job parsing error in `prima-expert.nomad`. The previous fix, which wrapped the `worker_count` expression in quotes, resolved the bitwise operator error but introduced a new data type mismatch (`Unsuitable value type; a number is required`).

This was because the `count` parameter in a Nomad job file expects a raw integer, not a string.

This commit replaces the quoted expression with an unquoted Jinja2 conditional: `count = {{ worker_count if worker_count is defined else 1 }}`

This approach ensures that the output is always a raw integer, satisfying the Nomad parser's requirement, while still providing a safe default value if `worker_count` is not defined. This resolves the parsing error and allows the job to be submitted successfully.