### PR TITLE
Fix: Correct MQTT configuration in Home Assistant

### DIFF
--- a/ansible/roles/home_assistant/templates/configuration.yaml.j2
+++ b/ansible/roles/home_assistant/templates/configuration.yaml.j2
@@ -2,6 +2,5 @@
 default_config:
 
 # Configure the MQTT integration
-mqtt:
-  server: "{{ hostvars['controller_node_1']['ansible_host'] | default('127.0.0.1') }}"
-  port: 1883
+# Using single-line format to avoid YAML parsing issues with duplicate keys.
+mqtt: {"broker": "{{ hostvars['controller_node_1']['ansible_host'] | default('127.0.0.1') }}", "port": 1883}


### PR DESCRIPTION
The Home Assistant MQTT integration was failing to load due to an invalid configuration. The key for the MQTT broker was incorrectly set to `server` instead of `broker`.

This change corrects the key to `broker` and reformats the configuration to a single-line JSON style to prevent potential YAML parsing issues.