### PR TITLE
fix(llama-server): Correct --flash-attn argument in Nomad job

### DIFF
--- a/ansible/jobs/prima-expert.nomad
+++ b/ansible/jobs/prima-expert.nomad
@@ -77,7 +77,7 @@ health_check_url="http://127.0.0.1:{{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }}/h
     --host 0.0.0.0 \
     --port {{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }} \
     --n-gpu-layers 999 \
-    --flash-attn \
+    --flash-attn auto \
     --mlock \
     $rpc_args &
 


### PR DESCRIPTION
The llama-server was failing to start due to an incorrect argument. The `--flash-attn` flag was being passed without a value, causing the argument parser to fail.

This change corrects the issue by providing the value 'auto' to the `--flash-attn` flag in the prima-expert.nomad job template. This ensures the server starts with the intended Flash Attention configuration.