### PR TITLE
fix(mqtt): Resolve mosquitto startup failure

### DIFF
--- a/ansible/roles/nomad/templates/nomad.hcl.client.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.client.j2
@@ -15,7 +15,7 @@ plugin "docker" {
     volumes {
       enabled = true
     }
-    allow_caps = ["NET_RAW", "NET_ADMIN"]
+    allow_caps = ["NET_RAW", "NET_ADMIN", "SETUID", "SETGID"]
   }
 }
 client {


### PR DESCRIPTION
This commit provides a complete fix for the mosquitto service failing to start due to permission errors. This was a regression that appeared after a server reboot. The issue was threefold:

1.  The host volume directory (`/opt/nomad/volumes/mqtt-data`) was owned by root, preventing the non-root `mosquitto` user inside the container from writing to it.
2.  The container runtime was preventing the mosquitto process from dropping root privileges to the `mosquitto` user, causing an "Error setting groups whilst dropping privileges" crash.
3.  The Nomad client configuration was not configured to allow the necessary capabilities for the Docker driver.

This has been resolved by:
- Adding an Ansible task to recursively `chown` the host volume to the correct UID/GID (1883).
- Adding `SETUID` and `SETGID` to the `allow_caps` list in the Nomad client configuration for the Docker plugin.
- Adding the `SETUID` and `SETGID` capabilities to the Nomad job's docker driver configuration.