### PR TITLE
Fix(ansible): Correct Home Assistant volume path in Nomad job

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -13,7 +13,7 @@ job "home-assistant" {
 
     volume "ha-config" {
       type      = "host"
-      source    = "ha-config"
+      source    = "volumes/ha-config"
       read_only = false
     }
 


### PR DESCRIPTION
The Home Assistant container was failing to start because its configuration directory was being mounted to the wrong host path.

The Ansible playbook creates the directory at `/opt/nomad/volumes/ha-config`, but the Nomad job was mounting `ha-config`, which resolves to `/opt/nomad/ha-config`.

This change corrects the `source` path in the Nomad job template to `volumes/ha-config`, ensuring the container can access its configuration and start up correctly. This resolves the timeout error in the Ansible playbook.