### PR TITLE
Fix: Resolve multiple Ansible and Nomad configuration errors

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -35,7 +35,7 @@ job "expert-{{ expert_name }}" {
     }
 
     task "llama-server-master" {
-      driver = "exec"
+      driver = "raw_exec"
 
       template {
         data = <<EOH
@@ -86,7 +86,7 @@ for model_data in $(echo "$MODEL_CONFIG_JSON" | jq -c '.[]'); do
     --host 0.0.0.0 \
     --port {{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }} \
     --n-gpu-layers 999 \
-    --fa auto \
+    --flash-attn auto \
     --mlock \
     $rpc_args &
 
@@ -163,20 +163,14 @@ EOH
     }
 
     task "rpc-server-worker" {
-      driver = "exec"
-
-      template {
-        data = <<EOH
-#!/bin/bash
-set -e
-/usr/local/bin/rpc-server --host 0.0.0.0 --port {{ '{{' }} env "NOMAD_PORT_rpc" {{ '}}' }}
-EOH
-        destination = "local/run_rpc.sh"
-        perms       = "0755"
-      }
+      driver = "raw_exec"
 
       config {
-        command = "local/run_rpc.sh"
+        command = "/usr/local/bin/rpc-server"
+        args = [
+          "--host", "0.0.0.0",
+          "--port", "{{ '{{' }} env \"NOMAD_PORT_rpc\" {{ '}}' }}"
+        ]
       }
 
       resources {

--- a/ansible/roles/nomad/templates/nomad.hcl.client.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.client.j2
@@ -36,4 +36,9 @@ client {
     path      = "/dev/snd"
     read_only = false
   }
+
+  host_volume "models" {
+    path      = "{{ nomad_models_dir }}"
+    read_only = true
+  }
 }

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -146,7 +146,7 @@
 
 - name: Install Playwright browsers using the virtual environment's python
   ansible.builtin.command:
-    cmd: "/home/{{ target_user }}/.local/bin/python -m playwright install"
+    cmd: "{{ pipecat_app_dir }}/venv/bin/python -m playwright install"
 
   become: yes
   become_user: "{{ target_user }}"

--- a/test_nomad_config.yaml
+++ b/test_nomad_config.yaml
@@ -1,0 +1,14 @@
+- name: Test Nomad client configuration
+  hosts: all
+  remote_user: "{{ target_user }}"
+  become: yes
+
+  vars:
+    target_user: "loki"
+    nomad_data_dir: "/opt/nomad"
+    nomad_zip_url: "https://releases.hashicorp.com/nomad/1.7.7/nomad_1.7.7_linux_amd64.zip"
+    cni_url: "https://github.com/containernetworking/plugins/releases/download/v1.5.1/cni-plugins-linux-amd64-v1.5.1.tgz"
+    nomad_models_dir: "/opt/nomad/models"
+
+  roles:
+    - nomad


### PR DESCRIPTION
This commit addresses a series of issues that prevented the successful deployment of the expert and pipecat applications.

The following changes have been made:

1.  **Ansible: Define `experts` variable.**
    - Added the `experts` variable to `group_vars/all.yaml` to resolve the initial "undefined variable" error in the `llama_cpp` role.

2.  **Ansible: Fix Jinja2 templating conflict.**
    - Escaped the Nomad-specific `{{ }}` syntax in `ansible/jobs/expert.nomad.j2` to prevent conflicts with Ansible's templating engine.

3.  **Nomad: Add `models` host volume.**
    - Added the `models` host volume definition to `ansible/roles/nomad/templates/nomad.hcl.client.j2` to satisfy the job's volume requirement.

4.  **Nomad: Use `raw_exec` driver.**
    - Changed the task driver in `ansible/jobs/expert.nomad.j2` from `exec` to `raw_exec` to match the working configuration of other jobs and resolve a likely cause of deployment timeouts.

5.  **Ansible: Correct Playwright installation path.**
    - Updated the `pipecatapp` role to use the correct Python executable from the application's virtual environment (`/opt/pipecatapp/venv`) when installing Playwright browsers.

These fixes collectively address the root causes of the playbook failures and Nomad job deployment issues.