### PR TITLE
The world-model-service Nomad job was failing to start because it was…

### DIFF
--- a/ansible/roles/world_model_service/world_model.nomad.j2
+++ b/ansible/roles/world_model_service/world_model.nomad.j2
@@ -23,6 +23,7 @@ job "world-model-service" {
       config {
         image   = "world-model-service:latest"
         ports   = ["http"]
+        force_pull = false
       }
 
       volume_mount {


### PR DESCRIPTION
… attempting to pull the locally-built Docker image from a remote repository. This resulted in a "pull access denied" error.

This commit fixes the issue by adding `force_pull = false` to the Docker driver configuration in the job file. This instructs Nomad to use the local image if it is present and not attempt to pull it from a remote registry.