### PR TITLE
Fix: Correct llama-server flash-attn flag in debug job

### DIFF
--- a/ansible/jobs/prima-expert-debug.nomad
+++ b/ansible/jobs/prima-expert-debug.nomad
@@ -49,7 +49,7 @@ echo "Attempting to start llama-server with hardcoded model: Llama-3-8B-Instruct
   --host 0.0.0.0 \
   --port {{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }} \
   --n-gpu-layers 999 \
-  -fa auto \
+  --flash-attn auto \
   --mlock \
   2>&1
 


### PR DESCRIPTION
The `prima-expert-debug.nomad` job was using the shorthand `-fa auto` flag to configure flash attention for the `llama-server`. This caused the server to crash with a `std::invalid_argument` what(): stoi` error, as the argument parser does not correctly handle the shorthand flag when a value is provided.

This change replaces the shorthand `-fa` flag with the full `--flash-attn` flag, ensuring the argument is parsed correctly and preventing the server from crashing.