### PR TITLE
fix(ansible): Ensure world-model-service Nomad job is deployed synchr…

### DIFF
--- a/ansible/roles/world_model_service/handlers/main.yaml
+++ b/ansible/roles/world_model_service/handlers/main.yaml
@@ -1,9 +1,0 @@
-- name: "Run nomad job"
-  ansible.builtin.command:
-    cmd: "nomad job run /opt/nomad/jobs/world_model.nomad"
-  environment:
-    NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
-  changed_when: true
-  become: no
-  async: 300
-  poll: 0

--- a/ansible/roles/world_model_service/tasks/main.yaml
+++ b/ansible/roles/world_model_service/tasks/main.yaml
@@ -49,5 +49,13 @@
     group: "root"
     mode: "0644"
   become: true
-  notify:
-    - "Run nomad job"
+  register: nomad_job_template
+
+- name: "World Model Service : Run nomad job"
+  ansible.builtin.command:
+    cmd: "nomad job run /opt/nomad/jobs/world_model.nomad"
+  environment:
+    NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
+  changed_when: true
+  become: no
+  when: nomad_job_template.changed


### PR DESCRIPTION
…onously

The world-model-service Nomad job was failing to start because the updated job configuration was not being reliably deployed.

The deployment was handled by an asynchronous 'fire-and-forget' Ansible handler. This meant that if the `nomad job run` command failed for any reason, the playbook would not report an error, and the old, broken version of the job would continue to run.

This commit refactors the Ansible role to make the deployment a synchronous, conditional task. This ensures that when the job template changes, the `nomad job run` command is executed immediately and the playbook will wait for it to complete, failing if the deployment is unsuccessful.

This change, combined with the previous addition of `force_pull = false`, will ensure the service starts correctly with the locally-built image.