### PR TITLE
feat(ansible): Deploy llamacpp-rpc jobs from llama_cpp role

### DIFF
--- a/ansible/roles/llama_cpp/handlers/main.yaml
+++ b/ansible/roles/llama_cpp/handlers/main.yaml
@@ -1,3 +1,9 @@
-- name: update ld cache
-  ansible.builtin.command: ldconfig
+- name: run nomad llamacpp-rpc job
+  ansible.builtin.command:
+    cmd: nomad job run "/opt/nomad/jobs/llamacpp-rpc-{{ item.filename | regex_replace('\\.gguf$', '') }}.nomad"
+  loop: "{{ all_models_for_rpc }}"
+  environment:
+    NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
+  loop_control:
+    label: "{{ item.filename }}"
   become: yes

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -122,6 +122,32 @@
     mode: '0755'
   become: yes
 
+- name: Flatten model list for RPC jobs
+  ansible.builtin.set_fact:
+    all_models_for_rpc: "{{ expert_models.values() | sum(start=[]) | unique(attribute='filename') }}"
+
+- name: Stop and purge any existing llamacpp-rpc jobs if llama.cpp was rebuilt
+  ansible.builtin.command:
+    cmd: nomad job stop -purge "llamacpp-rpc-{{ item.filename | regex_replace('\\.gguf$', '') }}"
+  loop: "{{ all_models_for_rpc }}"
+  register: rpc_job_stop_status
+  changed_when: "'Running' in rpc_job_stop_status.stdout"
+  failed_when: false # Don't fail if the job doesn't exist
+  environment:
+    NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
+  when: build_llama_cpp
+
+- name: Template and run llamacpp-rpc nomad job for each model
+  ansible.builtin.template:
+    src: ../../jobs/llamacpp-rpc.nomad.j2
+    dest: "/opt/nomad/jobs/llamacpp-rpc-{{ item.filename | regex_replace('\\.gguf$', '') }}.nomad"
+    mode: '0644'
+  loop: "{{ all_models_for_rpc }}"
+  become: yes
+  notify: run nomad llamacpp-rpc job
+  loop_control:
+    label: "{{ item.filename }}"
+
 - name: Stop and purge any existing expert jobs if llama.cpp was rebuilt
   ansible.builtin.command:
     cmd: nomad job stop -purge "expert-{{ item }}"

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -134,6 +134,7 @@
       loop_control:
         loop_var: role_name
       when: not external_model_server
+      tags: llama_cpp
 
     - name: Flush handlers to ensure all services are started
       meta: flush_handlers


### PR DESCRIPTION
Adds tasks to the `llama_cpp` role to template and run the `llamacpp-rpc.nomad.j2` job for each model defined in `expert_models`.

This ensures that the RPC services are created and available for the expert orchestrator jobs to use.