### PR TITLE
fix(rag_tool): Handle cases with fewer than k search results

### DIFF
--- a/ansible/roles/pipecatapp/files/tools/rag_tool.py
+++ b/ansible/roles/pipecatapp/files/tools/rag_tool.py
@@ -93,7 +93,7 @@ class RAG_Tool:
         distances, indices = self.index.search(np.array(query_embedding, dtype=np.float32), k)
 
         results = []
-        for i in range(k):
+        for i in range(len(indices[0])):
             if indices[0][i] != -1: # FAISS returns -1 for no result
                 doc_index = indices[0][i]
                 doc = self.documents[doc_index]


### PR DESCRIPTION
This commit fixes an `IndexError` in the `search_knowledge_base` method of the `RAG_Tool`. The error occurred when the number of documents in the FAISS index was less than the hardcoded value of `k` (3).

The fix changes the loop to iterate over the actual number of results returned by the FAISS search, preventing the index out of bounds error.

A new unit test has been added to specifically verify this scenario.