### PR TITLE
fix(ansible): Correct playbook structure and add download retries

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -69,23 +69,11 @@
   roles:
     - system_deps
     - common
+    - consul
+    - docker
+    - nomad
 
   tasks:
-    - name: Create Nomad volumes directory before service setup
-      ansible.builtin.file:
-        path: /opt/nomad/volumes
-        state: directory
-        mode: '0755'
-
-    - name: Run Consul setup
-      include_role:
-        name: "{{ role_name }}"
-      loop:
-        - consul
-        - docker
-        - nomad
-      loop_control:
-        loop_var: role_name
 
     - name: Flush handlers to ensure Nomad is restarted with new config
       meta: flush_handlers


### PR DESCRIPTION
This commit resolves two issues that were causing the Ansible playbook to fail:

1.  **Handler Not Found Error:** The `Restart nomad` handler was not being found because the `nomad` role was being loaded dynamically using `include_role` within a loop. Handlers in dynamically included roles are not registered for notification. This was fixed by refactoring `playbook.yaml` to use a static `roles:` list for the `consul`, `docker`, and `nomad` roles, which is the standard practice and ensures handlers are correctly loaded.

2.  **Transient Network Failures:** The task to download the Nomad binary was failing with "Temporary failure in name resolution". This was fixed by adding a retry loop (`until`, `retries`, `delay`) to the `get_url` task in the `nomad` role, making the playbook more resilient to transient network issues.

Additionally, a redundant task to create the Nomad volumes directory was removed from the main playbook, as this is handled within the `nomad` role.