### PR TITLE
fix(nomad): Use volume mount for sound device in pipecatapp job

### DIFF
--- a/ansible/jobs/pipecatapp.nomad
+++ b/ansible/jobs/pipecatapp.nomad
@@ -26,6 +26,11 @@ job "pipecat-app" {
 
     }
 
+    volume "snd" {
+      type      = "host"
+      read_only = false
+      source    = "snd"
+    }
     task "pipecat-task" {
       driver = "raw_exec"
 
@@ -64,8 +69,10 @@ job "pipecat-app" {
 
       }
 
-      device "snd" {
-        source = "/dev/snd"
+      volume_mount {
+        volume      = "snd"
+        destination = "/dev/snd"
+        read_only   = false
       }
 
       resources {


### PR DESCRIPTION
The 'raw_exec' driver does not support the 'device' block. This commit replaces the unsupported block with a 'volume' and 'volume_mount' to correctly expose the host's sound device to the task, resolving the job parsing failure.