### PR TITLE
Fix Ansible Playbook and Bootstrap Script

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -72,7 +72,6 @@
         dest: /opt/cluster-infra/
         rsync_opts:
           - "--exclude=.git"
-        delegate_to: localhost
       when: inventory_hostname == 'localhost'
 
   roles:


### PR DESCRIPTION
- Corrected a syntax error in the router.nomad.j2 template.
- Fixed an incorrect file path for the llamacpp-rpc.nomad.j2 job.
- Added a synchronize task to handle single-node bootstrap.
- Removed unsupported 'delegate_to' from synchronize task.