### PR TITLE
Fix: Configure pipecat-app to use dynamic port

### DIFF
--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -7,11 +7,9 @@ job "{{ job_name | default('pipecat-app') }}" {
 
     network {
       mode = "host"
-      port "http" {
-        to = 8000
-      }
+      port "http" {}
     }
-    
+
     service {
       name     = "{{ service_name | default('pipecat-app') }}"
       port     = "http"
@@ -27,6 +25,10 @@ job "{{ job_name | default('pipecat-app') }}" {
 
     task "pipecat-task" {
       driver = "raw_exec"
+
+      env {
+        WEB_PORT = "${NOMAD_PORT_http}"
+      }
  
       config {
         command = "/opt/pipecatapp/start_pipecat.sh"


### PR DESCRIPTION
The pipecat-app service was failing its health check because it was listening on a hardcoded port (8000), while Nomad was assigning a dynamic port and registering that with Consul. This mismatch caused Consul to report the service as unhealthy.

This commit fixes the issue by:

1.  Modifying the `pipecatapp.nomad.j2` template to pass the dynamically assigned port to the application via the `WEB_PORT` environment variable.
2.  Updating `app.py` to read the `WEB_PORT` environment variable and use it to configure the Uvicorn server.

This ensures that the application listens on the same port that Nomad registers with Consul, allowing the health check to pass.