### PR TITLE
Fix(ansible): Correct import_playbook syntax in core_infra.yaml

### DIFF
--- a/playbooks/services/core_infra.yaml
+++ b/playbooks/services/core_infra.yaml
@@ -25,20 +25,10 @@
           - "--exclude=.git"
       when: inventory_hostname == 'localhost'
 
-  tasks:
-    - name: Import system_deps role
-      include_role:
-        name: system_deps
+  roles:
+    - role: system_deps
+    - role: common
 
-    - name: Import common role
-      include_role:
-        name: common
-
-    - name: Import Consul playbook
-      ansible.builtin.import_playbook: consul.yaml
-
-    - name: Import Docker playbook
-      ansible.builtin.import_playbook: docker.yaml
-
-    - name: Import Nomad playbook
-      ansible.builtin.import_playbook: nomad.yaml
+- ansible.builtin.import_playbook: consul.yaml
+- ansible.builtin.import_playbook: docker.yaml
+- ansible.builtin.import_playbook: nomad.yaml


### PR DESCRIPTION
Refactored the playbook to use a static 'roles' section and moved 'import_playbook' directives to the top level, resolving the "extra params" error.