### PR TITLE
fix(ansible): Add --no-cache-dir to pip install

### DIFF
--- a/ansible/roles/python_deps/tasks/main.yaml
+++ b/ansible/roles/python_deps/tasks/main.yaml
@@ -43,7 +43,7 @@
   ansible.builtin.pip:
     requirements: "/opt/pipecatapp/requirements.txt"
     executable: "/opt/pipecatapp/venv/bin/pip3"
-    extra_args: -v
+    extra_args: -v --no-cache-dir
   environment:
     TMPDIR: /var/tmp/ansible_pip_build
   async: 1200 # Set timeout to 20 minutes


### PR DESCRIPTION
Adds the `--no-cache-dir` flag to the pip install task in the `python_deps` role. This is to prevent the task from hanging due to a corrupted pip cache.