### PR TITLE
fix: Correct Ansible playbook dry-run failures

### DIFF
--- a/ansible/roles/pxe_server/tasks/main.yaml
+++ b/ansible/roles/pxe_server/tasks/main.yaml
@@ -12,6 +12,7 @@
     path: "{{ tftp_root }}"
     state: directory
   become: yes
+  check_mode: no
 
 - name: Download and extract Debian netboot files
   unarchive:

--- a/deploy_expert.yaml
+++ b/deploy_expert.yaml
@@ -1,6 +1,6 @@
 - hosts: localhost
   connection: local
-  gather_facts: no
+  gather_facts: yes
 
   vars_files:
     - group_vars/models.yaml
@@ -17,7 +17,7 @@
   tasks:
     - name: "Render the Llama Expert job template with custom variables"
       ansible.builtin.template:
-        src: ansible/jobs/llama-expert.nomad
+        src: ansible/jobs/expert.nomad.j2
         dest: /tmp/{{ job_name }}.nomad
         mode: '0644'
 


### PR DESCRIPTION
This commit fixes several issues in Ansible playbooks that were identified by running `ansible-playbook --check`.

- **`deploy_expert.yaml`:**
  - Enabled fact gathering (`gather_facts: yes`) to ensure that the `ansible_memtotal_mb` variable is defined when the playbook is run.
  - Corrected the `src` path for the Nomad job template to point to the correct `expert.nomad.j2` file.

- **`ansible/roles/pxe_server/tasks/main.yaml`:**
  - Added `check_mode: no` to the task that creates the `/srv/tftp` directory. This ensures the directory is created even during a dry-run, preventing subsequent tasks from failing because the directory does not exist.