### PR TITLE
feat: Add term.everything tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 __pycache__/
 playbook_output.log
 .aider*
+.venv/

--- a/ansible/roles/pipecatapp/files/app.py
+++ b/ansible/roles/pipecatapp/files/app.py
@@ -47,6 +47,7 @@ from tools.web_browser_tool import WebBrowserTool
 from tools.ansible_tool import Ansible_Tool
 from tools.power_tool import Power_Tool
 from tools.summarizer_tool import SummarizerTool
+from tools.term_everything_tool import TermEverythingTool
 from moondream_detector import MoondreamDetector
 
 import uvicorn
@@ -337,6 +338,7 @@ class TwinService(FrameProcessor):
             "web_browser": WebBrowserTool(),
             "ansible": Ansible_Tool(),
             "power": Power_Tool(),
+            "term_everything": TermEverythingTool(app_image_path="/opt/mcp/termeverything.AppImage"),
         }
 
         if self.app_config.get("use_summarizer", False):

--- a/ansible/roles/pipecatapp/files/tools/term_everything_tool.py
+++ b/ansible/roles/pipecatapp/files/tools/term_everything_tool.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+import asyncio
+from typing import List, Any, Dict
+
+
+class TermEverythingTool(object):
+    """
+    A tool for running GUI applications in the terminal using term.everything.
+    """
+
+    def __init__(self, app_image_path: str, **kwargs):
+        super().__init__(**kwargs)
+        self.app_image_path = app_image_path
+
+    async def execute(self, command: str) -> str:
+        """
+        Executes the term.everything AppImage with the given command.
+        The command string is split into arguments.
+        """
+        command_parts = command.split()
+        try:
+            process = await asyncio.create_subprocess_exec(
+                self.app_image_path,
+                *command_parts,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                return f"Error: {stderr.decode().strip()}"
+            return stdout.decode().strip()
+        except Exception as e:
+            return f"Error: {e}"

--- a/ansible/roles/term_everything/tasks/main.yml
+++ b/ansible/roles/term_everything/tasks/main.yml
@@ -1,0 +1,39 @@
+- name: Clone term.everything repository
+  ansible.builtin.git:
+    repo: 'https://github.com/mmulet/term.everything.git'
+    dest: '/tmp/term.everything'
+    version: 'main'
+    recursive: yes
+
+- name: Build term.everything AppImage
+  ansible.builtin.command:
+    cmd: ./distribute.sh
+    chdir: '/tmp/term.everything'
+  register: build_result
+  changed_when: build_result.rc == 0
+
+- name: Create tools directory
+  ansible.builtin.file:
+    path: '/opt/mcp/tools'
+    state: directory
+    mode: '0755'
+
+- name: Find the AppImage file
+  find:
+    paths: /tmp/term.everything/dist
+    patterns: '*.AppImage'
+  register: find_result
+
+- name: Move AppImage to tools directory
+  ansible.builtin.move:
+    src: "{{ item.path }}"
+    dest: "/opt/mcp/termeverything.AppImage"
+    remote_src: yes
+    mode: '0755'
+  with_items: "{{ find_result.files }}"
+  when: find_result.files | length > 0
+
+- name: Clean up temporary build directory
+  ansible.builtin.file:
+    path: '/tmp/term.everything'
+    state: absent

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -208,6 +208,7 @@
 
   roles:
     - role: bootstrap_agent
+    - role: term_everything
     - role: pipecatapp
 # In your main playbook.yaml, after "Play 4"
 #

--- a/testing/unit_tests/test_term_everything_tool.py
+++ b/testing/unit_tests/test_term_everything_tool.py
@@ -1,0 +1,94 @@
+import pytest
+import sys
+import os
+import subprocess
+from unittest.mock import patch, AsyncMock
+
+# Ensure the tool's path is in the system path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../ansible/roles/pipecatapp/files')))
+
+from tools.term_everything_tool import TermEverythingTool
+
+# Mock path for the AppImage
+MOCK_APPIMAGE_PATH = "/opt/mcp/termeverything.AppImage"
+
+@pytest.fixture
+def tool():
+    """Provides a reusable instance of the TermEverythingTool."""
+    return TermEverythingTool(app_image_path=MOCK_APPIMAGE_PATH)
+
+@pytest.mark.asyncio
+async def test_execute_command_success(tool):
+    """
+    Tests the happy path where the command executes successfully.
+    """
+    # 1. ARRANGE
+    command = "search --path /home"
+    expected_stdout = "Command executed successfully."
+
+    # Mock the asyncio subprocess
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (expected_stdout.encode(), b"")
+    mock_process.returncode = 0
+
+    # 2. ACT
+    with patch('asyncio.create_subprocess_exec', return_value=mock_process) as mock_create_subprocess:
+        result = await tool.execute(command)
+
+        # 3. ASSERT
+        mock_create_subprocess.assert_called_once_with(
+            MOCK_APPIMAGE_PATH,
+            *command.split(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        assert result == expected_stdout
+
+@pytest.mark.asyncio
+async def test_execute_command_failure(tool):
+    """
+    Tests the failure path where the command returns a non-zero exit code.
+    """
+    # 1. ARRANGE
+    command = "search --invalid"
+    expected_stderr = "Error: Invalid argument."
+
+    # Mock the asyncio subprocess to simulate a failure
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", expected_stderr.encode())
+    mock_process.returncode = 1
+
+    # 2. ACT
+    with patch('asyncio.create_subprocess_exec', return_value=mock_process) as mock_create_subprocess:
+        result = await tool.execute(command)
+
+        # 3. ASSERT
+        mock_create_subprocess.assert_called_once_with(
+            MOCK_APPIMAGE_PATH,
+            *command.split(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        assert result == f"Error: {expected_stderr}"
+
+@pytest.mark.asyncio
+async def test_execute_exception(tool):
+    """
+    Tests the tool's behavior when an exception occurs during subprocess execution.
+    """
+    # 1. ARRANGE
+    command = "search --path /home"
+    error_message = "A critical error occurred."
+
+    # 2. ACT
+    with patch('asyncio.create_subprocess_exec', side_effect=Exception(error_message)) as mock_create_subprocess:
+        result = await tool.execute(command)
+
+        # 3. ASSERT
+        mock_create_subprocess.assert_called_once_with(
+            MOCK_APPIMAGE_PATH,
+            *command.split(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        assert result == f"Error: {error_message}"


### PR DESCRIPTION
Adds the term.everything tool as a new tool for agents to use.

This includes:
* A new Ansible role to build and install the term.everything AppImage.
* A new TermEverythingTool Python class to wrap the AppImage.
* Unit tests for the new tool.

Note: The pipecat integration tests are still failing due to a pre-existing environment issue. This change is isolated to the term.everything tool and its related components.