### PR TITLE
Refactor Ansible compilation roles for idempotency

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -10,14 +10,8 @@
     state: present
   become: yes
 
-- name: Check if llama-server is already installed
-  ansible.builtin.stat:
-    path: /usr/local/bin/llama-server
-  register: llama_server_binary
-
 - name: Build and install llama.cpp
   become: yes
-  when: not llama_server_binary.stat.exists
   block:
     - name: Create build directory for llama.cpp
       ansible.builtin.file:
@@ -69,11 +63,6 @@
         remote_src: yes
       loop: "{{ llama_artifacts.files | selectattr('path', 'match', '.*\\.so$') | list }}"
       notify: update ld cache
-
-    - name: Clean up llama.cpp build directory
-      ansible.builtin.file:
-        path: /opt/llama.cpp-build
-        state: absent
 
 - name: Create Nomad jobs directory
   ansible.builtin.file:

--- a/ansible/roles/primacpp/tasks/main.yaml
+++ b/ansible/roles/primacpp/tasks/main.yaml
@@ -69,12 +69,6 @@
   loop: "{{ primacpp_binaries.files }}"
   become: yes
 
-- name: Clean up prima.cpp build directory
-  ansible.builtin.file:
-    path: "{{ primacpp_install_dir }}"
-    state: absent
-  become: yes
-
 - name: Copy prima.cpp Nomad job file
   ansible.builtin.template:
     src: ../../jobs/primacpp.nomad

--- a/ansible/roles/whisper_cpp/tasks/main.yaml
+++ b/ansible/roles/whisper_cpp/tasks/main.yaml
@@ -8,14 +8,8 @@
     state: present
   become: yes
 
-- name: Check if whisper.cpp stream binary is already installed
-  ansible.builtin.stat:
-    path: /usr/local/bin/stream
-  register: whisper_stream_binary
-
 - name: Build and install whisper.cpp
   become: yes
-  when: not whisper_stream_binary.stat.exists
   block:
     - name: Create build directory for whisper.cpp
       ansible.builtin.file:
@@ -58,8 +52,3 @@
         mode: '0755'
         remote_src: yes
       loop: "{{ whisper_binaries.files }}"
-
-    - name: Clean up whisper.cpp build directory
-      ansible.builtin.file:
-        path: /opt/whisper.cpp-build
-        state: absent


### PR DESCRIPTION
This commit refactors the Ansible roles for `llama_cpp`, `whisper_cpp`, and `primacpp` to be more idempotent.

The following changes were made to each role:
- The task to clean up the build directory has been removed. This allows for pulling updates from the git repository and rebuilding without manual intervention.
- The initial check for the existence of the binary has been removed. The idempotency is now handled by the `creates` argument on the `cmake` and build commands.

These changes make the deployment process more stable and predictable, as the Ansible playbook can be run multiple times without causing errors or unintended side effects.