### PR TITLE
ci: Install community.general collection in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: "Install Ansible and dependencies"
         run: pip install -r requirements-dev.txt
 
+      - name: "Install Ansible collections"
+        run: ansible-galaxy collection install community.general
+
       - name: "Cache Ansible baseline"
         uses: actions/cache@v4
         id: cache-ansible-baseline


### PR DESCRIPTION
The Ansible Change Detection job was failing with exit code 4 because the 'community.general' Ansible collection was not installed. This collection provides modules used by the main playbook.

Added a step to the GitHub Actions workflow to install the collection using 'ansible-galaxy', ensuring all required modules are available during the playbook run.