### PR TITLE
Fix VAD model download path in pipecatapp role

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -104,17 +104,20 @@
 
 - name: Create VAD model directory
   ansible.builtin.file:
-    path: /root/.cache/torch/hub/snakers4_silero-vad_master
+    path: "/home/{{ target_user }}/.cache/torch/hub/snakers4_silero-vad_master"
     state: directory
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
     mode: '0755'
   become: yes
 
 - name: Clone silero-vad model
   ansible.builtin.git:
     repo: 'https://github.com/snakers4/silero-vad.git'
-    dest: /root/.cache/torch/hub/snakers4_silero-vad_master
+    dest: "/home/{{ target_user }}/.cache/torch/hub/snakers4_silero-vad_master"
     version: master
   become: yes
+  become_user: "{{ target_user }}"
 
 - name: Ensure Nomad jobs directory exists
   ansible.builtin.file:


### PR DESCRIPTION
The `pipecatapp` Ansible role was incorrectly downloading the silero-vad model to the `/root/.cache` directory. This would cause the application to fail at runtime when running as a non-root user, as it would look for the model in the user's home directory.

This commit corrects the destination path to use the `target_user`'s home directory (`/home/{{ target_user }}/.cache/...`). It also ensures the directory is created with the correct ownership and that the git clone operation is performed as the `target_user`.