### PR TITLE
feat: Allow net_raw and net_admin capabilities in Nomad client

### DIFF
--- a/ansible/roles/nomad/templates/nomad.hcl.client.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.client.j2
@@ -15,7 +15,7 @@ plugin "docker" {
     volumes {
       enabled = true
     }
-    allow_caps = ["NET_RAW"]
+    allow_caps = ["NET_RAW", "NET_ADMIN"]
   }
 }
 client {


### PR DESCRIPTION
Adds the `net_raw` and `net_admin` capabilities to the list of allowed capabilities in the Nomad client configuration. This is required for the Home Assistant container to run successfully, as it needs these capabilities for DHCP discovery.