### PR TITLE
feat(ansible): Add retries to Nomad download task

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -4,6 +4,10 @@
     dest: "/tmp/nomad.zip"
     mode: '0644'
     timeout: 30
+  register: download_task
+  until: download_task is success
+  retries: 5
+  delay: 10
 
 - name: Unzip Nomad
   ansible.builtin.unarchive:


### PR DESCRIPTION
The Ansible playbook was failing during the "Download Nomad" task due to transient network errors, specifically "Temporary failure in name resolution".

This change makes the download task more resilient by adding a retry loop. The task will now attempt to download the file up to 5 times with a 10-second delay between attempts, which should prevent the playbook from failing due to temporary network issues.