### PR TITLE
Fix: Resolve multiple Ansible playbook failures

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -103,7 +103,7 @@
 
 - name: Run expert jobs
   ansible.builtin.command:
-    cmd: nomad job run -meta "expert_name={{ item }}" /opt/nomad/jobs/expert.nomad
+    cmd: nomad job run -var "expert_name={{ item }}" /opt/nomad/jobs/expert.nomad
   loop:
     - main
     - coding


### PR DESCRIPTION
This commit addresses three separate issues that caused the Ansible playbook to fail during execution.

1.  **Handle undefined 'workers' group:** The playbook would fail with an 'undefined variable' error when the 'workers' inventory group was not present. This has been resolved by adding a conditional check to the `expected_cluster_size` variable in `group_vars/all.yaml`. It now defaults to `1` if the `workers` group is not defined.

2.  **Resolve `python-consul` dependency conflict:** Tasks in the `download_models` role were failing due to a dependency on the outdated `python-consul` library. This has been fixed by replacing the `community.general.consul_kv` module with the `ansible.builtin.uri` module to interact with the Consul KV store directly via its HTTP API.

3.  **Correct `nomad job run` flag:** The `nomad job run` command in the `llama_cpp` role was using an incorrect `-meta` flag, which is not supported by the installed Nomad version. This has been corrected to use the proper `-var` flag for passing variables to the job.