### PR TITLE
Fix: Correctly render Nomad job template before running

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -236,18 +236,29 @@
   gather_facts: no
   become: no
 
-  # Define the list of experts to deploy
   vars:
+    # Define the list of experts to deploy
     experts:
       - name: main
       - name: coding
       - name: math
       - name: extract
+    # Define the path for the rendered job file
+    llamacpp_rpc_pool_job_file: /tmp/llamacpp-rpc-pool.nomad
 
   tasks:
-    - name: Ensure the GPU Provider Pool job is running
-      ansible.builtin.command: >
-        nomad job run -var="job_name=llamacpp-rpc-pool" -var="worker_count={{ groups['workers'] | length if 'workers' in groups else 1 }}" /opt/cluster-infra/ansible/jobs/llamacpp-rpc.nomad.j2
+    - name: Render the GPU Provider Pool job template
+      ansible.builtin.template:
+        src: /opt/cluster-infra/ansible/jobs/llamacpp-rpc.nomad.j2
+        dest: "{{ llamacpp_rpc_pool_job_file }}"
+        mode: '0644'
+      vars:
+        job_name: llamacpp-rpc-pool
+        worker_count: "{{ groups['workers'] | length if 'workers' in groups else 1 }}"
+
+    - name: Ensure the GPU Provider Pool job is running from rendered file
+      ansible.builtin.command:
+        cmd: "nomad job run {{ llamacpp_rpc_pool_job_file }}"
       changed_when: true # This command always triggers a deployment evaluation
 
     - name: Wait for GPU Providers to become healthy in Consul


### PR DESCRIPTION
The playbook was failing because it was attempting to run a Nomad job directly from a Jinja2 template file. Nomad's HCL parser does not understand Jinja2 syntax, leading to an "Unsupported operator" error.

This change fixes the issue by introducing a two-step process:
1.  Use the `ansible.builtin.template` module to render the `.nomad.j2` file to a temporary file on the local machine.
2.  Run `nomad job run` against the newly rendered static file.

This ensures that Nomad receives a valid HCL file and resolves the parsing error.