### PR TITLE
fix: Install missing dependencies for unit tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,16 @@ opencv-python-headless
 # Note: torch should be installed with --index-url https://download.pytorch.org/whl/cpu
 torch
 ultralytics
+# Added to fix unit test failures
+pyyaml
+pipecat-ai
+openevolve
+faiss-cpu
+websockets
+sentence-transformers
+python-consul2
+fastapi
+paramiko
+uvicorn
+langchain
+python-nomad


### PR DESCRIPTION
The unit tests were failing due to numerous `ModuleNotFoundError` exceptions. This was because the testing environment was missing several Python packages required by the application and the tests themselves.

This commit resolves the issue by installing all the necessary dependencies from the three separate requirements files:
- `requirements-dev.txt`
- `ansible/roles/python_deps/files/requirements.txt`
- `prompt_engineering/requirements-dev.txt`

With these dependencies in place, the command `python -m unittest discover testing/unit_tests` now runs to completion and all tests pass.