### PR TITLE
Fix: Install podman dependency for term.everything build

### DIFF
--- a/ansible/roles/term_everything/tasks/main.yml
+++ b/ansible/roles/term_everything/tasks/main.yml
@@ -5,6 +5,12 @@
     version: "main"
     recursive: yes
 
+- name: Install podman
+  ansible.builtin.package:
+    name: podman
+    state: present
+  become: yes
+
 - name: Build term.everything AppImage
   ansible.builtin.command:
     cmd: ./distribute.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -83,10 +83,14 @@ fi
 
 
 # Purge any existing jobs and processes to ensure a clean deployment.
-echo "Purging any old Nomad jobs..."
-nomad job stop -purge llamacpp-rpc || true
-nomad job stop -purge pipecat-app || true
-echo "Purge complete."
+if command -v nomad &> /dev/null; then
+    echo "Purging any old Nomad jobs..."
+    nomad job stop -purge llamacpp-rpc || true
+    nomad job stop -purge pipecat-app || true
+    echo "Purge complete."
+else
+    echo "Nomad not found, skipping job purge."
+fi
  free -h
 
 echo "Forcefully terminating any orphaned application processes to prevent memory leaks..."


### PR DESCRIPTION
The `term.everything` Ansible role was failing because the `podman` dependency was not installed on the target machine. This change adds a task to the `term_everything` role to install `podman` before the AppImage build is attempted.

This also includes a defensive change to `bootstrap.sh` to check if `nomad` is installed before attempting to stop jobs, preventing errors on a fresh setup.