### PR TITLE
feat(ansible): Selectively start main expert at boot

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -101,6 +101,7 @@
     job_name: "expert-{{ item }}"
     expert_name: "{{ item }}"
     model_list: "{{ expert_models[item] }}"
+    nomad_namespace: "{{ nomad_namespace }}"
 
 - name: Run expert jobs
   ansible.builtin.command:


### PR DESCRIPTION
This change modifies the Ansible deployment to pre-generate all expert Nomad job files but only run the `main` expert's job at startup. This allows for a fast initial deployment while enabling the `pipecat` application to start other experts on-demand.

Key changes:
- The `llama_cpp` role now has a conditional on its `Run expert jobs` task to only start the service where `item == 'main'`.
- The `llama_cpp` role's template task now correctly includes the `nomad_namespace` variable, fixing the job submission error.
- The `pipecatapp` role has been corrected to wait for the `expert-api-main` service, ensuring the core router is available before the application starts.