### PR TITLE
feat(testing): Add unit tests for RAG tool

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    requires_display: marks tests that require a graphical display to run.
+addopts = -m "not requires_display"

--- a/testing/unit_tests/test_pipecat_app.py
+++ b/testing/unit_tests/test_pipecat_app.py
@@ -36,7 +36,7 @@ def test_health_check(client, mocker):
 # More advanced tests for the TwinService can be added here
 # For example, mocking the LLM and other services to test the agent's logic
 
-@pytest.mark.skip(reason="Skipping tests that require a display.")
+@pytest.mark.requires_display
 @pytest.mark.asyncio
 async def test_twin_service_initialization(mocker):
     """Tests that the TwinService initializes correctly."""
@@ -54,7 +54,7 @@ async def test_twin_service_initialization(mocker):
     assert service is not None
 
 # Example of a more advanced test with mocking
-@pytest.mark.skip(reason="Skipping tests that require a display.")
+@pytest.mark.requires_display
 @pytest.mark.asyncio
 async def test_twin_service_sends_vision_frame(mocker):
     """Tests that TwinService sends a vision frame to the LLM."""
@@ -83,7 +83,6 @@ async def test_twin_service_sends_vision_frame(mocker):
 # In a CI environment, these might be run as a separate step after
 # the application has been deployed to a staging environment.
 
-@pytest.mark.skip(reason="Skipping integration tests.")
 @pytest.mark.asyncio
 async def test_health_check_is_healthy(mocker):
     """Tests that the /health endpoint returns a 200 OK status."""
@@ -104,7 +103,6 @@ async def test_health_check_is_healthy(mocker):
         assert response.json() == {"status": "ok"}
 
 
-@pytest.mark.skip(reason="Skipping integration tests.")
 @pytest.mark.asyncio
 async def test_main_page_loads(mocker):
     """Tests that the main page ('/') loads correctly."""


### PR DESCRIPTION
This commit introduces a new test file, `testing/unit_tests/test_rag_tool.py`, to provide comprehensive unit test coverage for the `RAG_Tool`.

The new tests mock the `SentenceTransformer` and `faiss` dependencies to ensure that the tests are fast and focused on the tool's logic. The tests cover the following scenarios:

-   Successful initialization of the `RAG_Tool`.
-   Correctly building the knowledge base.
-   Gracefully handling an empty knowledge base.
-   Successful searching of the knowledge base.

In addition to adding the new tests, this commit also includes the following changes:

-   Adds `langchain` to the runtime dependencies.
-   Adds a `pytest.ini` to skip tests that require a display.
-   Moves the `pyautogui` import to be within the methods that use it to avoid `DISPLAY` errors in a headless environment.
-   Adds missing sections to the `ADAPTATION_AGENT.md` file to ensure that it passes schema validation.