### PR TITLE
fix(nomad): Correct device constraint attribute

### DIFF
--- a/ansible/roles/home_assistant/templates/home-assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home-assistant.nomad.j2
@@ -61,7 +61,7 @@ job "home-assistant" {
         device "usb" {
           count = 10
           constraint {
-            attribute = "class_id"
+            attribute = "usb.class_id"
             value     = "30929"
           }
         }


### PR DESCRIPTION
Updated the `home-assistant.nomad.j2` file to use the correct namespaced attribute for the USB device constraint. The attribute was changed from `class_id` to `usb.class_id` to comply with modern Nomad HCL syntax.