### PR TITLE
fix(ansible): Correct Nomad device constraint and restart handler

### DIFF
--- a/ansible/roles/home_assistant/templates/home-assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home-assistant.nomad.j2
@@ -61,7 +61,7 @@ job "home-assistant" {
         device "usb" {
           count = 10
           constraint {
-            attribute = "class_id"
+            attribute = "usb.class_id"
             value     = "30929"
           }
         }

--- a/ansible/roles/nomad/handlers/main.yaml
+++ b/ansible/roles/nomad/handlers/main.yaml
@@ -1,14 +1,16 @@
 - name: Restart nomad
-  service:
-    name: nomad
-    state: restarted
+  block:
+    - name: Restart nomad service
+      ansible.builtin.service:
+        name: nomad
+        state: restarted
 
-- name: Wait for Nomad API to be ready after restart
-  ansible.builtin.uri:
-    url: "http://127.0.0.1:4646/v1/agent/self"
-    status_code: 200
-  register: nomad_api_status
-  until: nomad_api_status.status == 200
-  retries: 12
-  delay: 5
+    - name: Wait for Nomad API to be ready after restart
+      ansible.builtin.uri:
+        url: "http://{{ advertise_ip | default('127.0.0.1') }}:4646/v1/agent/self"
+        status_code: 200
+      register: nomad_api_status
+      until: nomad_api_status.status == 200
+      retries: 12
+      delay: 5
   


### PR DESCRIPTION
This commit addresses two issues related to the Nomad deployment:

1.  **Device Constraint Syntax:** Updated the `home-assistant.nomad.j2` file to use the correct namespaced attribute for the USB device constraint. The attribute was changed from `class_id` to `usb.class_id` to comply with modern Nomad HCL syntax, resolving a job parsing error.

2.  **Restart Handler Race Condition:** Refactored the Nomad restart handler in `ansible/roles/nomad/handlers/main.yaml` to prevent a race condition. The restart and a subsequent API wait task are now grouped in a single `block`, ensuring the Nomad service is fully available before the playbook continues. The wait task now also uses the `advertise_ip` variable for better reliability.