### PR TITLE
Fix(ansible): Correct syntax error in pipecatapp role

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -42,8 +42,6 @@
   ansible.builtin.debug:
     msg: "⚠️ No verified experts found — skipping expert job creation."
   when: verified_experts is not defined or verified_experts | length == 0
-    mode: '0755'
-  become: yes
 
 - name: Ensure correct ownership of the application directory
   ansible.builtin.file:


### PR DESCRIPTION
The `ansible.builtin.debug` task in the `pipecatapp` role included invalid parameters `mode` and `become`, which caused a YAML syntax error during playbook execution.

This commit removes these incorrect parameters, allowing the playbook to run successfully.