### PR TITLE
Fix: Correctly identify verified experts in pipecatapp role

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -36,19 +36,19 @@
   ansible.builtin.set_fact:
     successful_models: "{{ benchmark_results | selectattr('status', 'equalto', 'success') | map(attribute='model') | list }}"
 
-- name: Identify verified experts with at least one successful model
+- name: Identify verified experts by checking their models against benchmark results
   ansible.builtin.set_fact:
     verified_experts: >-
       {{
-        experts
-        | select('in', (
-            successful_models
-            | map('regex_replace', '^', '')
-            | list
-          ))
-        | list
+        verified_experts | default([]) + [item]
       }}
-  when: successful_models | length > 0
+  loop: "{{ experts }}"
+  vars:
+    # Get the list of model filenames for the current expert
+    expert_model_files: "{{ expert_models[item] | map(attribute='filename') | list }}"
+    # Check if any of the expert's models are in the list of successful models
+    is_verified: "{{ expert_model_files | intersect(successful_models) | length > 0 }}"
+  when: is_verified
 
 - name: Fallback and warn if no verified experts found
   ansible.builtin.debug:


### PR DESCRIPTION
The previous logic for identifying verified experts was flawed. It attempted to match the expert's name (e.g., 'coding') with the model's filename, which would never result in a match.

This change corrects the logic by iterating through each expert and checking if any of its associated model filenames (as defined in `group_vars/models.yaml`) are present in the list of successfully benchmarked models. This ensures that only experts with verified models are deployed.