### PR TITLE
Fix(ansible): Resolve multiple playbook errors and add missing models…

### DIFF
--- a/ansible/group_vars/models.yaml
+++ b/ansible/group_vars/models.yaml
@@ -1,0 +1,63 @@
+expert_models:
+  main:
+    - name: "Llama-3-8B-Instruct"
+      url: "https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF-v2/resolve/main/Meta-Llama-3-8B-Instruct-v2.Q4_K_M.gguf"
+      filename: "Meta-Llama-3-8B-Instruct-Q4_K_M.gguf"
+      memory_mb: 8192
+    - name: "phi-3-mini-instruct"
+      url: "https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q4_K_M.gguf"
+      filename: "Phi-3-mini-4k-instruct-Q4_K_M.gguf"
+      memory_mb: 4096
+  coding:
+    - name: "CodeLlama-7B-Instruct"
+      url: "https://huggingface.co/TheBloke/CodeLlama-7B-Instruct-GGUF/resolve/main/codellama-7b-instruct.Q4_K_M.gguf"
+      filename: "codellama-7b-instruct.Q4_K_M.gguf"
+      memory_mb: 8192
+    - name: "phi-3-mini-instruct"
+      url: "https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q4_K_M.gguf"
+      filename: "Phi-3-mini-4k-instruct-Q4_K_M.gguf"
+      memory_mb: 4096
+  math:
+    - name: "LFM2-350M-Math"
+      url: "https://huggingface.co/LiquidAI/LFM2-350M-Math-GGUF/resolve/main/LFM2-350M-Math-Q4_K_M.gguf"
+      filename: "LFM2-350M-Math-Q4_K_M.gguf"
+      memory_mb: 2048
+  extract:
+    - name: "LFM2-1.2B-Extract"
+      url: "https://huggingface.co/LiquidAI/LFM2-1.2B-Extract-GGUF/resolve/main/LFM2-1.2B-Extract-Q4_K_M.gguf"
+      filename: "LFM2-1.2B-Extract-Q4_K_M.gguf"
+      memory_mb: 4096
+
+tts_voices:
+  - name: "en_US-l2arctic-medium"
+    repo_id: "rhasspy/piper-voices"
+    path_in_repo: "en/en_US/l2arctic/medium"
+  - name: "en_US-lessac-low"
+    repo_id: "rhasspy/piper-voices"
+    path_in_repo: "en/en_US/lessac/low"
+
+piper_voice_files:
+  - url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/l2arctic/medium/en_US-l2arctic-medium.onnx"
+    filename: "en_US-l2arctic-medium.onnx"
+  - url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/l2arctic/medium/en_US-l2arctic-medium.onnx.json"
+    filename: "en_US-l2arctic-medium.onnx.json"
+  - url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/low/en_US-lessac-low.onnx"
+    filename: "en_US-lessac-low.onnx"
+  - url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/low/en_US-lessac-low.onnx.json"
+    filename: "en_US-lessac-low.onnx.json"
+
+embedding_models:
+  - name: "bge-large-en-v1.5"
+    repo_id: "BAAI/bge-large-en-v1.5"
+
+stt_models:
+  - name: "whisper-large-v3"
+    url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin"
+    filename: "ggml-large-v3.bin"
+
+vision_models:
+  - name: "yolov8n"
+    url: "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8n.pt"
+    filename: "yolov8n.pt"
+  - name: "moondream2"
+    repo_id: "vikhyatk/moondream2"


### PR DESCRIPTION
….yaml

This commit addresses several cascading errors that prevented the `llama_cpp` expert job from deploying correctly. The primary root cause was a missing `ansible/group_vars/models.yaml` file, which has now been created with the necessary model definitions.

This comprehensive fix includes:
1.  **Created `ansible/group_vars/models.yaml`:** The playbook was failing to load this critical variable file, causing undefined variable errors downstream. The file has been created with the correct data structure for all model types.
2.  **Fixed Undefined `job_name`:** The `job_name` variable was not being passed to the `expert.nomad.j2` template. This has been corrected by adding it to the `vars` of the template task in `ansible/roles/llama_cpp/tasks/main.yaml`.
3.  **Fixed `download_models` Loop:** The `download_models` role was using `item.url` instead of `item.item.url` when looping over registered results. This has been corrected for both the TTS and Vision model download tasks.
4.  **Defined `nomad_models_dir`:** The variable for the Nomad models directory was not defined, preventing the correct rendering of the `host_volume` in the Nomad client config. This has been fixed by adding `nomad_models_dir: /opt/nomad/models` to `ansible/group_vars/all.yaml`.
5.  **Corrected Nomad Volume Definition:** The `volume` block for the "models" `host_volume` was previously placed incorrectly. It has been moved inside the `group "master"` block in `ansible/jobs/expert.nomad.j2` to match Nomad's required syntax.
6.  **Prevented Build Hang:** The `cmake` build command for `llama.cpp` was using an unbounded `-j` flag, which could exhaust system resources. This has been limited to `-j 2` to prevent hangs.