### PR TITLE
Fix Nomad HCL2 parsing error by using Ansible templates

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -1,2 +1,7 @@
 external_model_server: false
 target_user: user
+experts:
+  - main
+  - coding
+  - math
+  - extract

--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -1,10 +1,9 @@
-job "expert-${meta.expert_name}" {
+job "expert-{{ expert_name }}" {
   datacenters = ["dc1"]
   namespace   = "default"
 
   meta {
-    # This will be overridden by the `nomad run -meta` command
-    expert_name = "main"
+    expert_name = "{{ expert_name }}"
   }
 
   group "master" {
@@ -22,10 +21,10 @@ job "expert-${meta.expert_name}" {
     }
 
     service {
-      name     = "prima-api-${meta.expert_name}"
+      name     = "prima-api-{{ expert_name }}"
       provider = "consul"
       port     = "http"
-      tags     = ["expert", "${meta.expert_name}"]
+      tags     = ["expert", "{{ expert_name }}"]
 
       check {
         type     = "http"
@@ -152,7 +151,7 @@ EOH
     }
 
     service {
-      name     = "expert-${meta.expert_name}-worker"
+      name     = "expert-{{ expert_name }}-worker"
       provider = "consul"
       port     = "rpc"
 

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -81,34 +81,29 @@
     mode: '0755'
   become: yes
 
-- name: Copy generic expert Nomad job file
-  ansible.builtin.copy:
-    src: ../../jobs/expert.nomad
-    dest: /opt/nomad/jobs/expert.nomad
-    mode: '0644'
-
 - name: Stop and purge any existing expert jobs to ensure idempotency
   ansible.builtin.command:
     cmd: nomad job stop -purge "expert-{{ item }}"
-  loop:
-    - main
-    - coding
-    - math
-    - extract
+  loop: "{{ experts }}"
   register: expert_job_stop_status
-  changed_when: "expert_job_stop_status.rc == 0"
+  changed_when: "'Running' in expert_job_stop_status.stdout"
   failed_when: false # Don't fail if the job doesn't exist
   environment:
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
 
+- name: Create expert job files from template
+  ansible.builtin.template:
+    src: ../../jobs/expert.nomad.j2
+    dest: "/opt/nomad/jobs/expert-{{ item }}.nomad"
+    mode: '0644'
+  loop: "{{ experts }}"
+  vars:
+    expert_name: "{{ item }}"
+
 - name: Run expert jobs
   ansible.builtin.command:
-    cmd: nomad job run -var "expert_name={{ item }}" /opt/nomad/jobs/expert.nomad
-  loop:
-    - main
-    - coding
-    - math
-    - extract
+    cmd: "nomad job run /opt/nomad/jobs/expert-{{ item }}.nomad"
+  loop: "{{ experts }}"
   environment:
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
 


### PR DESCRIPTION
The `nomad job run` command was failing with an HCL2 parsing error because the `expert.nomad` job file contained `${...}` syntax in the job name and other fields. The HCL2 parser does not allow this type of interpolation directly in strings.

This change resolves the issue by converting the static `expert.nomad` file into a Jinja2 template (`expert.nomad.j2`).

Key changes:
- Renamed `ansible/jobs/expert.nomad` to `ansible/jobs/expert.nomad.j2`.
- Replaced HCL2-style interpolation (`${...}`) with Ansible/Jinja2-style variables (`{{ ... }}`).
- Updated `ansible/roles/llama_cpp/tasks/main.yaml` to use the `ansible.builtin.template` module to generate a separate, valid Nomad job file for each expert.
- The list of experts is now defined in `ansible/group_vars/all.yaml` for better maintainability.
- The `nomad job run` command now executes the generated, expert-specific job files, removing the need for the `-var` flag that caused the parsing error.