### PR TITLE
Fix(app): Update PiperVoice.from_files to PiperVoice.load

### DIFF
--- a/ansible/roles/pipecatapp/files/app.py
+++ b/ansible/roles/pipecatapp/files/app.py
@@ -239,7 +239,7 @@ class PiperTTSService(FrameProcessor):
             config_path (str): The path to the Piper TTS model config file.
         """
         super().__init__()
-        self.voice = PiperVoice.from_files(model_path, config_path)
+        self.voice = PiperVoice.load(model_path, config_path)
         self.sample_rate = self.voice.config.sample_rate
 
     async def process_frame(self, frame, direction):


### PR DESCRIPTION
The `piper-tts` library has been updated, and the `PiperVoice.from_files` method is no longer available. This commit updates the code to use the new `PiperVoice.load` method, which resolves the `AttributeError` that was causing the application to crash on startup.