### PR TITLE
Fix: Correctly scope YAML linting in lint.sh

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -26,18 +26,22 @@ if [ -f "$EXCLUDE_FILE" ]; then
 fi
 
 echo "--- Running YAML Linter ---"
-# Find all yaml files and filter them using grep. The -f flag reads patterns from a file.
-# We filter the exclude file to remove comments and empty lines before passing it to grep.
+# Find all yaml files.
+YAML_FILES_TO_LINT=$(find . -type f \( -name "*.yaml" -o -name "*.yml" \))
+
+# If an exclude file exists, filter the list of files.
 if [ -f "$EXCLUDE_FILE" ]; then
     EXCLUDE_PATTERNS=$(grep -v '^#' "$EXCLUDE_FILE" | grep -v '^$')
     if [ -n "$EXCLUDE_PATTERNS" ]; then
-        # Use process substitution to feed the patterns to grep's -f option
-        yamllint $(find . -type f \( -name "*.yaml" -o -name "*.yml" \) | grep -vFf <(echo "$EXCLUDE_PATTERNS"))
-    else
-        yamllint . # Run on all files if exclude list is empty
+        YAML_FILES_TO_LINT=$(echo "$YAML_FILES_TO_LINT" | grep -vFf <(echo "$EXCLUDE_PATTERNS"))
     fi
-else
-    yamllint . # Run on all files if exclude file doesn't exist
+fi
+
+# Run yamllint only if there are files to lint.
+if [ -n "$YAML_FILES_TO_LINT" ]; then
+    # We are intentionally word-splitting the file list.
+    # shellcheck disable=SC2086
+    yamllint $YAML_FILES_TO_LINT
 fi
 
 echo "--- Running Markdown Linter ---"

--- a/testing/unit_tests/test_lint_script.py
+++ b/testing/unit_tests/test_lint_script.py
@@ -1,0 +1,59 @@
+import unittest
+import subprocess
+import os
+import tempfile
+import shutil
+
+class TestLintScript(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.scripts_dir = os.path.join(self.test_dir, 'scripts')
+        os.makedirs(self.scripts_dir)
+
+        # Copy the lint.sh script to the temporary directory
+        shutil.copy('scripts/lint.sh', self.scripts_dir)
+
+        # Create a yamllint config file to disable the document-start rule
+        with open(os.path.join(self.test_dir, '.yamllint'), 'w') as f:
+            f.write('rules:\n')
+            f.write('  document-start: disable\n')
+
+        # Create some test files
+        with open(os.path.join(self.test_dir, 'good.yaml'), 'w') as f:
+            f.write('- a\n- b\n')
+        with open(os.path.join(self.test_dir, 'bad.yaml'), 'w') as f:
+            f.write('key: value:\n')
+        with open(os.path.join(self.test_dir, 'also_bad.yml'), 'w') as f:
+            f.write('key2: value2:\n')
+        with open(os.path.join(self.test_dir, 'excluded.yaml'), 'w') as f:
+            f.write('key3: value3:\n')
+        with open(os.path.join(self.test_dir, 'not_yaml.txt'), 'w') as f:
+            f.write('this is not yaml\n')
+        with open(os.path.join(self.scripts_dir, 'lint_exclude.txt'), 'w') as f:
+            f.write('excluded.yaml\n')
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_lint_script(self):
+        # Run the lint.sh script from the temporary directory
+        process = subprocess.Popen(
+            ['/bin/bash', os.path.join(self.scripts_dir, 'lint.sh')],
+            cwd=self.test_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+        stdout, stderr = process.communicate()
+
+        # Check the output
+        self.assertIn('bad.yaml', stdout)
+        self.assertIn('also_bad.yml', stdout)
+        self.assertNotIn('good.yaml', stdout)
+        self.assertNotIn('excluded.yaml', stdout)
+        self.assertNotIn('not_yaml.txt', stdout)
+        # The markdown linter will run and fail, so we don't check stderr
+        # self.assertEqual(stderr, '')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The `lint.sh` script was incorrectly configured to run `yamllint` on the entire directory (`.`) in certain scenarios. This could lead to the linter attempting to parse non-YAML files, causing spurious errors or unpredictable behavior.

This commit refactors the script to:
1.  Explicitly find all files with `.yaml` or `.yml` extensions.
2.  Filter this list against the `lint_exclude.txt` file.
3.  Run `yamllint` only on the resulting list of files.

This ensures that the YAML linter only ever runs on the intended YAML source files.

A new unit test, `testing/unit_tests/test_lint_script.py`, has been added to verify this behavior. The test creates a temporary environment with a mix of YAML and non-YAML files and asserts that the linter correctly identifies and reports on only the intended files.