### PR TITLE
feat(ansible): Make world_model_service job async and create volume

### DIFF
--- a/ansible/roles/world_model_service/handlers/main.yaml
+++ b/ansible/roles/world_model_service/handlers/main.yaml
@@ -5,3 +5,5 @@
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
   changed_when: true
   become: no
+  async: 300
+  poll: 0

--- a/ansible/roles/world_model_service/tasks/main.yaml
+++ b/ansible/roles/world_model_service/tasks/main.yaml
@@ -10,6 +10,7 @@
   loop:
     - "/opt/world_model_service"
     - "/opt/world_model_service/config"
+    - "/opt/nomad/volumes/world_model_storage"
   become: true
 
 - name: "World Model Service : Copy service files"


### PR DESCRIPTION
The handler for the `world_model_service` was blocking playbook execution. This change makes the `nomad job run` command asynchronous, preventing hangs.

Additionally, the `world-model` job was failing to be placed due to a missing host volume. Added a task to create the required `/opt/nomad/volumes/world_model_storage` directory.