### PR TITLE
Fix(ansible): Resolve undefined experts variable and template conflict

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -64,7 +64,7 @@ else
   echo "No workers found after waiting. Starting in standalone mode."
 fi
 
-health_check_url="http://127.0.0.1:{{ env "NOMAD_PORT_http" }}/health"
+health_check_url="http://127.0.0.1:{{ '{{' }} env \"NOMAD_PORT_http\" {{ '}}' }}/health"
 
 echo "Fetching model configuration from Consul..."
 MODEL_CONFIG_JSON=$(curl -s http://127.0.0.1:8500/v1/kv/config/models/${NOMAD_META_expert_name}?raw)
@@ -84,7 +84,7 @@ for model_data in $(echo "$MODEL_CONFIG_JSON" | jq -c '.[]'); do
   /usr/local/bin/llama-server \
     --model "/opt/nomad/models/llm/${model_filename}" \
     --host 0.0.0.0 \
-    --port {{ env "NOMAD_PORT_http" }} \
+    --port {{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }} \
     --n-gpu-layers 999 \
     --fa auto \
     --mlock \
@@ -169,7 +169,7 @@ EOH
         data = <<EOH
 #!/bin/bash
 set -e
-/usr/local/bin/rpc-server --host 0.0.0.0 --port {{ env "NOMAD_PORT_rpc" }}
+/usr/local/bin/rpc-server --host 0.0.0.0 --port {{ '{{' }} env "NOMAD_PORT_rpc" {{ '}}' }}
 EOH
         destination = "local/run_rpc.sh"
         perms       = "0755"

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -1,7 +1,3 @@
-- name: Load common variables
-  ansible.builtin.include_vars:
-    file: "{{ playbook_dir }}/group_vars/all.yaml"
-
 - name: Install build and runtime dependencies for llama.cpp
   ansible.builtin.apt:
     name:


### PR DESCRIPTION
This commit addresses two issues that caused the Ansible playbook to fail:

1.  **Undefined `experts` variable:** The `llama_cpp` role was failing because the `experts` variable it looped over was not defined. This has been resolved by adding a list of experts to `group_vars/all.yaml`.

2.  **Jinja2 templating conflict:** The `expert.nomad.j2` template file used Nomad's `{{ }}` syntax, which conflicted with Ansible's Jinja2 delimiters. This was fixed by escaping the Nomad-specific syntax (e.g., `{{ '{{' }} ... {{ '}}' }}`), ensuring that Ansible renders the template correctly.

These changes allow the `llama_cpp` role to execute successfully.