### PR TITLE
feat: Create World Model service

### DIFF
--- a/ansible/roles/world_model_service/files/Dockerfile
+++ b/ansible/roles/world_model_service/files/Dockerfile
@@ -1,0 +1,26 @@
+# Use an official Python runtime as a parent image
+FROM python:3.12-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application's code into the container at /app
+COPY app.py .
+
+# Make port 8000 available to the world outside this container
+EXPOSE 8000
+
+# Define environment variables
+# These can be overridden at runtime by Nomad
+ENV MQTT_HOST="mqtt"
+ENV MQTT_PORT=1883
+ENV MQTT_TOPIC="#"
+
+# Run app.py when the container launches
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ansible/roles/world_model_service/files/app.py
+++ b/ansible/roles/world_model_service/files/app.py
@@ -1,0 +1,66 @@
+import os
+import json
+import threading
+from fastapi import FastAPI
+import paho.mqtt.client as mqtt
+
+# --- Configuration ---
+MQTT_HOST = os.getenv("MQTT_HOST", "localhost")
+MQTT_PORT = int(os.getenv("MQTT_PORT", 1883))
+MQTT_TOPIC = os.getenv("MQTT_TOPIC", "#")
+
+# --- In-Memory State ---
+world_state = {}
+state_lock = threading.Lock()
+
+# --- FastAPI App ---
+app = FastAPI()
+
+# --- MQTT Client ---
+def on_connect(client, userdata, flags, rc, properties=None):
+    """Callback for when the client connects to the MQTT broker."""
+    if rc == 0:
+        print("Connected to MQTT Broker!")
+        client.subscribe(MQTT_TOPIC)
+    else:
+        print(f"Failed to connect, return code {rc}\n")
+
+def on_message(client, userdata, msg):
+    """Callback for when a PUBLISH message is received from the server."""
+    global world_state
+    print(f"Received message on topic {msg.topic}: {msg.payload.decode()}")
+    try:
+        # Assume payload is JSON, otherwise store as raw string
+        payload = json.loads(msg.payload.decode())
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        payload = msg.payload.decode()
+
+    with state_lock:
+        # Use a nested structure for topics, e.g., "home/livingroom/light" -> {"home": {"livingroom": {"light": payload}}}
+        keys = msg.topic.split('/')
+        current_level = world_state
+        for key in keys[:-1]:
+            current_level = current_level.setdefault(key, {})
+        current_level[keys[-1]] = payload
+
+
+def run_mqtt_client():
+    """Sets up and runs the MQTT client loop."""
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    client.on_connect = on_connect
+    client.on_message = on_message
+    client.connect(MQTT_HOST, MQTT_PORT, 60)
+    client.loop_forever()
+
+# --- API Endpoints ---
+@app.get("/state")
+async def get_state():
+    """Returns the current world state."""
+    with state_lock:
+        return world_state
+
+@app.on_event("startup")
+async def startup_event():
+    """Start the MQTT client in a background thread on app startup."""
+    mqtt_thread = threading.Thread(target=run_mqtt_client, daemon=True)
+    mqtt_thread.start()

--- a/ansible/roles/world_model_service/files/requirements.txt
+++ b/ansible/roles/world_model_service/files/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+paho-mqtt

--- a/ansible/roles/world_model_service/tasks/main.yaml
+++ b/ansible/roles/world_model_service/tasks/main.yaml
@@ -1,0 +1,52 @@
+- name: "World Model Service : Ensure world_model_service directories exist"
+  tags:
+    - world_model_service
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: "0755"
+  loop:
+    - "/opt/world_model_service"
+    - "/opt/world_model_service/config"
+  become: true
+
+- name: "World Model Service : Copy service files"
+  tags:
+    - world_model_service
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "/opt/world_model_service/"
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: "0644"
+  loop:
+    - "app.py"
+    - "requirements.txt"
+    - "Dockerfile"
+  become: true
+
+- name: "World Model Service : Build the docker image"
+  tags:
+    - world_model_service
+  community.docker.docker_image:
+    name: "world-model-service:latest"
+    build:
+      path: "/opt/world_model_service/"
+    source: build
+    state: present
+  become: true
+
+- name: "World Model Service : Deploy world_model.nomad job"
+  tags:
+    - world_model_service
+  ansible.builtin.template:
+    src: "world_model.nomad.j2"
+    dest: "/opt/nomad/jobs/world_model.nomad"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  become: true
+  notify:
+    - "Run nomad job"

--- a/ansible/roles/world_model_service/world_model.nomad.j2
+++ b/ansible/roles/world_model_service/world_model.nomad.j2
@@ -1,0 +1,46 @@
+job "world-model-service" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "world-model" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 8000
+      }
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image   = "world-model-service:latest"
+        ports   = ["http"]
+      }
+
+      env {
+        MQTT_HOST = "{{ nomad_host_ip }}"
+        MQTT_PORT = "1883"
+      }
+
+      resources {
+        cpu    = 250
+        memory = 128
+      }
+
+      service {
+        name = "world-model-api"
+        tags = ["api", "world-model"]
+        port = "http"
+
+        check {
+          type     = "http"
+          path     = "/state"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -123,6 +123,7 @@
         - paddler
         - vision
         - power_manager
+        - world_model_service
       loop_control:
         loop_var: role_name
 


### PR DESCRIPTION
This change introduces the initial implementation of the World Model service, a core component of the "home brain" architecture.

The service is responsible for:
- Subscribing to all topics on the MQTT message bus.
- Building a real-time, in-memory state representation of the environment based on incoming messages.
- Exposing this "world state" via a REST API endpoint (`/state`).

This is implemented as a new Ansible role (`world_model_service`) which includes:
- A FastAPI Python application.
- A Dockerfile for containerization.
- A Nomad job for deployment on the cluster.

The new role is integrated into the main playbook.