### PR TITLE
Fix multiple Ansible playbook errors

### DIFF
--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -49,8 +49,15 @@
       become: true
 
     - name: Place the Docker daemon configuration file
-      ansible.builtin.template:
-        src: daemon.json.j2
+      ansible.builtin.copy:
+        content: |
+          {
+            "cgroup-driver": "systemd",
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "100m"
+            }
+          }
         dest: /etc/docker/daemon.json
         mode: '0644'
       become: true


### PR DESCRIPTION
This commit resolves several issues that were causing the Ansible playbooks to fail:

- Corrects the `import_playbook` syntax in `playbooks/services/core_infra.yaml` by moving the imports to the top level.
- Fixes the Docker daemon configuration in `ansible/roles/docker/tasks/main.yaml` by using a `copy` task with the correct `cgroup-driver` syntax to prevent interference.
- Removes the invalid `preemption` key from the Nomad client configuration in `ansible/roles/nomad/templates/nomad.hcl.client.j2`.
- Defines the `external_model_server` variable in `group_vars/all.yaml` to prevent undefined variable errors.
- Adds a conditional to the benchmark-related tasks in the `llama_cpp` role to prevent errors when benchmarking is disabled.
- Corrects the variable name passed to the `llamacpp-rpc.nomad.j2` template in `ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml` to resolve a templating error.