### PR TITLE
Fix Ansible template error in Home Assistant Nomad job

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -55,7 +55,7 @@ job "home-assistant" {
         data = <<EOF
 default_config:
 mqtt:
-  broker: "{{ env "MQTT_BROKER" }}"
+  broker: "{{ '{{' }} env "MQTT_BROKER" {{ '}}' }}"
   port: 1883
 EOF
         destination = "local/configuration.yaml"

--- a/testing/unit_tests/test_home_assistant_template.py
+++ b/testing/unit_tests/test_home_assistant_template.py
@@ -9,6 +9,5 @@ def test_home_assistant_template():
     j2_env = Environment(loader=FileSystemLoader('ansible/roles/home_assistant/templates'), trim_blocks=True)
     template = j2_env.get_template('home_assistant.nomad.j2')
     result = template.render()
-    job = yaml.safe_load(result)
 
-    assert job['group'][0]['task'][0]['env']['MQTT_BROKER'] == 'mqtt.service.consul'
+    assert 'MQTT_BROKER = "mqtt.service.consul"' in result


### PR DESCRIPTION
The playbook was failing due to an Ansible templating error in the `home_assistant.nomad.j2` file. The Nomad-specific `{{ env "..." }}` syntax was conflicting with Jinja2's templating engine.

This commit fixes the issue by properly escaping the inner curly braces, ensuring that Ansible renders the Nomad template syntax correctly.

Additionally, this commit corrects a broken unit test (`test_home_assistant_template.py`) that was attempting to parse the HCL Nomad job file as YAML. The test now uses a simple string assertion to validate the template's output.