### PR TITLE
fix(ci): Install ansible.posix collection in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: "Install Ansible collections"
-        run: ansible-galaxy collection install community.general
+        run: ansible-galaxy collection install community.general ansible.posix
 
       - name: "Cache Ansible baseline"
         uses: actions/cache@v4


### PR DESCRIPTION
The Ansible change detection CI job was failing with an exit code of 4. This was caused by the playbook attempting to use the `synchronize` module without the `ansible.posix` collection being installed in the CI environment.

This change adds the installation of the `ansible.posix` collection to the `ansible-check` job in the `ci.yml` workflow, resolving the failure.