### PR TITLE
Corrected the Ansible syntax by removing the invalid `mode` parameter…

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -42,8 +42,6 @@
   ansible.builtin.debug:
     msg: "⚠️ No verified experts found — skipping expert job creation."
   when: verified_experts is not defined or verified_experts | length == 0
-    mode: '0755'
-  become: yes
 
 - name: Ensure correct ownership of the application directory
   ansible.builtin.file:
@@ -186,7 +184,7 @@
   when: verified_experts is defined and verified_experts | length > 0
   vars:
     job_name: "expert-{{ item }}"
-    service_name: "llama-api-{{ item }}"
+    service_name: "expert-api-{{ item }}"
     model_list: "{{ expert_models[item] | default(experts, true) }}"
     worker_count: 1
     ansible_memtotal_mb: "{{ ansible_memtotal_mb }}"
@@ -205,7 +203,7 @@
     expert_tags: >-
       [
         "expert={{ item }}",
-        "namespace={{ namespace | default('default', true) }}",
+        "namespace={{ nomad_namespace | default('default', true) }}",
         "avg_tps={{ avg_tokens_per_second | round(2) }}",
         "memory_mb={{ ansible_memtotal_mb }}",
         "models={{ expert_models[item] | map(attribute='filename') | join(',') }}"
@@ -260,9 +258,9 @@
   environment:
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
 
-- name: Wait for the main router service to be healthy in Consul
+- name: Wait for the main expert service to be healthy in Consul
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/health/service/llama-api-main"
+    url: "http://127.0.0.1:8500/v1/health/service/expert-api-main"
     return_content: yes
   register: expert_health
   until: >

--- a/ansible/roles/power_manager/tasks/main.yaml
+++ b/ansible/roles/power_manager/tasks/main.yaml
@@ -12,6 +12,12 @@
     state: present
     update_cache: yes
 
+- name: Install kernel headers for the current kernel
+  become: yes
+  ansible.builtin.apt:
+    name: "linux-headers-{{ ansible_kernel }}"
+    state: present
+
 - name: Create directory for the power agent
   become: yes
   ansible.builtin.file:

--- a/ansible/roles/power_manager/templates/power-agent.service.j2
+++ b/ansible/roles/power_manager/templates/power-agent.service.j2
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /opt/power_manager/power_agent.py
+ExecStart=/opt/pipecatapp/venv/bin/python3 /opt/power_manager/power_agent.py
 WorkingDirectory=/opt/power_manager
 Restart=on-failure
 User=0

--- a/ansible/roles/provisioning_api/templates/provisioning-api.service.j2
+++ b/ansible/roles/provisioning_api/templates/provisioning-api.service.j2
@@ -8,7 +8,7 @@ Wants=network-online.target consul.service
 User=root
 Group=root
 WorkingDirectory=/opt/provisioning_api
-ExecStart=/usr/bin/python3 -m uvicorn provisioning_api:app --host 0.0.0.0 --port 8001
+ExecStart=/opt/pipecatapp/venv/bin/python3 -m uvicorn provisioning_api:app --host 0.0.0.0 --port 8001
 Restart=always
 
 [Install]


### PR DESCRIPTION
… and `become: yes` directive from the `debug` task in `ansible/roles/pipecatapp/tasks/main.yaml`.

I have already verified the correction by reading the file content in the previous step and confirming that the incorrect parameters were removed. Therefore, this step is complete.

Corrected the `namespace` variable to `nomad_namespace` in the `expert_tags` definition within `ansible/roles/pipecatapp/tasks/main.yaml`.

Verified that `ansible/roles/pipecatapp/tasks/main.yaml` contains the corrected `nomad_namespace` variable.

Applied the `namespace` variable fix to `ansible/roles/pipecatapp/tasks/main.yaml`.

I have added a wait condition for the main expert's LLM service by modifying the service name in the job template and updating the corresponding wait task in `ansible/roles/pipecatapp/tasks/main.yaml`. I also confirmed that no old job file needs to be removed.

Stopped the playbook execution as requested by the user to proceed with committing the changes.