### PR TITLE
Fix: Correct STT model handling in Ansible playbook

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -133,15 +133,39 @@
     mode: '0755'
   become: yes
 
-- name: Clone all STT models from all providers
-  ansible.builtin.git:
-    repo: "https://huggingface.co/{{ item.1.repo_id }}"
-    dest: "/opt/nomad/models/stt/{{ item.0.key }}/{{ item.1.name }}"
-    version: main
-  loop: "{{ stt_models | dict2items | subelements('value') }}"
-  loop_control:
-    label: "{{ item.0.key }}/{{ item.1.name }}"
-  become: yes
+- name: Download all STT models from all configured providers
+  block:
+    - name: Create provider-specific STT model directory
+      ansible.builtin.file:
+        path: "/opt/nomad/models/stt/{{ item.key }}"
+        state: directory
+        mode: '0755'
+      loop: "{{ stt_models | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
+      become: yes
+
+    - name: Clone STT model repositories
+      ansible.builtin.git:
+        repo: "https://huggingface.co/{{ item.1.repo_id }}"
+        dest: "/opt/nomad/models/stt/{{ item.0.key }}/{{ item.1.name }}"
+        version: main
+      loop: "{{ stt_models | dict2items | subelements('value') }}"
+      loop_control:
+        label: "{{ item.0.key }}/{{ item.1.name }}"
+      when: item.1.repo_id is defined
+      become: yes
+
+    - name: Download single-file STT models
+      ansible.builtin.get_url:
+        url: "{{ item.1.url }}"
+        dest: "/opt/nomad/models/stt/{{ item.0.key }}/{{ item.1.filename }}"
+        mode: '0644'
+      loop: "{{ stt_models | dict2items | subelements('value') }}"
+      loop_control:
+        label: "{{ item.0.key }}/{{ item.1.filename }}"
+      when: item.1.url is defined
+      become: yes
 
 - name: Create VAD model directory
   ansible.builtin.file:

--- a/ansible/roles/power_manager/tasks/main.yaml
+++ b/ansible/roles/power_manager/tasks/main.yaml
@@ -12,11 +12,6 @@
     state: present
     update_cache: yes
 
-- name: Install kernel headers for the current kernel
-  become: yes
-  ansible.builtin.apt:
-    name: "linux-headers-{{ ansible_kernel }}"
-    state: present
 
 - name: Create directory for the power agent
   become: yes

--- a/ansible/roles/system_deps/tasks/main.yaml
+++ b/ansible/roles/system_deps/tasks/main.yaml
@@ -25,6 +25,13 @@
       - iperf3
       - jq
       - libavif16
+      - libavformat-dev
+      - libavcodec-dev
+      - libavdevice-dev
+      - libavutil-dev
+      - libavfilter-dev
+      - libswscale-dev
+      - libswresample-dev
       - libcurl4-openssl-dev
       - libevent-2.1-7t64
       - libflite1
@@ -38,6 +45,7 @@
       - ncdu
       - nfs-common
       - openssh-server
+      - pkg-config
       - portaudio19-dev
       - python3
       - python3-dev


### PR DESCRIPTION
The recent refactoring of the `stt_models` variable to support multiple providers (e.g., `whisper-cpp`, `faster-whisper`) introduced a bug in the Ansible deployment. The playbook was using a single `git` task that expected a `repo_id` for all models, which failed for models defined with a direct `url`.

This change addresses the issue by:
- Replacing the single task with a conditional block in `ansible/roles/pipecatapp/tasks/main.yaml`.
- Using `ansible.builtin.git` for models with a `repo_id`.
- Using `ansible.builtin.get_url` for models with a `url`.

Additionally, this commit includes fixes for subsequent dependency issues discovered during validation:
- Added `ffmpeg` development libraries and `pkg-config` to `ansible/roles/system_deps/tasks/main.yaml` to allow the `av` Python package to build correctly.
- Removed a redundant and failing task in `ansible/roles/power_manager/tasks/main.yaml` that attempted to install a specific version of the kernel headers.