### PR TITLE
Fix(ansible): Refactor playbook to resolve handler loading issue

### DIFF
--- a/ansible/roles/nomad/handlers/main.yaml
+++ b/ansible/roles/nomad/handlers/main.yaml
@@ -1,4 +1,4 @@
-- name: "Nomad service restart"
+- name: Restart nomad
   block:
     - name: Restart nomad service
       ansible.builtin.service:

--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -107,7 +107,7 @@
     mode: '0644'
   become: yes
   notify:
-    - "Nomad service restart"
+    - Restart nomad
 
 - name: Copy Nomad systemd service file
   ansible.builtin.template:

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -73,8 +73,12 @@
     - docker
     - nomad
 
-  tasks:
+- name: Play 2a - Run tasks after roles
+  hosts: all
+  remote_user: "{{ target_user }}"
+  become: yes
 
+  tasks:
     - name: Flush handlers to ensure Nomad is restarted with new config
       meta: flush_handlers
 

--- a/promote_controller.yaml
+++ b/promote_controller.yaml
@@ -72,12 +72,19 @@
         owner: root
         group: root
         mode: '0644'
-      notify: "Nomad service restart"
+      notify: Restart nomad
 
   handlers:
     - name: restart consul
       ansible.builtin.systemd:
         name: consul
+        state: restarted
+        enabled: true
+        daemon_reload: true
+
+    - name: Restart nomad
+      ansible.builtin.systemd:
+        name: nomad
         state: restarted
         enabled: true
         daemon_reload: true


### PR DESCRIPTION
The playbook was failing with a "handler not found" error because a play contained both a `roles:` section and a `tasks:` section. This is a known issue in Ansible that prevents handlers from being loaded correctly from roles.

This commit refactors the playbook by splitting the problematic play into two separate plays. The first play is dedicated to running the roles, which ensures their handlers are loaded correctly. The second play then runs the tasks. This is the standard and recommended way to structure a playbook to avoid this handler loading conflict.