### PR TITLE
fix(nomad): correct device constraint syntax in home-assistant job

### DIFF
--- a/ansible/roles/home_assistant/templates/home-assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home-assistant.nomad.j2
@@ -1,0 +1,71 @@
+job "home-assistant" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "home-assistant-group" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 8123
+      }
+    }
+
+    volume "ha-config" {
+      type      = "host"
+      source    = "ha-config"
+      read_only = false
+    }
+
+    service {
+      name     = "home-assistant"
+      port     = "http"
+      provider = "consul"
+
+      check {
+        type     = "http"
+        path     = "/"
+        interval = "30s"
+        timeout  = "5s"
+      }
+    }
+
+    task "home-assistant" {
+      driver = "docker"
+
+      config {
+        image = "homeassistant/home-assistant:stable"
+        ports = ["http"]
+        volumes = [
+          "/etc/localtime:/etc/localtime:ro",
+        ]
+      }
+
+      env {
+        HA_SERVER = "http://127.0.0.1:8123"
+        HA_TOKEN = "{{ home_assistant_token | default('') }}"
+        MQTT_SERVER = "{{ hostvars['controller_node_1']['ansible_host'] | default('127.0.0.1') }}"
+      }
+
+
+      volume_mount {
+        volume      = "ha-config"
+        destination = "/config"
+        read_only   = false
+      }
+
+      resources {
+        cpu    = 1000 # 1 GHz
+        memory = 2048 # 2 GB
+
+        device "usb" {
+          count = 10
+          constraint {
+            attribute = "class_id"
+            value     = "30929"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The `device` block in the `home-assistant.nomad.j2` template used an unsupported `class` argument, causing the Nomad job to fail with a parsing error.

This change replaces the incorrect syntax with a `constraint` block, using `class_id` as the attribute and the decimal equivalent of the original hexadecimal value. This resolves the HCL syntax error and allows the Home Assistant job to run correctly.