### PR TITLE
Fix Nomad health check for router service

### DIFF
--- a/ansible/jobs/router.nomad.j2
+++ b/ansible/jobs/router.nomad.j2
@@ -26,10 +26,12 @@ job "router" {
 
       check {
         type     = "http"
+        address  = "{{ advertise_ip }}"
+        port     = "http"
         path     = "/health"
         interval = "15s"
         timeout  = "5s"
-        initial_delay = "10m" 
+        initial_delay = "60s"
       }
     }
 


### PR DESCRIPTION
The health check for the 'router' Nomad job was failing because it was not correctly configured for 'host' network mode. The check was defaulting to localhost, but the service was listening on the host's advertise IP.

This change explicitly sets the health check's `address` to `{{ advertise_ip }}` and `port` to `"http"` to ensure it targets the correct IP and port. Additionally, the `initial_delay` has been reduced from a prohibitive 10 minutes to a more reasonable 60 seconds to allow the service to be marked healthy faster.