### PR TITLE
refactor(nomad): Improve prima-expert job template

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -90,7 +90,7 @@
     job_name: "prima-expert-main"
     service_name: "prima-api-main"
     namespace: "default"
-    model_list: "{{ main_expert_models }}"
+    expert_models: "{{ main_expert_models }}"
     worker_count: 1
 
 - name: Copy benchmark Nomad job file

--- a/ansible/roles/system_deps/tasks/main.yaml
+++ b/ansible/roles/system_deps/tasks/main.yaml
@@ -23,6 +23,7 @@
       - hollywood
       - htop
       - iperf3
+      - jq
       - libavif16
       - libcurl4-openssl-dev
       - libevent-2.1-7t64


### PR DESCRIPTION
This commit refactors the `prima-expert.nomad` job template and related Ansible configurations to improve robustness and maintainability.

The following changes have been made:
- Increased the health check wait time to 5 minutes (30 attempts) to allow more time for large models to load.
- Increased the master task's memory allocation to 16384MB to prevent potential OOM kills.
- Parameterized the model list using a Jinja2 loop, making the template reusable for different expert models.
- Updated the Consul KV key to `experts/{{ job_name }}/active_model` for better namespacing.
- Added `jq` as a system dependency in the `system_deps` Ansible role, as it is required by the job's startup script.