### PR TITLE
This commit fully implements and automates the prompt evolution workf…

### DIFF
--- a/ansible/jobs/evolve-prompt.nomad.j2
+++ b/ansible/jobs/evolve-prompt.nomad.j2
@@ -1,0 +1,35 @@
+job "evolve-prompt" {
+  datacenters = ["dc1"]
+  namespace   = "default"
+  type        = "batch"
+
+  periodic {
+    # Run daily at midnight (UTC)
+    cron             = "0 0 * * *"
+    prohibit_overlap = true
+  }
+
+  group "evolution" {
+    count = 1
+
+    task "run-evolution" {
+      driver = "exec"
+
+      config {
+        command = "python3"
+        args = [
+          "prompt_engineering/evolve.py"
+        ]
+      }
+
+      env {
+        OPENAI_API_KEY = "{{ openai_api_key }}"
+      }
+
+      resources {
+        cpu    = 1000 # 1 GHz
+        memory = 2048 # 2 GB
+      }
+    }
+  }
+}

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -138,6 +138,11 @@
     src: pipecatapp.nomad.j2
     dest: /opt/nomad/jobs/pipecatapp.nomad
 
+- name: Template prompt evolution Nomad job file
+  ansible.builtin.template:
+    src: ../../jobs/evolve-prompt.nomad.j2
+    dest: /opt/nomad/jobs/evolve-prompt.nomad
+
 - name: Install Playwright browsers using the virtual environment's python
   ansible.builtin.command:
     cmd: "/home/{{ target_user }}/.local/bin/python3 -m playwright install"

--- a/deploy_prompt_evolution.yaml
+++ b/deploy_prompt_evolution.yaml
@@ -1,0 +1,10 @@
+- name: Deploy the prompt evolution Nomad job
+  hosts: localhost
+  connection: local
+  gather_facts: no
+
+  tasks:
+    - name: Deploy the prompt evolution job to Nomad
+      ansible.builtin.command:
+        cmd: "nomad job run ansible/jobs/evolve-prompt.nomad"
+      changed_when: true


### PR DESCRIPTION
…low.

The `prompt_engineering/evolve.py` script, previously a placeholder, is now functional. It reads its initial prompt from `prompts/router.txt`, which has been added with a sensible default.

To support this change and ensure its correctness, a unit test has been added in `testing/unit_tests/test_prompt_engineering.py`. This test verifies that the `evolve.py` script correctly initializes the `OpenEvolve` library.

Furthermore, the prompt evolution process is now automated as a periodic, low-priority task. This is achieved by:
1.  Creating a new Nomad batch job at `ansible/jobs/evolve-prompt.nomad.j2` scheduled to run daily.
2.  Integrating this job into the `pipecatapp` Ansible role, which now templates the job file and copies it to the target machine.
3.  Securely providing the `OPENAI_API_KEY` to the job as an environment variable via the Ansible template.