### PR TITLE
Fix asyncio.run() error in logging and add config

### DIFF
--- a/docker/pipecatapp/pipecat_config.json
+++ b/docker/pipecatapp/pipecat_config.json
@@ -1,0 +1,8 @@
+{
+    "tts_voices": [
+        {
+            "model": "en_US-lessac-medium.onnx",
+            "config": "en_US-lessac-medium.onnx.json"
+        }
+    ]
+}


### PR DESCRIPTION
- Fixed a `RuntimeError` caused by calling `asyncio.run()` from an already running event loop within the `WebSocketLogHandler`. The handler now correctly schedules the broadcast task on the existing loop.
- Added a default `pipecat_config.json` to the Docker build context to prevent a `FileNotFoundError` on startup and ensure the application has the necessary TTS configuration.