### PR TITLE
fix(pipecat-app): Make service discovery and health checks more robust

### DIFF
--- a/ansible/roles/pipecatapp/files/web_server.py
+++ b/ansible/roles/pipecatapp/files/web_server.py
@@ -118,8 +118,15 @@ async def get_status():
 
 @app.get("/health")
 async def get_health():
-    """A simple health check endpoint that returns a 200 OK status."""
-    return {"status": "ok"}
+    """A health check endpoint that verifies the agent is fully initialized."""
+    if twin_service_instance and twin_service_instance.router_llm:
+        # The presence of the router_llm indicates that the LLM service
+        # has been successfully discovered and the agent is ready.
+        return JSONResponse(content={"status": "ok"})
+    else:
+        # Return a 503 Service Unavailable status if the agent is not ready.
+        # This prevents Nomad from marking the allocation as healthy prematurely.
+        return JSONResponse(status_code=503, content={"status": "initializing"})
 
 @app.get("/api/web_uis")
 async def get_web_uis():


### PR DESCRIPTION
The pipecat-app deployment was failing because the application would exit if it couldn't immediately discover the main LLM service. This caused the Nomad health checks to fail and the deployment to time out.

This commit addresses the issue by:

1.  Making the LLM service discovery in `app.py` indefinite. The application will now wait until the service is available instead of exiting.
2.  Improving the `/health` endpoint in `web_server.py` to return a 503 status until the application is fully initialized. This ensures Nomad only marks the service as healthy when it's ready.