### PR TITLE
Fix(ansible): Use advertise_ip for CONSUL_HOST in world_model

### DIFF
--- a/ansible/roles/world_model_service/templates/world_model.nomad.j2
+++ b/ansible/roles/world_model_service/templates/world_model.nomad.j2
@@ -22,7 +22,7 @@ job "world-model-service" {
       env {
         MQTT_HOST = "mqtt.service.consul"
         MQTT_PORT = "1883"
-        CONSUL_HOST = "{{ nomad_host_ip }}"
+        CONSUL_HOST = "{{ advertise_ip }}"
         CONSUL_PORT = "8500"
       }
 


### PR DESCRIPTION
The playbook was failing with an `AnsibleUndefinedVariable` error because the `nomad_host_ip` variable was not defined.

This change replaces the undefined variable with `advertise_ip`, which is the correct variable for the node's advertised IP address in this environment. This resolves the playbook failure.