### PR TITLE
fix(ansible): use bash for benchmark parsing

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -7,6 +7,7 @@
 
     - name: Parse benchmark JSONL content safely using shell and jq
       ansible.builtin.shell:
+        executable: /bin/bash
         cmd: |
           set -o pipefail
           echo '{{ benchmark_log_raw.content }}' | base64 --decode | while IFS= read -r line; do


### PR DESCRIPTION
The 'Parse benchmark JSONL content' task was failing with the error "/bin/sh: 1: set: Illegal option -o pipefail" because the default shell (/bin/sh) does not support the 'pipefail' option.

This change explicitly sets the task's executable to /bin/bash, which resolves the issue.