### PR TITLE
refactor: improve idempotency of ansible roles

### DIFF
--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -175,6 +175,7 @@
   ansible.builtin.script: "download_hf_repo.py {{ item.item.repo_id }} /opt/nomad/models/vision/{{ item.item.name }}"
   args:
     executable: "/opt/pipecatapp/venv/bin/python"
+    creates: "/opt/nomad/models/vision/{{ item.item.name }}"
   loop: "{{ vision_model_files_hub.results }}"
   when: not item.stat.exists
   become: yes
@@ -200,6 +201,7 @@
   ansible.builtin.script: "download_hf_repo.py {{ item.item.repo_id }} /opt/nomad/models/embedding/{{ item.item.name }}"
   args:
     executable: "/opt/pipecatapp/venv/bin/python"
+    creates: "/opt/nomad/models/embedding/{{ item.item.name }}"
   loop: "{{ embedding_model_files_hub.results }}"
   when: not item.stat.exists
   become: yes

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -122,7 +122,7 @@
     mode: '0755'
   become: yes
 
-- name: Stop and purge any existing expert jobs to ensure idempotency
+- name: Stop and purge any existing expert jobs if llama.cpp was rebuilt
   ansible.builtin.command:
     cmd: nomad job stop -purge "expert-{{ item }}"
   loop: "{{ experts }}"
@@ -131,29 +131,33 @@
   failed_when: false # Don't fail if the job doesn't exist
   environment:
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
+  when: build_llama_cpp
 
-- name: Prepare for model benchmarking
-  become: yes
+- name: Run model benchmarking if enabled
   block:
-    - name: Clear previous benchmark results
-      ansible.builtin.file:
-        path: /var/log/llama_benchmarks.jsonl
-        state: absent
+    - name: Prepare for model benchmarking
+      become: yes
+      block:
+        - name: Clear previous benchmark results
+          ansible.builtin.file:
+            path: /var/log/llama_benchmarks.jsonl
+            state: absent
 
-    - name: Create empty benchmark results file
-      ansible.builtin.file:
-        path: /var/log/llama_benchmarks.jsonl
-        state: touch
-        mode: '0644'
-        owner: "{{ target_user }}"
-        group: "{{ target_user }}"
+        - name: Create empty benchmark results file
+          ansible.builtin.file:
+            path: /var/log/llama_benchmarks.jsonl
+            state: touch
+            mode: '0644'
+            owner: "{{ target_user }}"
+            group: "{{ target_user }}"
 
-- name: Flatten model list for benchmarking
-  ansible.builtin.set_fact:
-    all_models_to_benchmark: "{{ expert_models.values() | sum(start=[]) | unique(attribute='filename') }}"
+    - name: Flatten model list for benchmarking
+      ansible.builtin.set_fact:
+        all_models_to_benchmark: "{{ expert_models.values() | sum(start=[]) | unique(attribute='filename') }}"
 
-- name: Benchmark each available model and record results
-  ansible.builtin.include_tasks: benchmark_single_model.yaml
-  loop: "{{ all_models_to_benchmark }}"
-  loop_control:
-    loop_var: model_item
+    - name: Benchmark each available model and record results
+      ansible.builtin.include_tasks: benchmark_single_model.yaml
+      loop: "{{ all_models_to_benchmark }}"
+      loop_control:
+        loop_var: model_item
+  when: run_benchmarks | default(false)

--- a/ansible/roles/whisper_cpp/tasks/main.yaml
+++ b/ansible/roles/whisper_cpp/tasks/main.yaml
@@ -8,7 +8,39 @@
     state: present
   become: yes
 
