### PR TITLE
fix(nomad): Correct llama-server RPC argument

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -72,7 +72,7 @@ done
 rpc_args=""
 if [ -n "$worker_ips" ]; then
   echo "Workers found. Configuring RPC."
-  rpc_args="--rpc $worker_ips"
+  rpc_args="--rpc-server $worker_ips"
 else
   echo "No workers found after waiting. Starting in standalone mode."
 fi
@@ -86,21 +86,52 @@ health_check_url="http://127.0.0.1:{{ '{{' }} env \"NOMAD_PORT_http\" {{ '}}' }}
 {% for model in suitable_models %}
   echo "Attempting to start llama-server with suitable model: {{ model.name }}"
 
-  # Construct the full command in a variable for logging
-  full_command="/usr/local/bin/llama-server \
-    --model /opt/nomad/models/llm/{{ model.filename }} \
+  /usr/local/bin/llama-server \
+    --model "/opt/nomad/models/llm/{{ model.filename }}" \
     --host 0.0.0.0 \
     --port {{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }} \
     --n-gpu-layers 99 \
     --mlock \
-    $rpc_args"
+    $rpc_args &
 
-  # Echo the command to the log for debugging, then exit
-  echo "--- INTENDED COMMAND (DIAGNOSTIC) ---"
-  echo "$full_command"
-  echo "-------------------------------------"
-  echo "Exiting for diagnostic purposes."
-  exit 0
+  server_pid=$!
+  echo "Server process started (PID $server_pid). Waiting for health check..."
+
+  healthy=false
+  for i in {1..30};
+  do
+    sleep 10
+
+    # Use curl with verbose logging to diagnose health check failures.
+    # We redirect stdout to /dev/null but let stderr (where -v output goes) print.
+    if curl -s --fail --verbose $health_check_url > /dev/null; then
+      echo "✅ Server is healthy with model {{ model.name }}!"
+      healthy=true
+      break
+    else
+      echo "Health check failed (attempt $i/30). See verbose curl output above."
+    fi
+  done
+
+
+  if [ "$healthy" = true ]; then
+    echo "Successfully started llama-server with model: {{ model.name }}"
+    # Write the active model to Consul KV for other services to discover
+    curl -X PUT --data "{{ model.name }}" "http://127.0.0.1:8500/v1/kv/experts/${NOMAD_META_expert_name}/active_model"
+
+    # If we get here, the server is healthy and running. Wait for it to exit.
+    if [ -n "$server_pid" ]; then
+      wait $server_pid
+    fi
+    exit 0
+  else
+    echo "❌ Server failed to become healthy with {{ model.name }}. Trying next model."
+    # Only try to kill the process if the PID was captured.
+    if [ -n "$server_pid" ]; then
+      kill $server_pid
+      wait $server_pid 2>/dev/null
+    fi
+  fi
 {% endfor %}
 {% else %}
   echo "FATAL: No suitable models found for the available system memory of {{ ansible_memtotal_mb }} MB."

--- a/ansible/jobs/llamacpp-rpc.nomad.j2
+++ b/ansible/jobs/llamacpp-rpc.nomad.j2
@@ -76,14 +76,41 @@ health_check_url="http://127.0.0.1:{{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }}/h
     --port {{ '{{' }} env "NOMAD_PORT_http" {{ '}}' }} \
     --n-gpu-layers 99 \
     --mlock \
-    --rpc $worker_ips"
+    --rpc-server $worker_ips"
 
-  # Echo the command to the log for debugging, then exit
-  echo "--- INTENDED COMMAND (DIAGNOSTIC) ---"
-  echo "$full_command"
-  echo "-------------------------------------"
-  echo "Exiting for diagnostic purposes."
-  exit 0
+  $full_command &
+
+  server_pid=$!
+  echo "Server process started (PID $server_pid). Waiting for health check..."
+
+  healthy=false
+  for i in {1..30}; do
+    sleep 10
+    # Use curl with verbose logging to diagnose health check failures.
+    # We redirect stdout to /dev/null but let stderr (where -v output goes) print.
+    if curl -s --fail --verbose $health_check_url > /dev/null; then
+      echo "✅ Server is healthy with model {{ model.name }}!"
+      healthy=true
+      break
+    else
+      echo "Health check failed (attempt $i/30). See verbose curl output above."
+    fi
+  done
+
+  if [ "$healthy" = true ]; then
+    # If we get here, the server is healthy and running. Wait for it to exit.
+    if [ -n "$server_pid" ]; then
+      wait $server_pid
+    fi
+    exit 0
+  else
+    echo "❌ Server failed to become healthy with {{ model.name }}. Trying next model."
+    # Only try to kill the process if the PID was captured.
+    if [ -n "$server_pid" ]; then
+      kill $server_pid
+      wait $server_pid 2>/dev/null
+    fi
+  fi
 {% endfor %}
 {% else %}
   echo "FATAL: No suitable models found for the available system memory of {{ ansible_memtotal_mb }} MB."


### PR DESCRIPTION
This commit resolves a critical issue causing the `llama-server` process to crash instantly upon startup with a `std::invalid_argument: stoi` error.

The root cause was the use of an incorrect and undocumented command-line flag, `--rpc`, to specify the RPC server addresses. The correct flag, according to the official `llama.cpp` documentation, is `--rpc-server`.

This change replaces the incorrect flag in both the `expert.nomad.j2` and `llamacpp-rpc.nomad.j2` templates.

Additionally, this commit retains the defensive check for a valid `$server_pid` before calling `wait` or `kill`, which was the initial issue reported. This makes the startup scripts more resilient to process launch failures.