### PR TITLE
fix(ansible): add missing 'update ld cache' handler

### DIFF
--- a/ansible/roles/llama_cpp/handlers/main.yaml
+++ b/ansible/roles/llama_cpp/handlers/main.yaml
@@ -7,3 +7,8 @@
   loop_control:
     label: "{{ item.filename }}"
   become: yes
+
+- name: update ld cache
+  ansible.builtin.command:
+    cmd: ldconfig
+  become: yes


### PR DESCRIPTION
The playbook was failing with "handler not found" for 'update ld cache' in the llama_cpp role.

This change adds the missing handler, which runs 'ldconfig' to update the shared library cache after new libraries are installed.