### PR TITLE
Fix: Define default value for external_model_server

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -31,6 +31,7 @@ pipecat_api_keys: ""
 
 # Configuration for external, third-party LLM experts.
 # This is a dictionary that will be converted to a JSON string.
+external_model_server: false
 external_experts_config:
   openai_gpt4:
     base_url: "https://api.openai.com/v1"


### PR DESCRIPTION
This commit fixes a fatal error in the Ansible playbook caused by the `external_model_server` variable being undefined.

The variable is used in a conditional check, and if it's not set, the playbook fails. This change adds a default value of `false` for `external_model_server` in `group_vars/all.yaml` to ensure the playbook can run without this variable being explicitly passed.