### PR TITLE
Fix(nomad): Use advertise_ip in restart handler

### DIFF
--- a/ansible/roles/nomad/handlers/restart_nomad_handler_tasks.yaml
+++ b/ansible/roles/nomad/handlers/restart_nomad_handler_tasks.yaml
@@ -7,8 +7,7 @@
 
 - name: Wait for Nomad API to be ready after restart
   ansible.builtin.uri:
-    #url: "http://{{ advertise_ip | default('127.0.0.1') }}:4646/v1/agent/self"
-    url: "http://127.0.0.1:4646/v1/agent/self"
+    url: "http://{{ advertise_ip | default('127.0.0.1') }}:4646/v1/agent/self"
     status_code: 200
   register: nomad_api_status
   until: nomad_api_status.status == 200


### PR DESCRIPTION
The `Wait for Nomad API to be ready after restart` task in the Nomad role was failing because it used a hardcoded `127.0.0.1` address.

The Nomad service is configured to bind to the host's `advertise_ip`. This change updates the handler to use the `advertise_ip` variable, ensuring the health check targets the correct IP and preventing the playbook from failing.