### PR TITLE
Fix(ansible): Correct llama_cpp expert job definition

### DIFF
--- a/ansible/roles/nomad/templates/nomad.hcl.client.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.client.j2
@@ -19,8 +19,8 @@ consul {
 client {
   enabled = true
   options = {
-    "driver.raw_exec.enable"      = "1"
-    "raw_exec.volumes.enabled" = "true"
+    "driver.raw_exec.enable" = "1",
+    "driver.exec.enable"     = "1"
   }
 
   host_volume "pipecatapp" {


### PR DESCRIPTION
This commit resolves multiple issues that caused the Ansible playbook to fail when deploying the `llama_cpp` expert Nomad job:

1.  **Undefined `job_name` variable:** The `job_name` variable was not being defined within the loop that creates the expert job files. This caused a Jinja2 templating error. The fix defines `job_name` for each item in the loop within `ansible/roles/llama_cpp/tasks/main.yaml`.

2.  **Incorrect Driver for Host Volumes:** The Nomad job was attempting to use the `raw_exec` driver, which does not support host volumes, leading to a job parsing error. The driver for the `llama-server-master` and `rpc-server-worker` tasks has been changed to `exec` in `ansible/jobs/expert.nomad.j2`.

3.  **`exec` Driver Not Enabled:** The `exec` driver was not enabled in the Nomad client configuration. This has been corrected by adding `driver.exec.enable = "1"` to the client options in `ansible/roles/nomad/templates/nomad.hcl.client.j2`.

Additionally, the `test_llama_cpp.yaml` playbook has been improved to provide a more robust integration test environment, ensuring that dependent services like Consul and Nomad are running before the `llama_cpp` role is tested.