### PR TITLE
Fix(nomad): Add mqtt-data host_volume to client config

### DIFF
--- a/ansible/roles/nomad/templates/nomad.hcl.client.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.client.j2
@@ -41,4 +41,9 @@ client {
     path      = "{{ nomad_models_dir }}"
     read_only = true
   }
+
+  host_volume "mqtt-data" {
+    path      = "/opt/nomad/volumes/mqtt-data"
+    read_only = false
+  }
 }


### PR DESCRIPTION
The Ansible playbook was hanging when running the mqtt job because the Nomad client configuration was missing the required `host_volume` definition for `mqtt-data`. This prevented the Nomad scheduler from placing the job.

This change adds the `mqtt-data` host volume to the Nomad client configuration template, allowing the mqtt job to be scheduled correctly.