### PR TITLE
Fix(world-model-service): Use dynamic port allocation

### DIFF
--- a/ansible/roles/world_model_service/files/Dockerfile
+++ b/ansible/roles/world_model_service/files/Dockerfile
@@ -13,9 +13,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the rest of the application's code into the container at /app
 COPY app.py .
 
-# Make port 8000 available to the world outside this container
-EXPOSE 8000
-
 # Define environment variables
 # These can be overridden at runtime by Nomad
 ENV MQTT_HOST="mqtt"
@@ -23,4 +20,4 @@ ENV MQTT_PORT=1883
 ENV MQTT_TOPIC="#"
 
 # Run app.py when the container launches
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "app.py"]

--- a/ansible/roles/world_model_service/files/app.py
+++ b/ansible/roles/world_model_service/files/app.py
@@ -1,6 +1,7 @@
 import os
 import json
 import threading
+import uvicorn
 from fastapi import FastAPI
 import paho.mqtt.client as mqtt
 
@@ -8,6 +9,7 @@ import paho.mqtt.client as mqtt
 MQTT_HOST = os.getenv("MQTT_HOST", "localhost")
 MQTT_PORT = int(os.getenv("MQTT_PORT", 1883))
 MQTT_TOPIC = os.getenv("MQTT_TOPIC", "#")
+PORT = int(os.getenv("PORT", 8000))
 
 # --- In-Memory State ---
 world_state = {}
@@ -64,3 +66,6 @@ async def startup_event():
     """Start the MQTT client in a background thread on app startup."""
     mqtt_thread = threading.Thread(target=run_mqtt_client, daemon=True)
     mqtt_thread.start()
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=PORT)

--- a/ansible/roles/world_model_service/files/requirements.txt
+++ b/ansible/roles/world_model_service/files/requirements.txt
@@ -1,3 +1,3 @@
 fastapi
-uvicorn[standard]
+uvicorn
 paho-mqtt

--- a/ansible/roles/world_model_service/world_model.nomad.j2
+++ b/ansible/roles/world_model_service/world_model.nomad.j2
@@ -12,9 +12,8 @@ job "world-model-service" {
     }
 
     network {
-      port "http" {
-        to = 8000
-      }
+      mode = "host"
+      port "http" {}
     }
 
     task "server" {
@@ -37,6 +36,7 @@ job "world-model-service" {
         MQTT_PORT = "1883"
         CONSUL_HOST = "{{ advertise_ip }}"
         CONSUL_PORT = "8500"
+        PORT = "${NOMAD_PORT_http}"
       }
 
       resources {


### PR DESCRIPTION
The `world-model-service` Nomad job was using a hardcoded port, which is inflexible. This change updates the service to use dynamic port allocation provided by Nomad.

- The Nomad job (`world_model.nomad.j2`) is now configured with `network.mode = "host"` to request a dynamic port from Nomad.
- The allocated port is passed to the application container via the `PORT` environment variable.
- The FastAPI application (`app.py`) has been updated to read the `PORT` environment variable to start its Uvicorn server on the correct port.
- The `Dockerfile` has been modified to run the application using `python app.py` and removes the now-unnecessary `EXPOSE` instruction.
- Fixed a build issue by changing `uvicorn[standard]` to `uvicorn` in `requirements.txt`.