### PR TITLE
Fix(ansible): Install Cython separately to fix av build error

### DIFF
--- a/ansible/roles/python_deps/tasks/main.yaml
+++ b/ansible/roles/python_deps/tasks/main.yaml
@@ -33,7 +33,14 @@
       - pip
       - setuptools
       - wheel
-      - cython
+    state: latest
+    executable: "/opt/pipecatapp/venv/bin/pip3"
+  become: yes
+  become_user: "{{ target_user }}"
+
+- name: Install Cython separately to ensure it's available for other builds
+  ansible.builtin.pip:
+    name: cython
     state: latest
     executable: "/opt/pipecatapp/venv/bin/pip3"
   become: yes


### PR DESCRIPTION
Separates the installation of the `cython` pip package from the other base packages in the `python_deps` role. This ensures that `cython` is installed and available before other packages that may depend on it for building, such as `av`, are installed. This prevents a race condition that can cause the build to fail.