### PR TITLE
fix(nomad): Harden server startup scripts against PID errors

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -118,12 +118,18 @@ health_check_url="http://127.0.0.1:{{ '{{' }} env \"NOMAD_PORT_http\" {{ '}}' }}
     # Write the active model to Consul KV for other services to discover
     curl -X PUT --data "{{ model.name }}" "http://127.0.0.1:8500/v1/kv/experts/${NOMAD_META_expert_name}/active_model"
 
-    wait $server_pid
+    # If we get here, the server is healthy and running. Wait for it to exit.
+    if [ -n "$server_pid" ]; then
+      wait $server_pid
+    fi
     exit 0
   else
     echo "❌ Server failed to become healthy with {{ model.name }}. Trying next model."
-    kill $server_pid
-    wait $server_pid 2>/dev/null
+    # Only try to kill the process if the PID was captured.
+    if [ -n "$server_pid" ]; then
+      kill $server_pid
+      wait $server_pid 2>/dev/null
+    fi
   fi
 {% endfor %}
 {% else %}

--- a/ansible/jobs/llamacpp-rpc.nomad.j2
+++ b/ansible/jobs/llamacpp-rpc.nomad.j2
@@ -93,12 +93,18 @@ health_check_url="http://127.0.0.1:{{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }}/h
   done
 
   if [ "$healthy" = true ]; then
-    wait $server_pid
+    # If we get here, the server is healthy and running. Wait for it to exit.
+    if [ -n "$server_pid" ]; then
+      wait $server_pid
+    fi
     exit 0
   else
     echo "❌ Server failed to become healthy with {{ model.name }}. Trying next model."
-    kill $server_pid
-    wait $server_pid 2>/dev/null
+    # Only try to kill the process if the PID was captured.
+    if [ -n "$server_pid" ]; then
+      kill $server_pid
+      wait $server_pid 2>/dev/null
+    fi
   fi
 {% endfor %}
 {% else %}


### PR DESCRIPTION
The shell scripts within the Nomad job templates for `expert` and `llamacpp-rpc` were susceptible to a race condition where the `llama-server` process could fail to start, leaving the `$server_pid` variable empty.

Subsequent calls to `kill $server_pid` or `wait $server_pid` would then fail with a string-to-integer conversion error, causing the entire Nomad task to crash.

This change adds a check to ensure that `$server_pid` is not empty before attempting to use it, making the scripts more resilient to process startup failures.