### PR TITLE
fix(ansible): Correct volume ownership for mqtt job

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -194,21 +194,6 @@
     mode: '0755'
   become: yes
 
-- name: Create subdirectories for Nomad volumes
-  ansible.builtin.file:
-    path: "/opt/nomad/volumes/{{ item }}"
-    state: directory
-    owner: "{{ target_user | default('loki') }}"
-    group: "{{ target_user | default('loki') }}"
-    mode: '0755'
-  loop:
-    - mqtt-data
-    - ha-config
-    - world_model_storage
-  become: yes
-
-
-
 - name: Start and enable Nomad service
   ansible.builtin.systemd:
     name: nomad


### PR DESCRIPTION
Removed the task that incorrectly set ownership on the mqtt-data volume from the nomad role. The mqtt role is responsible for setting the correct permissions, and the nomad role was overwriting them, causing the mqtt service to fail to start.