### PR TITLE
fix(ansible): Ensure Nomad restarts on config change

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -121,6 +121,8 @@
     group: root
     mode: '0644'
   become: yes
+  notify:
+    - Restart nomad
 
 - name: Deploy the Nomad configuration from template
   ansible.builtin.template:
@@ -132,6 +134,8 @@
   vars:
     is_controller: "{{ true if inventory_hostname in groups['controller_nodes'] else false }}"
   become: yes
+  notify:
+    - Restart nomad
 
 - name: Create systemd override directory for Nomad service
   ansible.builtin.file:


### PR DESCRIPTION
The Nomad service was not being restarted when its configuration files were updated by Ansible. This caused the service to continue running with an old configuration, leading to errors when jobs required capabilities that were present in the new configuration but not in the old one.

This change adds a `notify` directive to the Ansible tasks that create the Nomad configuration files. This ensures that the Nomad service is restarted whenever its configuration changes, applying the new settings and preventing capability-related errors.