-- name: Build and install whisper.cpp
+- name: Get latest commit hash from whisper.cpp remote repo
+  ansible.builtin.command:
+    cmd: "git ls-remote https://github.com/ggml-org/whisper.cpp.git HEAD"
+  register: git_ls_remote_result
+  changed_when: false
+  become: no
+
+- name: Extract commit hash from git ls-remote output
+  ansible.builtin.set_fact:
+    latest_commit_hash: "{{ git_ls_remote_result.stdout.split()[0] }}"
+
+- name: Check for existing whisper.cpp version file
+  ansible.builtin.stat:
+    path: /usr/local/etc/whisper-cpp.version
+  register: version_file_stat
+  become: yes
+
+- name: Read installed whisper.cpp version
+  ansible.builtin.slurp:
+    src: /usr/local/etc/whisper-cpp.version
+  when: version_file_stat.stat.exists
+  register: installed_version_raw
+  become: yes
+
+- name: Set installed_version fact
+  ansible.builtin.set_fact:
+    installed_version: "{{ (installed_version_raw.content | b64decode | trim) if 'content' in installed_version_raw else 'none' }}"
+
+- name: Decide if whisper.cpp needs to be built
+  ansible.builtin.set_fact:
+    build_whisper_cpp: "{{ installed_version != latest_commit_hash }}"
+
+- name: Build and install whisper.cpp if needed
   become: yes
   block:
     - name: Create build directory for whisper.cpp
@@ -21,43 +53,46 @@
       ansible.builtin.git:
         repo: 'https://github.com/ggml-org/whisper.cpp.git'
         dest: /opt/whisper.cpp-build
-        version: master
+        version: "{{ latest_commit_hash }}"
         update: yes
-      register: whisper_git_result
 
-    - name: Build and install from source if updated
-      block:
-        - name: Configure whisper.cpp build
-          ansible.builtin.command:
-            cmd: cmake -B build
-          args:
-            chdir: /opt/whisper.cpp-build
-            creates: /opt/whisper.cpp-build/build/Makefile
+    - name: Configure whisper.cpp build
+      ansible.builtin.command:
+        cmd: cmake -B build
+      args:
+        chdir: /opt/whisper.cpp-build
+        creates: /opt/whisper.cpp-build/build/Makefile
 
-        - name: Build whisper.cpp
-          ansible.builtin.command:
-            cmd: cmake --build build --config Release -j
-          args:
-            chdir: /opt/whisper.cpp-build
-            creates: /opt/whisper.cpp-build/build/bin/stream
+    - name: Build whisper.cpp
+      ansible.builtin.command:
+        cmd: cmake --build build --config Release -j
+      args:
+        chdir: /opt/whisper.cpp-build
+        creates: /opt/whisper.cpp-build/build/bin/stream
 
-        - name: Find compiled binaries
-          ansible.builtin.find:
-            paths: /opt/whisper.cpp-build/build/bin
-            patterns: '*'
-            file_type: file
-          register: whisper_binaries
+    - name: Find compiled binaries
+      ansible.builtin.find:
+        paths: /opt/whisper.cpp-build/build/bin
+        patterns: '*'
+        file_type: file
+      register: whisper_binaries
 
-        - name: Install whisper.cpp binaries
-          ansible.builtin.copy:
-            src: "{{ item.path }}"
-            dest: "/usr/local/bin/{{ item.path | basename }}"
-            mode: '0755'
-            remote_src: yes
-          loop: "{{ whisper_binaries.files }}"
+    - name: Install whisper.cpp binaries
+      ansible.builtin.copy:
+        src: "{{ item.path }}"
+        dest: "/usr/local/bin/{{ item.path | basename }}"
+        mode: '0755'
+        remote_src: yes
+      loop: "{{ whisper_binaries.files }}"
 
-        - name: Clean up whisper.cpp build directory
-          ansible.builtin.file:
-            path: /opt/whisper.cpp-build
-            state: absent
-      when: whisper_git_result.changed
+    - name: Stamp the installed version
+      ansible.builtin.copy:
+        content: "{{ latest_commit_hash }}"
+        dest: /usr/local/etc/whisper-cpp.version
+        mode: '0644'
+
+    - name: Clean up whisper.cpp build directory
+      ansible.builtin.file:
+        path: /opt/whisper.cpp-build
+        state: absent
+  when: build_whisper_cpp


### PR DESCRIPTION
Improved the idempotency of the `download_models`, `llama_cpp`, and `whisper_cpp` Ansible roles.

- In `download_models`, added the `creates` argument to `script` tasks to prevent re-running model downloads.
- In `llama_cpp`, made disruptive tasks like stopping jobs and running benchmarks conditional to avoid them running on every execution.
- In `whisper_cpp`, implemented a git-hash-based version check to ensure the build only runs when the source repository has changed.