### PR TITLE
feat(nomad): Add explicit command logging for diagnostics

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -51,7 +51,7 @@ job "expert-{{ expert_name }}" {
       template {
         data = <<EOH
 #!/bin/bash
-set -ex
+set -e
 echo "--- Starting RPC Master for {{ job_name }} ---"
 
 # 1. Discover RPC worker services via Consul
@@ -86,13 +86,21 @@ health_check_url="http://127.0.0.1:{{ '{{' }} env \"NOMAD_PORT_http\" {{ '}}' }}
 {% for model in suitable_models %}
   echo "Attempting to start llama-server with suitable model: {{ model.name }}"
 
-  /usr/local/bin/llama-server \
-    --model "/opt/nomad/models/llm/{{ model.filename }}" \
+  # Construct the full command in a variable for logging
+  full_command="/usr/local/bin/llama-server \
+    --model /opt/nomad/models/llm/{{ model.filename }} \
     --host 0.0.0.0 \
     --port {{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }} \
     --n-gpu-layers 99 \
     --mlock \
-    $rpc_args &
+    $rpc_args"
+
+  # Echo the command to the log for debugging, then execute it
+  echo "--- EXECUTING COMMAND ---"
+  echo "$full_command"
+  echo "-------------------------"
+
+  $full_command &
 
   server_pid=$!
   echo "Server process started (PID $server_pid). Waiting for health check..."

--- a/ansible/jobs/llamacpp-rpc.nomad.j2
+++ b/ansible/jobs/llamacpp-rpc.nomad.j2
@@ -41,7 +41,7 @@ job "{{ job_name | default('prima-expert-main') }}" {
       template {
         data = <<EOH
 #!/bin/bash
-set -ex
+set -e
 echo "--- Starting RPC Master for {{ job_name }} ---"
 
 # 1. Discover RPC worker services via Consul
@@ -69,13 +69,21 @@ health_check_url="http://127.0.0.1:{{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }}/h
 {% for model in suitable_models %}
   echo "Attempting to start llama-server with suitable model: {{ model.name }}"
 
-  /usr/local/bin/llama-server \
-    --model "/opt/nomad/models/llm/{{ model.filename }}" \
+  # Construct the full command in a variable for logging
+  full_command="/usr/local/bin/llama-server \
+    --model /opt/nomad/models/llm/{{ model.filename }} \
     --host 0.0.0.0 \
     --port {{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }} \
     --n-gpu-layers 99 \
     --mlock \
-    --rpc $worker_ips &
+    --rpc $worker_ips"
+
+  # Echo the command to the log for debugging, then execute it
+  echo "--- EXECUTING COMMAND ---"
+  echo "$full_command"
+  echo "-------------------------"
+
+  $full_command &
 
   server_pid=$!
   echo "Server process started (PID $server_pid). Waiting for health check..."


### PR DESCRIPTION
This change modifies the startup scripts in the `expert` and `llamacpp-rpc` Nomad jobs to explicitly log the `llama-server` command before it is executed.

The full command is constructed and stored in a variable, which is then printed to standard output. This is a more reliable method for capturing the exact command line than using `set -x`, especially in environments where log output might be buffered or suppressed.

This is a diagnostic step to identify the root cause of the `std::invalid_argument: stoi` crash in the `llama-server` process.