### PR TITLE
fix(nomad): Correct llama-server args and heal_cluster.yaml

### DIFF
--- a/heal_cluster.yaml
+++ b/heal_cluster.yaml
@@ -2,6 +2,7 @@
   hosts: controller_nodes[0] # This should run on the primary controller
   connection: local
   become: no
+  gather_facts: yes
 
   vars_files:
     - group_vars/all.yaml


### PR DESCRIPTION
This commit resolves a series of cascading failures that prevented the successful deployment of the `llama-server` Nomad jobs.

The initial issue was a shell error (`wait: pid is not a valid integer`) caused by the `llama-server` process crashing instantly. This was traced to a `std::invalid_argument: stoi` error in the server itself.

The root cause of the crash was the use of an incorrect and undocumented `--rpc` command-line flag. This has been corrected to the documented `--rpc-server` flag in both the `expert.nomad.j2` and `llamacpp-rpc.nomad.j2` templates.

A subsequent deployment attempt revealed a secondary issue: an Ansible templating error (`recursive loop detected in template string: {{ ansible_memtotal_mb }}`) in the `heal_cluster.yaml` playbook. This was caused by the playbook missing the `gather_facts: yes` directive, which prevented the `ansible_memtotal_mb` variable from being defined. This has also been corrected.

Finally, the startup scripts have been hardened to prevent shell errors if the server process fails to launch by checking if the PID variable is set before using it.