### PR TITLE
Fix: Correct Ansible playbook check script and role errors

### DIFF
--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -8,6 +8,7 @@
   command: "curl -L -o /tmp/consul.zip {{ consul_zip_url }}"
   args:
     creates: /tmp/consul.zip
+  check_mode: no
 
 - name: Unzip Consul
   unarchive:
@@ -16,6 +17,7 @@
     remote_src: yes
     creates: /tmp/consul
   become: yes
+  check_mode: no
 
 - name: Move Consul to /usr/local/bin
   copy:

--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -8,6 +8,7 @@
   until: download_task is success
   retries: 5
   delay: 10
+  check_mode: no
 
 - name: Unzip Nomad
   ansible.builtin.unarchive:
@@ -15,6 +16,7 @@
     dest: "/tmp"
     remote_src: yes
     creates: /tmp/nomad
+  check_mode: no
 
 - name: Get version of the existing Nomad binary
   ansible.builtin.command:
@@ -157,6 +159,7 @@
     dest: /tmp/cni-plugins.tgz
     mode: '0644'
     timeout: 30
+  check_mode: no
 
 - name: Extract CNI plugins into /opt/cni/bin
   ansible.builtin.unarchive:
@@ -164,6 +167,7 @@
     dest: /opt/cni/bin
     remote_src: yes
   become: yes
+  check_mode: no
 
 - name: Ensure /dev/snd directory exists for Nomad volume
   ansible.builtin.file:

--- a/ansible/roles/pxe_server/tasks/main.yaml
+++ b/ansible/roles/pxe_server/tasks/main.yaml
@@ -20,6 +20,7 @@
     dest: /srv/tftp
     remote_src: yes
   become: yes
+  check_mode: no
 
 - name: Download iPXE BIOS bootloader
   get_url:


### PR DESCRIPTION
This commit addresses several issues preventing the `check_all_playbooks.sh` script from running successfully.

- Modified `check_all_playbooks.sh` to dynamically find the `ansible-playbook` executable, removing a hardcoded path and improving portability.
- Added `check_mode: no` to download and unarchive tasks in the `consul`, `nomad`, and `pxe_server` Ansible roles. This ensures that necessary files are created during `--check` mode, allowing subsequent tasks to pass.
- Installed the `community.general` Ansible collection, which was a missing dependency.