### PR TITLE
Fix Ansible templating error in config_manager

### DIFF
--- a/ansible/roles/config_manager/tasks/main.yaml
+++ b/ansible/roles/config_manager/tasks/main.yaml
@@ -85,7 +85,6 @@
           "nomad_models_dir": nomad_models_dir,
           "expected_cluster_size": expected_cluster_size,
           "ha_url": "{{ ha_url | default('') }}",
-          # Include token only if it was found
           "ha_token": "{{ hass_token | default('') if (hass_token is defined and hass_token is not none) else '' }}"
         } | to_json
       }}


### PR DESCRIPTION
Removed a comment from a Jinja2 template that was causing a fatal error during JSON conversion. JSON does not support comments, and the Ansible task was failing to populate Consul KV with application settings as a result.