### PR TITLE
fix(nomad): Correct Home Assistant volume mount conflict

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -37,11 +37,6 @@ job "home-assistant" {
         image = "homeassistant/home-assistant:stable"
         ports = ["http"]
 
-        # Mount the configuration volume
-        volumes = [
-          "/opt/nomad/volumes/ha-config:/config"
-        ]
-
         # Allow access to USB devices for Zigbee/Z-Wave controllers
         devices = [
           {


### PR DESCRIPTION
The Home Assistant Nomad job definition contained a redundant and conflicting volume configuration. It specified the volume mount using both the top-level `volume` and `volume_mount` directives (the correct method) and the Docker driver's `volumes` directive simultaneously.

This conflict can prevent the job from starting correctly, leading to downstream failures in the Ansible playbook where tasks wait for the `home-assistant` service to become healthy.

This commit removes the incorrect `volumes` directive from the `config` block of the task, leaving the correct `volume` and `volume_mount` directives as the single source of truth for the volume configuration.