### PR TITLE
Fix(pipecatapp): Correct expert service name in environment

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -80,6 +80,8 @@
     dest: "{{ pipecat_app_dir }}/pipecat.env"
     mode: '0644'
   become: yes
+  vars:
+    llama_api_service_name: "expert-api-main"
 
 - name: Copy pipecat startup script
   ansible.builtin.template:


### PR DESCRIPTION
The pipecatapp was failing to start because it was configured to look for the `llamacpp-rpc-api` service, but the expert job registers itself in Consul as `expert-api-main`.

This change updates the Ansible task that generates the `pipecat.env` file to explicitly set `LLAMA_API_SERVICE_NAME` to `expert-api-main`, resolving the service discovery mismatch.