### PR TITLE
Fix(ansible): Correct model discovery logic in download_models role

### DIFF
--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -25,11 +25,12 @@
 
 - name: Set model facts from Consul KV
   ansible.builtin.set_fact:
-    llm_models_to_download: "{{ consul_models.results | selectattr('status', 'equalto', 200) | selectattr('item', 'in', ['main', 'coding', 'math', 'extract', 'router']) | map(attribute='content') | map('from_json') | safe_flatten | list }}"
+    llm_models_to_download: "{{ consul_models.results | selectattr('status', 'equalto', 200) | selectattr('item', 'in', ['main', 'coding', 'math', 'extract', 'router']) | map(attribute='content') | map('from_json') | sum(start=[]) }}"
     piper_voice_files: "{{ consul_models.results | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'piper_voice_files') | map(attribute='content') | map('from_json') | first | default([]) }}"
     embedding_models: "{{ consul_models.results | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'embedding_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
-    stt_models: "{{ consul_models.results | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'stt_models') | map(attribute='content') | map('from_json') | first | default({}) }}"
+    stt_models: "{{ consul_models.results | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'stt_models') | map(attribute='content') | map('from_json') | map(attribute='stt_models') | first | default({}) }}"
     vision_models: "{{ consul_models.results | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'vision_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
+
          
 # ---------------------------------------------------------------------------- #
 #                                  LLM Models                                  #


### PR DESCRIPTION
The `download_models` role was failing to correctly identify and download LLM and STT models due to a bug in how it processed data from Consul.

The Jinja2 filter used to create the `llm_models_to_download` variable was incorrectly attempting to flatten a list of lists, resulting in an empty variable and causing the download tasks to be skipped.

A similar logic error was present in the filter for the `stt_models` variable, which was also causing the STT model download tasks to be skipped.

This commit corrects the Jinja2 filters for both variables, ensuring that the model data is parsed correctly and that all models are now properly discovered and downloaded.