### PR TITLE
feat: Allow net_raw capability in Nomad client

### DIFF
--- a/ansible/roles/nomad/templates/nomad.hcl.client.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.client.j2
@@ -15,6 +15,7 @@ plugin "docker" {
     volumes {
       enabled = true
     }
+    allow_caps = ["NET_RAW"]
   }
 }
 client {


### PR DESCRIPTION
Adds the `net_raw` capability to the list of allowed capabilities in the Nomad client configuration. This is required for the Home Assistant container to run successfully.