### PR TITLE
Fix(ansible): Correct model download loop and improve idempotency

### DIFF
--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -13,7 +13,7 @@
     url: "{{ item.url }}"
     dest: "/opt/nomad/models/stt/{{ item.filename }}"
     mode: '0644'
-  loop: "{{ stt_models }}"
+  loop: "{{ stt_whisper_models }}"
   become: yes
   loop_control:
     loop_var: item

--- a/group_vars/models.yaml
+++ b/group_vars/models.yaml
@@ -41,14 +41,6 @@ stt_whisper_models:
     url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin"
     filename: "ggml-base.en.bin"
 
-stt_models:
-- name: Clone the correct faster-whisper model
-  ansible.builtin.git:
-    repo: 'https://huggingface.co/Systran/faster-whisper-tiny.en'
-    dest: /opt/nomad/models/stt/faster-whisper-tiny.en
-    version: main
-  become: yes
-
 # A list of voices for the PiperTTSService to use, in order of preference.
 tts_voices:
   - name: "en_US-l2arctic-medium"


### PR DESCRIPTION
This commit addresses two issues:
1.  A failing Ansible task in the `download_models` role. The task was attempting to loop over a malformed variable (`stt_models`). This has been corrected to loop over the intended `stt_whisper_models` variable, and the faulty variable has been removed from `group_vars/models.yaml`.

2.  Lack of idempotency in the `llama_cpp`, `whisper_cpp`, and `primacpp` compilation roles. The tasks that removed the build directories have been deleted, allowing the roles to be run multiple times to pull updates and rebuild as necessary.