### PR TITLE
fix(ci): Install dev dependencies for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: '3.12'
 
       - name: "Install test dependencies"
-        run: pip install requests
+        run: pip install -r requirements-dev.txt
 
       - name: "Run unit tests"
         run: python -m unittest discover testing/unit_tests


### PR DESCRIPTION
The unit test job in the CI workflow was failing because it was only installing the 'requests' package, leading to 'ModuleNotFoundError' for packages like 'pytest' and 'yaml'.

This change updates the 'test' job in the '.github/workflows/ci.yml' file to install all necessary development dependencies from 'requirements-dev.txt', aligning it with the 'lint' and 'ansible-check' jobs and ensuring the testing environment is correctly configured.