### PR TITLE
Fix(ansible): Define job_name in llama_cpp role

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -98,6 +98,7 @@
     mode: '0644'
   loop: "{{ experts }}"
   vars:
+    job_name: "expert-{{ item }}"
     expert_name: "{{ item }}"
     model_list: "{{ expert_models[item] }}"
 


### PR DESCRIPTION
The `llama_cpp` role was failing during the 'Create expert job files from template' task due to an `AnsibleUndefinedVariable` error. The `expert.nomad.j2` template expected a `job_name` variable, which was not being defined in the task's loop.

This change defines the `job_name` variable within the loop in `ansible/roles/llama_cpp/tasks/main.yaml`, setting it to `expert-{{ item }}`. This resolves the error and allows the Ansible playbook to run successfully.