### PR TITLE
Fix multiple Ansible playbook errors

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -203,7 +203,7 @@
 - name: Create expert job files from template for verified models
   ansible.builtin.template:
     src: ../../jobs/expert.nomad.j2
-    dest: "/opt/nomad/jobs/expert-{{ item }}.nomad"
+    dest: "/opt/nomad/jobs/expert-{{ current_expert }}.nomad"
   loop: "{{ verified_experts | default([]) }}"
   loop_control:
     loop_var: current_expert # Using the previously updated loop variable name


### PR DESCRIPTION
This change addresses a cascade of issues that were causing the Ansible playbook to fail:

1.  **Undefined Variable in Loop:** An `'item' is undefined` error was occurring in the `pipecatapp` role because the `loop_var` was set to `current_expert`, but the `dest` parameter was still using `item`. This has been corrected.

2.  **Nomad `raw_exec` Command:** The `rpc-server` was failing to start because the `$NOMAD_PORT_rpc` environment variable was not being expanded. This has been fixed by wrapping the command in `/bin/bash -c "..."`.

3.  **Nomad Job File Syntax:** The `artifact` block was incorrectly placed inside the `resources` block in the `llamacpp-rpc.nomad.j2` template. It has been removed.

4.  **Fragile JSONL Parsing:** The `from_json` filter was failing the entire playbook run if it encountered any malformed JSON in the benchmark log. This has been replaced with a more resilient shell-based approach that uses `jq` to validate each line, ensuring that only valid JSON is processed.

5.  **Templating Error:** The `round` filter was being applied to a non-numeric value in the `llamacpp-rpc.nomad.j2` template, causing a `type AnsibleUnsafeText doesn't define __round__ method` error. This has been fixed by casting the `avg_tokens_per_second` variable to a `float` before rounding.