### PR TITLE
Fix(ansible): Resolve multiple playbook errors and add missing models…

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -46,7 +46,7 @@ job "expert-{{ expert_name }}" {
     }
 
     task "llama-server-master" {
-      driver = "raw_exec"
+      driver = "exec"
 
       template {
         data = <<EOH
@@ -180,7 +180,7 @@ EOH
     }
 
     task "rpc-server-worker" {
-      driver = "raw_exec"
+      driver = "exec"
 
       config {
         command = "/usr/local/bin/rpc-server"

--- a/ansible/roles/nomad/templates/nomad.hcl.client.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.client.j2
@@ -19,7 +19,8 @@ consul {
 client {
   enabled = true
   options = {
-    "driver.raw_exec.enable" = "1"
+    "driver.raw_exec.enable" = "1",
+    "driver.exec.enable"     = "1"
   }
 
   host_volume "pipecatapp" {


### PR DESCRIPTION
….yaml

This commit addresses several cascading errors that prevented the `llama_cpp` expert job from deploying correctly. The primary root cause was a missing `ansible/group_vars/models.yaml` file, which has now been created with the necessary model definitions.

This comprehensive fix includes:
1.  **Created `ansible/group_vars/models.yaml`:** The playbook was failing to load this critical variable file, causing undefined variable errors downstream. The file has been created with the correct data structure for all model types.
2.  **Fixed Undefined `job_name`:** The `job_name` variable was not being passed to the `expert.nomad.j2` template. This has been corrected by adding it to the `vars` of the template task in `ansible/roles/llama_cpp/tasks/main.yaml`.
3.  **Fixed `download_models` Loop:** The `download_models` role was using `item.url` instead of `item.item.url` when looping over registered results, causing an error. This has been corrected for both the TTS and Vision model download tasks.
4.  **Defined `nomad_models_dir`:** The variable for the Nomad models directory was not defined, preventing the correct rendering of the `host_volume` in the Nomad client config. This has been fixed by adding `nomad_models_dir: /opt/nomad/models` to `ansible/group_vars/all.yaml`.
5.  **Corrected Nomad Volume Definition:** The `volume` block for the "models" `host_volume` was previously placed incorrectly. It has been moved inside the `group "master"` block in `ansible/jobs/expert.nomad.j2` to match Nomad's required syntax.
6.  **Enabled `exec` driver:** The Nomad job requires the `exec` driver to use host volumes. The driver has been enabled in the client configuration and set for the relevant tasks in the job template.
7.  **Prevented Build Hang:** The `cmake` build command for `llama.cpp` was using an unbounded `-j` flag, which could exhaust system resources. This has been limited to `-j 2` to prevent hangs.