### PR TITLE
feat(nomad): Add command tracing to server startup scripts

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -51,7 +51,7 @@ job "expert-{{ expert_name }}" {
       template {
         data = <<EOH
 #!/bin/bash
-set -e
+set -ex
 echo "--- Starting RPC Master for {{ job_name }} ---"
 
 # 1. Discover RPC worker services via Consul

--- a/ansible/jobs/llamacpp-rpc.nomad.j2
+++ b/ansible/jobs/llamacpp-rpc.nomad.j2
@@ -41,7 +41,7 @@ job "{{ job_name | default('prima-expert-main') }}" {
       template {
         data = <<EOH
 #!/bin/bash
-set -e
+set -ex
 echo "--- Starting RPC Master for {{ job_name }} ---"
 
 # 1. Discover RPC worker services via Consul


### PR DESCRIPTION
This change adds `set -x` to the server startup scripts in the `expert` and `llamacpp-rpc` Nomad jobs. This will cause the shell to print each command and its arguments to stderr as it is executed.

This is a diagnostic step to capture the exact command-line arguments being passed to the `llama-server`, which is currently crashing with a `std::invalid_argument: stoi` error. This logging will help identify the incorrect argument that is causing the crash.