### PR TITLE
feat(nomad): Add verbose logging to server health checks

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -102,13 +102,14 @@ health_check_url="http://127.0.0.1:{{ '{{' }} env \"NOMAD_PORT_http\" {{ '}}' }}
   do
     sleep 10
 
-    if curl -s --fail $health_check_url > /dev/null; then
-
+    # Use curl with verbose logging to diagnose health check failures.
+    # We redirect stdout to /dev/null but let stderr (where -v output goes) print.
+    if curl -s --fail --verbose $health_check_url > /dev/null; then
       echo "✅ Server is healthy with model {{ model.name }}!"
       healthy=true
       break
     else
-      echo "Health check failed (attempt $i/30)..."
+      echo "Health check failed (attempt $i/30). See verbose curl output above."
     fi
   done
 

--- a/ansible/jobs/llamacpp-rpc.nomad.j2
+++ b/ansible/jobs/llamacpp-rpc.nomad.j2
@@ -83,12 +83,14 @@ health_check_url="http://127.0.0.1:{{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }}/h
   healthy=false
   for i in {1..30}; do
     sleep 10
-    if curl -s --fail $health_check_url > /dev/null; then
+    # Use curl with verbose logging to diagnose health check failures.
+    # We redirect stdout to /dev/null but let stderr (where -v output goes) print.
+    if curl -s --fail --verbose $health_check_url > /dev/null; then
       echo "✅ Server is healthy with model {{ model.name }}!"
       healthy=true
       break
     else
-      echo "Health check failed (attempt $i/30)..."
+      echo "Health check failed (attempt $i/30). See verbose curl output above."
     fi
   done
 


### PR DESCRIPTION
This change enhances the diagnostic capabilities of the `expert` and `llamacpp-rpc` Nomad jobs.

The health check loop in the server startup script has been modified to use `curl --verbose`. This will print the full HTTP request and response headers and body to stderr if the health check fails.

This additional logging is intended to help diagnose a recurring issue where the `llama-server` process fails to become healthy, causing deployment timeouts.