### PR TITLE
fix(ansible): Explicitly enable fact gathering for pipecatapp play

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -208,6 +208,7 @@
 - name: Play 4 - Deploy Core AI Services and Applications
   hosts: controller_nodes[0]
   connection: local
+  gather_facts: yes
 
   vars_files:
     - group_vars/all.yaml


### PR DESCRIPTION
The playbook was failing with an 'ansible_memtotal_mb is undefined' error during the templating of expert job files. This indicates that Ansible facts were not being gathered for the play that includes the 'pipecatapp' role.

This change explicitly adds 'gather_facts: yes' to the play, ensuring that host facts are available and resolving the templating error.