### PR TITLE
Fix multiple Ansible playbook errors

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -19,7 +19,7 @@
 
 - name: Wait for Nomad API to be ready before submitting job
   ansible.builtin.uri:
-    url: ""{{ ansible_default_ipv4.address }}:4646/v1/status/leader"
+    url: "http://{{ ansible_default_ipv4.address }}:4646/v1/status/leader"
     method: GET
     status_code: 200
   register: nomad_api_status

--- a/ansible/roles/world_model_service/handlers/main.yaml
+++ b/ansible/roles/world_model_service/handlers/main.yaml
@@ -1,0 +1,7 @@
+- name: "Run nomad job"
+  ansible.builtin.command:
+    cmd: "nomad job run /opt/nomad/jobs/world_model.nomad"
+  environment:
+    NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
+  changed_when: true
+  become: no

--- a/ansible/roles/world_model_service/world_model.nomad.j2
+++ b/ansible/roles/world_model_service/world_model.nomad.j2
@@ -20,7 +20,7 @@ job "world-model-service" {
       }
 
       env {
-        MQTT_HOST = "{{ nomad_host_ip }}"
+        MQTT_HOST = "{{ advertise_ip }}"
         MQTT_PORT = "1883"
         CONSUL_HOST = "{{ advertise_ip }}"
         CONSUL_PORT = "8500"


### PR DESCRIPTION
This commit addresses three separate issues that were causing the Ansible playbook to fail:

1.  **YAML Syntax Error:** Corrected a malformed `url` in the `home_assistant` role's `ansible.builtin.uri` task.
2.  **Undefined Variable:** Replaced the undefined `nomad_host_ip` variable with the correct `advertise_ip` variable in the `world_model_service` Nomad template.
3.  **Missing Handler:** Added the missing "Run nomad job" handler to the `world_model_service` role to allow the service's Nomad job to be deployed correctly.