### PR TITLE
feat: Add Admin UI dropdown to Pipecat UI

### DIFF
--- a/ansible/roles/pipecatapp/files/static/index.html
+++ b/ansible/roles/pipecatapp/files/static/index.html
@@ -23,11 +23,64 @@
         .error { color: #ff6347; }
         #status-light { width: 15px; height: 15px; border-radius: 50%; background-color: #f00; display: inline-block; margin-left: 10px; }
         input, button { padding: 5px; background-color: #333; color: #f0f0f0; border: 1px solid #555; }
+
+        /* Dropdown Button */
+        .dropbtn {
+            background-color: #008CBA;
+            color: white;
+            padding: 8px;
+            font-size: 14px;
+            border: none;
+            cursor: pointer;
+        }
+
+        /* The container <div> - needed to position the dropdown content */
+        .dropdown {
+            position: relative;
+            display: inline-block;
+        }
+
+        /* Dropdown Content (Hidden by Default) */
+        .dropdown-content {
+            display: none;
+            position: absolute;
+            background-color: #f9f9f9;
+            min-width: 160px;
+            box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+            z-index: 1;
+        }
+
+        /* Links inside the dropdown */
+        .dropdown-content a {
+            color: black;
+            padding: 12px 16px;
+            text-decoration: none;
+            display: block;
+        }
+
+        /* Change color of dropdown links on hover */
+        .dropdown-content a:hover {background-color: #f1f1f1}
+
+        /* Show the dropdown menu on hover */
+        .dropdown:hover .dropdown-content {
+            display: block;
+        }
+
+        /* Change the background color of the dropdown button when the dropdown content is shown */
+        .dropdown:hover .dropbtn {
+            background-color: #005f7a;
+        }
     </style>
 </head>
 <body>
     <h1>Mission Control <span id="status-light"></span></h1>
     <div id="controls">
+        <div class="dropdown">
+            <button class="dropbtn">Admin UIs</button>
+            <div class="dropdown-content" id="admin-ui-links">
+                <!-- Links will be populated by JavaScript -->
+            </div>
+        </div>
         <button id="test-and-evaluation-btn">test and evaluation</button>
         <input type="text" id="save-name-input" placeholder="Enter state name...">
         <button id="save-state-btn">Save State</button>
@@ -39,5 +92,39 @@
         <input type="text" id="message-input" style="flex-grow: 1; background-color: #333; color: #f0f0f0; border: 1px solid #555; padding: 5px;" placeholder="Type your message here and press Enter...">
     </div>
     <script src="/static/terminal.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            fetch('/api/web_uis')
+                .then(response => response.json())
+                .then(data => {
+                    const adminUiLinks = document.getElementById('admin-ui-links');
+                    if (data.length === 0) {
+                        const noLink = document.createElement('a');
+                        noLink.textContent = "No UIs found";
+                        noLink.href = "#";
+                        adminUiLinks.appendChild(noLink);
+                        return;
+                    }
+                    data.forEach(ui => {
+                        const link = document.createElement('a');
+                        link.textContent = ui.name;
+                        // Construct URL relative to the current host
+                        const url = new URL(ui.url);
+                        url.hostname = window.location.hostname;
+                        link.href = url.toString();
+                        link.target = "_blank"; // Open in new tab
+                        adminUiLinks.appendChild(link);
+                    });
+                })
+                .catch(error => {
+                    console.error('Error fetching web UIs:', error);
+                    const adminUiLinks = document.getElementById('admin-ui-links');
+                    const errorLink = document.createElement('a');
+                    errorLink.textContent = "Error loading UIs";
+                    errorLink.href = "#";
+                    adminUiLinks.appendChild(errorLink);
+                });
+        });
+    </script>
 </body>
 </html>

--- a/ansible/roles/pipecatapp/files/web_server.py
+++ b/ansible/roles/pipecatapp/files/web_server.py
@@ -4,6 +4,7 @@ from typing import List, Dict
 import asyncio
 from asyncio import Queue
 import json
+import requests
 
 app = FastAPI()
 
@@ -119,6 +120,74 @@ async def get_status():
 async def get_health():
     """A simple health check endpoint that returns a 200 OK status."""
     return {"status": "ok"}
+
+@app.get("/api/web_uis")
+async def get_web_uis():
+    """
+    Discovers web UIs from Consul.
+    It explicitly adds Consul and Nomad, and then discovers other services
+    that have an HTTP health check registered.
+    """
+    web_uis = []
+    consul_url = "http://127.0.0.1:8500"
+
+    try:
+        # 1. Add Consul UI
+        web_uis.append({"name": "Consul", "url": f"{consul_url}/ui"})
+
+        # 2. Add Nomad UI
+        nomad_service_response = requests.get(f"{consul_url}/v1/catalog/service/nomad")
+        nomad_service_response.raise_for_status()
+        nomad_services = nomad_service_response.json()
+        if nomad_services:
+            nomad_address = nomad_services[0].get("ServiceAddress") or nomad_services[0].get("Address")
+            web_uis.append({"name": "Nomad", "url": f"http://{nomad_address}:4646"})
+
+        # 3. Discover other HTTP services
+        services_response = requests.get(f"{consul_url}/v1/catalog/services")
+        services_response.raise_for_status()
+        all_services = services_response.json()
+
+        for service_name in all_services.keys():
+            if service_name in ["nomad", "consul"] or "pipecat" in service_name:
+                continue
+
+            health_response = requests.get(f"{consul_url}/v1/health/service/{service_name}?passing")
+            if health_response.status_code != 200:
+                continue
+
+            service_instances = health_response.json()
+            if not service_instances:
+                continue
+
+            has_http_check = any(
+                "http" in check.get("Type", "") and check.get("Status") == "passing"
+                for instance in service_instances
+                for check in instance.get("Checks", [])
+            )
+
+            if has_http_check:
+                instance = service_instances[0]
+                service_info = instance.get("Service", {})
+                address = service_info.get("Address") or instance.get("Node", {}).get("Address")
+                port = service_info.get("Port")
+                if address and port:
+                    web_uis.append({"name": service_name, "url": f"http://{address}:{port}"})
+
+    except requests.RequestException as e:
+        print(f"Could not connect to Consul to discover UIs: {e}")
+        return JSONResponse(
+            status_code=503,
+            content=[
+                {"name": "Consul (Not Reachable)", "url": "#"},
+                {"name": "Nomad (Not Reachable)", "url": "#"},
+            ]
+        )
+
+    unique_uis = [dict(t) for t in {tuple(d.items()) for d in web_uis}]
+    sorted_uis = sorted(unique_uis, key=lambda x: x['name'])
+
+    return JSONResponse(content=sorted_uis)
 
 @app.post("/api/state/save")
 async def save_state_endpoint(payload: Dict = Body(...)):


### PR DESCRIPTION
This commit introduces a new feature to the Pipecat web UI: a dropdown menu that provides links to other relevant web interfaces in the ecosystem, such as Nomad and Consul.

The changes include:

1.  A new API endpoint `/api/web_uis` in `web_server.py` that dynamically discovers services with web UIs by querying the local Consul agent. It explicitly includes Consul and Nomad and discovers other services with HTTP health checks.

2.  Updates to `index.html` to add the "Admin UIs" dropdown. This includes:
    - HTML for the dropdown structure.
    - CSS to style the dropdown for a clean user experience.
    - JavaScript to fetch the list of UIs from the new API endpoint on page load and dynamically populate the dropdown menu.