### PR TITLE
Refactor: Separate third-party LLM expert configuration

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -36,15 +36,6 @@ pipecat_api_keys: ""
 
 # ... existing variables ...
 
-# Configuration for external, third-party LLM experts.
-# This is a dictionary that will be converted to a JSON string.
-external_model_server: false
-external_experts_config:
-  openai_gpt4:
-    base_url: "https://api.openai.com/v1"
-    api_key_env: "OPENAI_API_KEY"
-    model: "gpt-4-turbo" # Specify the exact model name
-
 # -- Storing Secrets with Ansible Vault --
 # This is the plain text version. In a real environment, you should
 # encrypt this variable. First, create an encrypted file:

--- a/group_vars/external_experts.yaml
+++ b/group_vars/external_experts.yaml
@@ -1,0 +1,7 @@
+# Configuration for external, third-party LLM experts.
+external_model_server: false
+external_experts_config:
+  openai_gpt4:
+    base_url: "https://api.openai.com/v1"
+    api_key_env: "OPENAI_API_KEY"
+    model: "gpt-4-turbo" # Specify the exact model name

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -2,6 +2,11 @@
   hosts: all
   become: yes # We are already root
 
+  vars_files:
+    - group_vars/all.yaml
+    - group_vars/models.yaml
+    - group_vars/external_experts.yaml
+
   tasks:
     - name: Ensure the sudo package is installed
       ansible.builtin.apt:
@@ -44,10 +49,6 @@
   hosts: all
   remote_user: "{{ target_user }}"
   become: yes # Now we use the sudo privileges we just created
-
-  vars_files:
-    - group_vars/all.yaml
-    - group_vars/models.yaml
 
   pre_tasks:
     - name: Check connectivity to all nodes
@@ -202,9 +203,6 @@
     - name: Load model variables
       ansible.builtin.include_vars:
         file: group_vars/models.yaml
-  vars_files:
-    - group_vars/all.yaml
-    - group_vars/models.yaml
 
   roles:
     - role: bootstrap_agent


### PR DESCRIPTION
- Moves the configuration for external, third-party LLM experts from `group_vars/all.yaml` to a new, dedicated file `group_vars/external_experts.yaml`.
- Updates the main Ansible playbook (`playbook.yaml`) to load these variables from the new file.
- Centralizes the `vars_files` declaration to the playbook level to avoid redundancy across different plays.

This change improves the organization and clarity of the configuration by separating locally-hosted model settings from external service settings.