### PR TITLE
Refactor playbook to use import_role for handler loading

### DIFF
--- a/ansible/roles/nomad/handlers/main.yaml
+++ b/ansible/roles/nomad/handlers/main.yaml
@@ -13,4 +13,3 @@
       until: nomad_api_status.status == 200
       retries: 12
       delay: 5
-  

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -66,14 +66,26 @@
           - "--exclude=.git"
       when: inventory_hostname != 'localhost'
 
-  roles:
-    - system_deps
-    - common
-    - consul
-    - docker
-    - nomad
-
   tasks:
+    - name: Import system_deps role
+      ansible.builtin.import_role:
+        name: system_deps
+
+    - name: Import common role
+      ansible.builtin.import_role:
+        name: common
+
+    - name: Import consul role
+      ansible.builtin.import_role:
+        name: consul
+
+    - name: Import docker role
+      ansible.builtin.import_role:
+        name: docker
+
+    - name: Import nomad role
+      ansible.builtin.import_role:
+        name: nomad
 
     - name: Flush handlers to ensure Nomad is restarted with new config
       meta: flush_handlers


### PR DESCRIPTION
The playbook was failing with a "handler not found" error because a play contained both a `roles` section and a `tasks` section. This is a known issue in Ansible that prevents handlers from being loaded correctly.

This commit refactors the playbook to use `import_role` within the `tasks` section. This is the recommended way to include roles when a play also contains tasks, as it ensures that the roles and their handlers are loaded in the correct order.