### PR TITLE
feat(pipecatapp): Asynchronously build RAG knowledge base

### DIFF
--- a/ansible/roles/pipecatapp/files/web_server.py
+++ b/ansible/roles/pipecatapp/files/web_server.py
@@ -134,7 +134,7 @@ async def get_status():
 @app.get("/health", summary="Health Check", description="Provides a health check endpoint. It returns a 200 OK if the agent is initialized and ready, otherwise a 503 Service Unavailable. This is used by Nomad for service health checks.", tags=["System"])
 async def get_health():
     """A health check endpoint that verifies the agent is fully initialized."""
-    if twin_service_instance and twin_service_instance.router_llm:
+    if twin_service_instance and twin_service_instance.router_llm and twin_service_instance.tools.get("rag").is_ready:
         return JSONResponse(content={"status": "ok"})
     else:
         return JSONResponse(status_code=503, content={"status": "initializing"})


### PR DESCRIPTION
Moves the RAG tool's knowledge base construction to a background thread to prevent blocking application startup.

- The `RAG_Tool` now builds its index in a separate thread.
- A `is_ready` flag is added to the `RAG_Tool` to track the indexing status.
- The `search_knowledge_base` method now returns a "not ready" message if the index is still being built.
- The `/health` endpoint in `web_server.py` is updated to check the `RAG_Tool`'s `is_ready` flag before returning a healthy status.

This prevents the application from failing health checks due to a long-running initialization task.