### PR TITLE
The Mosquitto directory paths in `ansible/roles/mqtt/tasks/main.yaml`…

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -5,8 +5,8 @@
     mode: '0755'
   become: yes
   loop:
-    - /opt/nomad/volumes/mqtt-data/mosquitto/data
-    - /opt/nomad/volumes/mqtt-data/mosquitto/log
+    - /opt/nomad/volumes/mqtt-data/data
+    - /opt/nomad/volumes/mqtt-data/log
 
 - name: Create Mosquitto config file
   ansible.builtin.copy:

--- a/ansible/roles/mqtt/templates/mqtt.nomad.j2
+++ b/ansible/roles/mqtt/templates/mqtt.nomad.j2
@@ -41,17 +41,15 @@ job "mqtt" {
 
         # The entrypoint is overridden to explicitly load the config file.
         # The config file itself is created by Ansible and placed in the host volume.
+        # The entrypoint is overridden to explicitly load the config file.
+        # The config file itself is created by Ansible and placed in the host volume.
         command = "mosquitto"
         args = ["-c", "/mosquitto/mosquitto.conf"]
-
-        volumes = [
-          "/opt/nomad/volumes/mqtt-data/mosquitto/:/mosquitto/"
-        ]
       }
 
       volume_mount {
         volume      = "mqtt-data"
-        destination = "/mosquitto/"
+        destination = "/mosquitto"
         read_only   = false
       }
 


### PR DESCRIPTION
… have been corrected to align with the `mosquitto.conf` file.

The Nomad job file `ansible/roles/mqtt/templates/mqtt.nomad.j2` has been updated to use the standard `volume` and `volume_mount` directives, and the Docker-specific `volumes` directive has been removed.