### PR TITLE
feat(nomad): Allow CHOWN capability for Docker driver

### DIFF
--- a/ansible/roles/nomad/templates/nomad.hcl.client.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.client.j2
@@ -15,7 +15,7 @@ plugin "docker" {
     volumes {
       enabled = true
     }
-    allow_caps = ["NET_RAW", "NET_ADMIN", "SETUID", "SETGID"]
+    allow_caps = ["NET_RAW", "NET_ADMIN", "SETUID", "SETGID", "CHOWN"]
   }
 }
 client {


### PR DESCRIPTION
The eclipse-mosquitto container requires the CHOWN, SETGID, and SETUID capabilities to manage file permissions and drop privileges. The Nomad client configuration was missing the CHOWN capability in its `allow_caps` list for the Docker plugin, causing the container to fail during startup.

This commit adds the "CHOWN" capability to the `allow_caps` list in the `nomad.hcl.client.j2` template, resolving the driver error and allowing the mosquitto container to be deployed successfully.