### PR TITLE
feat: Add retry loop to apt update task

### DIFF
--- a/ansible/roles/system_deps/tasks/main.yaml
+++ b/ansible/roles/system_deps/tasks/main.yaml
@@ -1,8 +1,12 @@
 - name: Update apt cache
-  apt:
+  ansible.builtin.apt:
     update_cache: yes
     cache_valid_time: 3600
   become: yes
+  register: apt_update_result
+  until: apt_update_result is success
+  retries: 5
+  delay: 10
 
 - name: Install all system dependencies
   apt:


### PR DESCRIPTION
The Ansible playbook was failing during the `apt` cache update task due to what appears to be transient network errors. This change wraps the `apt` task in a retry loop, making the playbook more resilient to these temporary failures. The task will now attempt to run up to 5 times with a 10-second delay between each attempt, proceeding only after a successful update. This ensures the playbook can reliably run even in environments with intermittent network connectivity.