### PR TITLE
Fix Home Assistant MQTT configuration error

### DIFF
--- a/ansible/roles/home_assistant/templates/configuration.yaml.j2
+++ b/ansible/roles/home_assistant/templates/configuration.yaml.j2
@@ -1,6 +1,3 @@
 # Enables the default configuration for Home Assistant
 default_config:
 
-# Configure the MQTT integration
-# Using single-line format to avoid YAML parsing issues with duplicate keys.
-mqtt: {"broker": "{{ hostvars['controller_node_1']['ansible_host'] | default('127.0.0.1') }}", "port": 1883}

--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -52,7 +52,7 @@ job "home-assistant" {
       env {
         HA_SERVER = "http://127.0.0.1:8123"
         HA_TOKEN = "{{ home_assistant_token | default('') }}"
-        MQTT_SERVER = "{{ hostvars['controller_node_1']['ansible_host'] | default('127.0.0.1') }}"
+        MQTT_SERVER = "mqtt://{{ hostvars['controller_node_1']['ansible_host'] | default('127.0.0.1') }}:1883"
       }
 
 


### PR DESCRIPTION
Resolves a startup error in Home Assistant caused by a duplicate MQTT configuration.

The error was caused by a conflict between the static configuration in 'configuration.yaml' and the auto-configuration from the 'MQTT_SERVER' environment variable in the Nomad job.

This fix makes the environment variable the single source of truth by:
1.  Updating the `MQTT_SERVER` variable in the Nomad job to be a full URL (`mqtt://<host>:1883`).
2.  Removing the conflicting `mqtt:` block from the `configuration.yaml.j2` template.