### PR TITLE
feat: Use Phi-3 Mini for router model

### DIFF
--- a/group_vars/models.yaml
+++ b/group_vars/models.yaml
@@ -32,10 +32,10 @@ expert_models:
       filename: "LFM2-1.2B-Extract-Q4_K_M.gguf"
       memory_mb: 4096
   router:
-    - name: "hermes-2-pro-mistral-7b"
-      url: "https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/resolve/main/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf"
-      filename: "Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf"
-      memory_mb: 8192
+    - name: "phi-3-mini-instruct"
+      url: "https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q4_K_M.gguf"
+      filename: "Phi-3-mini-4k-instruct-Q4_K_M.gguf"
+      memory_mb: 4096
 
 # A list of voices for the PiperTTSService to use, in order of preference.
 tts_voices:


### PR DESCRIPTION
The previous router model, `hermes-2-pro-mistral-7b`, was too large and caused deployment failures due to resource exhaustion.

This change replaces the oversized model with the smaller, more efficient `phi-3-mini-instruct` model, which is better suited for the routing and tool-calling tasks. The associated memory requirement in the model configuration has been updated to reflect this change.

Additionally, the temporary memory increase in the Nomad job file has been reverted, as it is no longer necessary with the smaller model.