### PR TITLE
feat(ansible): Selectively start main expert at boot

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -6,6 +6,7 @@ expected_cluster_size: "{{ groups['workers'] | length if 'workers' in groups els
 advertise_ip: "{{ (ansible_all_ipv6_addresses | reject('equalto', '::1') | list | first) |
 default(ansible_default_ipv4.address) }}"
 
+nomad_namespace: "default"
 nomad_models_dir: "/opt/nomad/models"
 
 # Pipecat application settings


### PR DESCRIPTION
This change modifies the Ansible deployment to pre-generate all expert Nomad job files but only run the `main` expert's job at startup. This allows for a fast initial deployment while enabling the `pipecatapp` application to start other experts on-demand.

Key changes:
- The `llama_cpp` role now has a conditional on its `Run expert jobs` task to only start the service where `item == 'main'`.
- The `nomad_namespace` variable is now defined in `group_vars/all.yaml` to ensure it is globally available and correctly rendered in Nomad job templates, fixing the 'nonexistent namespace' error.
- The `pipecatapp` role has been corrected to wait for the `expert-api-main` service, ensuring the core router is available before the application starts.