### PR TITLE
feat: Make Home Assistant startup asynchronous

### DIFF
--- a/ansible/roles/config_manager/tasks/main.yaml
+++ b/ansible/roles/config_manager/tasks/main.yaml
@@ -1,27 +1,30 @@
-- name: Wait for Home Assistant to generate auth file
-  ansible.builtin.wait_for:
+
+# --- Check for auth file instead of waiting ---
+- name: Check if Home Assistant auth file exists
+  ansible.builtin.stat:
     path: /opt/nomad/volumes/ha-config/.storage/auth_provider.homeassistant
-    timeout: 300
+  register: hass_auth_file_stat
   become: yes
 
-- name: Read and register Home Assistant token
-  block:
-    - name: Read Home Assistant auth file
-      ansible.builtin.slurp:
-        src: /opt/nomad/volumes/ha-config/.storage/auth_provider.homeassistant
-      register: "hass_auth_file"
-      become: yes
+# --- Make subsequent tasks conditional ---
+- name: Read Home Assistant auth file if it exists
+  ansible.builtin.slurp:
+    src: /opt/nomad/volumes/ha-config/.storage/auth_provider.homeassistant
+  register: "hass_auth_file_content"
+  become: yes
+  when: hass_auth_file_stat.stat.exists # Only run if file exists
 
-    - name: Set hass_token fact
-      ansible.builtin.set_fact:
-        hass_token: >
-          {{
-            (hass_auth_file['content'] | b64decode | from_json).data.ll_tokens
-            | selectattr('type', 'eq', 'long_lived_access')
-            | map(attribute='token')
-            | first
-          }}
-
+- name: Set hass_token fact if file was read
+  ansible.builtin.set_fact:
+    # Use default filter to handle case where slurp didn't run
+    hass_token: >
+      {{
+        (hass_auth_file_content.content | default('e30K') | b64decode | from_json({}, true)).data.ll_tokens
+        | selectattr('type', 'eq', 'long_lived_access')
+        | map(attribute='token')
+        | first | default(none, true)
+      }}
+  when: hass_auth_file_stat.stat.exists # Only run if file exists
 
 - name: Populate Consul KV with Model Configurations
   ansible.builtin.uri:
@@ -43,13 +46,23 @@
   loop_control:
     label: "{{ item.key }}"
 
-- name: Populate Consul KV with Home Assistant Token
+- name: Populate Consul KV with Home Assistant Token if found
   ansible.builtin.uri:
     url: "http://127.0.0.1:8500/v1/kv/config/hass/token"
     method: PUT
     body: "{{ hass_token }}"
     status_code: 200
-  when: hass_token is defined
+  when: hass_token is defined and hass_token is not none # Only run if token was successfully extracted
+
+- name: Report if HA token was populated
+  ansible.builtin.debug:
+    msg: "Home Assistant token was found and populated into Consul KV."
+  when: hass_token is defined and hass_token is not none
+
+- name: Report if HA token was NOT populated
+  ansible.builtin.debug:
+    msg: "Home Assistant auth file not found or token could not be extracted yet. Token NOT populated into Consul KV."
+  when: hass_token is not defined or hass_token is none
 
 - name: Populate Consul KV with App Settings
   ansible.builtin.uri:
@@ -72,7 +85,8 @@
           "nomad_models_dir": nomad_models_dir,
           "expected_cluster_size": expected_cluster_size,
           "ha_url": "{{ ha_url | default('') }}",
-          "ha_token": "{{ hass_token | default('') }}"
+          # Include token only if it was found
+          "ha_token": "{{ hass_token | default('') if (hass_token is defined and hass_token is not none) else '' }}"
         } | to_json
       }}
     status_code: 200

--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -1,3 +1,4 @@
+
 - name: Ensure Home Assistant config directory exists
   ansible.builtin.file:
     path: /opt/nomad/volumes/ha-config
@@ -17,30 +18,39 @@
     dest: /opt/nomad/volumes/ha-config/configuration.yaml
   become: yes
 
-- name: Wait for Nomad to be ready
-  ansible.builtin.wait_for:
-    host: "{{ ansible_default_ipv4.address }}"
-    port: 4646
-    timeout: 60
+# --- Essential Dependency Checks (Keep these synchronous) ---
+- name: Wait for Nomad API to be ready before submitting job
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:4646/v1/status/leader"
+    method: GET
+    status_code: 200
+  register: nomad_api_status
+  until: nomad_api_status.status == 200
+  retries: 12 # ~1 minute
+  delay: 5
+  changed_when: false
+  become: no # Should be accessible locally
 
-- name: Wait for MQTT service to be available
-  ansible.builtin.wait_for:
-    host: "{{ hostvars['controller_node_1']['ansible_host'] | default('127.0.0.1') }}"
-    port: 1883
-    timeout: 60
-
-- name: Wait for MQTT service to be available
+- name: Wait for MQTT service to be available in Consul before starting HA
   ansible.builtin.uri:
     url: "http://127.0.0.1:8500/v1/health/service/mqtt?passing"
     return_content: yes
   register: mqtt_health
-  until: mqtt_health.json | length > 0
-  retries: 30
+  until: mqtt_health.json is defined and mqtt_health.json | length > 0
+  retries: 30 # ~5 minutes
   delay: 10
+  changed_when: false
+  become: no # Should be accessible locally
+# --- End Dependency Checks ---
 
-- name: Run home-assistant job
+- name: Run home-assistant job asynchronously
   ansible.builtin.command:
     cmd: nomad job run /opt/nomad/jobs/home-assistant.nomad
   environment:
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
   changed_when: true
+  become: no # Run nomad client as the ansible user
+  # --- Make the task asynchronous ---
+  async: 300 # Max runtime for the command itself (submit shouldn't take long)
+  poll: 0    # Fire and forget - don't wait for command completion
+  # --- End async changes ---


### PR DESCRIPTION
Modified the Ansible playbook to allow the Home Assistant Nomad job to start asynchronously. This prevents the main playbook from being blocked while waiting for Home Assistant to fully initialize.

Changes:
- In the `home_assistant` role, the `nomad job run` task is now asynchronous.
- The task that waited for the Home Assistant service to be healthy has been removed.
- In the `config_manager` role, the blocking `wait_for` task for the auth file is replaced with a non-blocking `stat` check.
- Token extraction and Consul KV population are now conditional based on the existence of the auth file.