### PR TITLE
Fix: Correctly deploy expert GPU providers with full model data

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -236,19 +236,17 @@
   gather_facts: no
   become: no
 
-  # Define the list of experts to deploy
   vars:
-    experts:
-      - name: main
-      - name: coding
-      - name: math
-      - name: extract
+    # This creates a new list containing only the first model object from each expert's list.
+    # The template needs the full object (name, filename, memory_mb, etc.), not just the name.
+    expert_primary_models: "{{ expert_models.values() | map('first') | list }}"
 
   tasks:
     - name: Deploy and run the GPU Provider Pool job for each expert
       include_tasks:
         file: "{{ playbook_dir }}/ansible/tasks/deploy_expert_gpu_provider.yaml"
-      loop: "{{ experts }}"
+      # We loop over the enriched list of model objects.
+      loop: "{{ expert_primary_models }}"
       loop_control:
         loop_var: item
 


### PR DESCRIPTION
This commit resolves a series of failures related to deploying Nomad jobs for the expert GPU provider pool.

The initial playbook failed due to two issues:
1.  A Jinja2 template (`.j2` file) was being passed directly to `nomad job run`, causing an HCL parsing error.
2.  The template was being rendered outside of a loop, causing an `AnsibleUndefinedVariable` error because the `item` variable was not defined.
3.  A subsequent fix revealed that the loop was only iterating over a simple list of expert names, while the template required the full model object (including `filename`, `memory_mb`, etc.).

This commit implements a robust, multi-part solution:
- The playbook now constructs an enriched list, `expert_primary_models`, which contains the full configuration object for each expert's primary model. This is achieved using a Jinja2 filter (`expert_models.values() | map('first') | list`).
- The deployment logic is modularized into a separate file, `ansible/tasks/deploy_expert_gpu_provider.yaml`, which is called via `include_tasks` within a loop.
- The loop now iterates over the enriched `expert_primary_models` list, providing the full model object to the template and resolving the `UndefinedError`.
- The included task file correctly implements the "render-then-run" pattern, ensuring Nomad receives a valid, fully rendered HCL file for each expert.