### PR TITLE
feat(ansible): Create benchmark_models role

### DIFF
--- a/ansible/roles/benchmark_models/tasks/benchmark_loop.yaml
+++ b/ansible/roles/benchmark_models/tasks/benchmark_loop.yaml
@@ -1,0 +1,57 @@
+- name: "Render benchmark Nomad job for model {{ model.name }}"
+  ansible.builtin.template:
+    src: model-benchmark.nomad.j2
+    dest: "/tmp/model-benchmark-{{ model.filename }}.nomad"
+    mode: '0644'
+  vars:
+    model_filename: "{{ model.filename }}"
+
+- name: "Run benchmark job for model {{ model.name }}"
+  ansible.builtin.command:
+    cmd: "nomad job run /tmp/model-benchmark-{{ model.filename }}.nomad"
+  register: benchmark_models_job_run_result
+  changed_when: "'job registration' in benchmark_models_job_run_result.stdout"
+
+- name: "Wait for benchmark job to complete for model {{ model.name }}"
+  ansible.builtin.command:
+    cmd: "nomad job status -json model-benchmark-{{ model.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}"
+  register: benchmark_models_job_status_result
+  until: "((benchmark_models_job_status_result.stdout | from_json).Status == 'dead') and ((benchmark_models_job_status_result.stdout | from_json).JobSummary.Summary.Complete == 1)"
+  retries: 60 # 5 minutes (60 * 5s)
+  delay: 5
+  changed_when: false
+
+- name: "Get allocation ID for model {{ model.name }}"
+  ansible.builtin.command:
+    cmd: "nomad job allocs -json model-benchmark-{{ model.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}"
+  register: benchmark_models_job_allocs_result
+  changed_when: false
+
+- name: "Capture benchmark logs for model {{ model.name }}"
+  ansible.builtin.command:
+    cmd: "nomad alloc logs {{ (benchmark_models_job_allocs_result.stdout | from_json)[0].ID }} benchmark-task"
+  register: benchmark_models_benchmark_logs
+  changed_when: false
+
+- name: "Check benchmark output and record result for model {{ model.name }}"
+  block:
+    - name: Check for success metric
+      ansible.builtin.debug:
+        msg: "Benchmark for {{ model.name }} successful. Tokens per second found."
+      when: "'tokens per second' in benchmark_models_benchmark_logs.stdout"
+
+    - name: Add to verified models list
+      ansible.builtin.set_fact:
+        benchmark_models_verified_models: "{{ benchmark_models_verified_models + [model] }}"
+      when: "'tokens per second' in benchmark_models_benchmark_logs.stdout"
+  always:
+    - name: "Purge benchmark job for model {{ model.name }}"
+      ansible.builtin.command:
+        cmd: "nomad job stop -purge model-benchmark-{{ model.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}"
+      changed_when: false
+
+    - name: "Remove temporary job file for model {{ model.name }}"
+      ansible.builtin.file:
+        path: "/tmp/model-benchmark-{{ model.filename }}.nomad"
+        state: absent
+      changed_when: false

--- a/ansible/roles/benchmark_models/tasks/main.yaml
+++ b/ansible/roles/benchmark_models/tasks/main.yaml
@@ -1,25 +1,31 @@
-You will create a dedicated Ansible role to orchestrate the benchmarking process.
+- name: Load model variables
+  ansible.builtin.include_vars:
+    file: group_vars/models.yaml
 
-Create the role structure: ansible/roles/benchmark_models
+- name: Initialize model list
+  ansible.builtin.set_fact:
+    benchmark_models_all_models: []
 
-Implement tasks/main.yaml:
+- name: Create a flattened and unique list of all models to benchmark
+  ansible.builtin.set_fact:
+    benchmark_models_all_models: "{{ benchmark_models_all_models + expert_models[item] }}"
+  loop: "{{ expert_models.keys() | list }}"
 
-This task file will contain the logic to iterate through all defined models.
+- name: Deduplicate the list of models
+  ansible.builtin.set_fact:
+    benchmark_models_unique_models: "{{ benchmark_models_all_models | unique(attribute='filename') }}"
 
-Load Variables: Ensure it has access to the expert_models from group_vars/models.yaml.
+- name: Initialize list of verified models
+  ansible.builtin.set_fact:
+    benchmark_models_verified_models: []
 
-Loop Through Models: Use a loop to iterate over all models in all expert lists. You will need to flatten the expert_models dictionary to get a single, unique list of models to test.
+- name: Iterate over each model and run benchmark
+  ansible.builtin.include_tasks:
+    file: benchmark_loop.yaml
+  loop: "{{ benchmark_models_unique_models }}"
+  loop_control:
+    loop_var: model
 
-Inside the loop, for each model:
-
-Render the Job: Use ansible.builtin.template to render the model-benchmark.nomad.j2 template, passing the model_filename. Save it to a unique temporary file.
-
-Run the Job: Use ansible.builtin.command to run the temporary Nomad job file.
-
-Wait for Completion: Use a do/until loop with nomad job status to poll until the batch job's status is dead (which means complete). This is a critical step. Add a reasonable number of retries and a delay.
-
-Log the Results: Use ansible.builtin.command with nomad alloc logs to capture the output of the completed benchmark. Register this output.
-
-Record Success/Failure: Check the output for a success metric (like "tokens per second"). Use ansible.builtin.set_fact to add the model to a list of verified_models if the benchmark was successful.
-
-Cleanup: Purge the benchmark job from Nomad and remove the temporary job file.
+- name: Display the list of verified models
+  ansible.builtin.debug:
+    var: benchmark_models_verified_models

--- a/ansible/roles/benchmark_models/templates/model-benchmark.nomad.j2
+++ b/ansible/roles/benchmark_models/templates/model-benchmark.nomad.j2
@@ -1,0 +1,33 @@
+# This Nomad job file runs a benchmark for a single model.
+# It is designed to be a short-lived batch job.
+
+job "model-benchmark-{{ model_filename | regex_replace('[^a-zA-Z0-9-]', '-') }}" {
+  datacenters = ["dc1"]
+  type        = "batch"
+  namespace   = "{{ namespace | default('default') }}"
+
+  group "benchmark-group" {
+    count = 1
+
+    task "benchmark-task" {
+      driver = "raw_exec"
+
+      config {
+        command = "/usr/local/bin/llama-server"
+        args = [
+          "--model", "/opt/nomad/models/llm/{{ model_filename }}",
+          "--host", "127.0.0.1",
+          "--port", "8080",
+          "--n-gpu-layers", "99",
+          "--mlock",
+          "--benchmark"
+        ]
+      }
+
+      resources {
+        cpu    = 2000
+        memory = 8192 # Allocate enough memory for the largest model
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces a new Ansible role `benchmark_models` to orchestrate the benchmarking of machine learning models.

The role includes:
- A Nomad job template for running a single model benchmark.
- Tasks to iterate through all defined models, run the benchmark job, wait for completion, and collect results.
- Logic to flatten and deduplicate the model list from `group_vars/models.yaml`.

The implementation follows Ansible best practices, including variable naming conventions and task structure.