### PR TITLE
Fix(ansible): Correct undefined benchmark variable in pipecatapp

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -216,22 +216,22 @@
     worker_count: 1
     # DO NOT redefine ansible_memtotal_mb here
     # The benchmark data calculation can stay if needed, adjust variable names if necessary
-    current_benchmark_data: >-
+    benchmark_data_for_expert: >-
       {{
-        (benchmark_results.stdout_lines | map('from_json') |
+        (benchmark_results |
         selectattr('model', 'in', expert_models[current_expert] | map(attribute='filename') | list) |
         list) | default([])
       }}
-    current_avg_tokens: >-
+    avg_tokens: >-
       {{
-        (current_benchmark_data | map(attribute='tokens_per_second') | list | sum / (current_benchmark_data | length))
-        if (current_benchmark_data | length > 0) else 0
+        (benchmark_data_for_expert | map(attribute='tokens_per_second') | list | sum / (benchmark_data_for_expert | length))
+        if (benchmark_data_for_expert | length > 0) else 0
       }}
     # expert_tags definition can stay, but ensure it doesn't redefine ansible_memtotal_mb
     current_expert_tags: >-
       [
         "expert={{ current_expert }}",
-        "avg_tps={{ current_avg_tokens | round(2) }}",
+        "avg_tps={{ avg_tokens | round(2) }}",
         "memory_mb={{ ansible_memtotal_mb }}", # Access global fact directly
         "models={{ model_list | map(attribute='filename') | join(',') }}"
       ]


### PR DESCRIPTION
The playbook was failing with an `AnsibleUndefinedVariable` error for `benchmark_data_for_expert`.

This was caused by a mismatch between the variable name defined in the `pipecatapp` role (`current_benchmark_data`) and the name used in the `expert.nomad.j2` template (`benchmark_data_for_expert`).

This commit renames the variable in the Ansible task to `benchmark_data_for_expert` to match the template, resolving the error.