### PR TITLE
I have corrected the Nomad job configuration by removing the invalid …

### DIFF
--- a/ansible/roles/home_assistant/templates/configuration.yaml.j2
+++ b/ansible/roles/home_assistant/templates/configuration.yaml.j2
@@ -3,5 +3,5 @@ default_config:
 
 # Configure the MQTT integration
 mqtt:
-  broker: "{% raw %}{{ env "MQTT_BROKER" }}{% endraw %}"
+  broker: "{{ hostvars['controller_node_1']['ansible_host'] | default('127.0.0.1') }}"
   port: 1883

--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -47,15 +47,6 @@ job "home-assistant" {
       device "usb" {
         count = 10
         class = "78D1"
-      template {
-        data = <<EOF
-default_config:
-mqtt:
-  broker: "{{ '{{' }} env "MQTT_BROKER" {{ '}}' }}"
-  port: 1883
-EOF
-        destination = "local/configuration.yaml"
-        change_mode = "restart"
       }
 
       volume_mount {


### PR DESCRIPTION
…`template` block from the `home_assistant.nomad.j2` file.

I have updated the `configuration.yaml.j2` file to use the correct Ansible variable for the MQTT broker's address.