### PR TITLE
Fix: Correct Nomad port variable in router template

### DIFF
--- a/ansible/jobs/router.nomad.j2
+++ b/ansible/jobs/router.nomad.j2
@@ -36,7 +36,7 @@ echo "--- Starting Router ---"
 exec /usr/local/bin/llama-server \
   --model /opt/nomad/models/llm/hermes-2-pro-mistral-7b.Q4_K_M.gguf \
   --host 0.0.0.0 \
-  --port {{ "{{ env "NOMAD_PORT_http" }}" }} \
+  --port ${NOMAD_PORT_http} \
   --n-gpu-layers 99 \
   --mlock
 EOH


### PR DESCRIPTION
The Ansible playbook was failing with a Jinja2 templating error because the router.nomad.j2 template was using an invalid syntax to access the Nomad-provided HTTP port.

This commit replaces the incorrect `{{ "{{ env "NOMAD_PORT_http" }}" }}` syntax with the correct shell environment variable `${NOMAD_PORT_http}`. This allows the `raw_exec` driver to correctly access the dynamically allocated port at runtime.