### PR TITLE
Fix Ansible Playbook and Bootstrap Script

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -66,6 +66,15 @@
           - "--exclude=.git"
       when: inventory_hostname != 'localhost'
 
+    - name: Synchronize control repository for local bootstrap
+      ansible.posix.synchronize:
+        src: "{{ playbook_dir }}/"
+        dest: /opt/cluster-infra/
+        rsync_opts:
+          - "--exclude=.git"
+        delegate_to: localhost
+      when: inventory_hostname == 'localhost'
+
   roles:
     - system_deps
     - common


### PR DESCRIPTION
- Corrected a syntax error in the router.nomad.j2 template.
- Fixed an incorrect file path for the llamacpp-rpc.nomad.j2 job.
- Added a synchronize task to handle single-node bootstrap.