### PR TITLE
fix(pipecat-app): Make service discovery and health checks more robust

### DIFF
--- a/testing/unit_tests/test_pipecat_app.py
+++ b/testing/unit_tests/test_pipecat_app.py
@@ -1,25 +1,62 @@
-import sys
+import unittest
 import requests
+import time
+import os
 
-def main():
-    if len(sys.argv) < 2:
-        print("Usage: python test_pipecat_app.py <ip_address>")
-        sys.exit(1)
+class TestPipecatApp(unittest.TestCase):
+    """
+    Unit tests for the Pipecat application's web server.
+    These are more like integration tests as they assume the server is running.
+    """
 
-    ip_address = sys.argv[1]
-    url = f"http://{ip_address}:8000"
+    def setUp(self):
+        """Set up the base URL for the web server."""
+        # Use an environment variable for the host, with a default for local testing.
+        host = os.environ.get("PIPECAT_HOST", "127.0.0.1")
+        self.base_url = f"http://{host}:8000"
 
-    try:
-        response = requests.get(url, timeout=10)
-        if response.status_code == 200:
-            print(f"Health check passed for {url}")
-            sys.exit(0)
-        else:
-            print(f"Health check failed for {url}. Status code: {response.status_code}")
-            sys.exit(1)
-    except requests.exceptions.RequestException as e:
-        print(f"Health check failed for {url}. Error: {e}")
-        sys.exit(1)
+    def test_health_check_eventually_healthy(self):
+        """
+        Tests that the /health endpoint eventually returns a 200 OK status.
+        This test will poll the endpoint for up to 60 seconds to allow the
+        application to fully initialize.
+        """
+        timeout = 60  # seconds
+        start_time = time.time()
+        last_status = None
+        last_content = None
 
-if __name__ == "__main__":
-    main()
+        while time.time() - start_time < timeout:
+            try:
+                response = requests.get(f"{self.base_url}/health", timeout=2)
+                if response.status_code == 200:
+                    self.assertEqual(response.json(), {"status": "ok"})
+                    return  # Test passes
+            except requests.exceptions.RequestException as e:
+                # It's okay to fail connection while the service is starting.
+                print(f"Connection failed: {e}. Retrying...")
+
+            time.sleep(2)
+
+        self.fail(
+            f"The /health endpoint did not return a 200 OK status within {timeout} seconds."
+        )
+
+    def test_main_page_loads(self):
+        """
+        Tests that the main page ('/') loads correctly and returns a 200 OK status.
+        This test also waits for the health check to pass first.
+        """
+        try:
+            self.test_health_check_eventually_healthy()
+            response = requests.get(self.base_url, timeout=10)
+            response.raise_for_status()  # Fail on non-200 status codes
+            self.assertIn("Mission Control", response.text)
+        except requests.exceptions.RequestException as e:
+            self.fail(f"Failed to load the main page at {self.base_url}: {e}")
+
+
+if __name__ == '__main__':
+    # This allows the test to be run directly, for example, in a CI/CD pipeline
+    # where the server is expected to be running at localhost.
+    unittest.main()


### PR DESCRIPTION
The pipecat-app deployment was failing because the application would exit if it couldn't immediately discover the main LLM service. This caused the Nomad health checks to fail and the deployment to time out.

This commit addresses the issue by:

1.  Making the LLM service discovery in `app.py` indefinite. The application will now wait until the service is available instead of exiting.
2.  Improving the `/health` endpoint in `web_server.py` to return a 503 status until the application is fully initialized. This ensures Nomad only marks the service as healthy when it's ready.
3.  Updating the e2e and unit tests to be compatible with the new health check logic, including refactoring the unit test to use the `unittest` framework.