### PR TITLE
fix(mqtt): Purge job before running to prevent resource locks

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -39,6 +39,14 @@
     recurse: yes
   become: yes
 
+- name: Purge mqtt job
+  ansible.builtin.command:
+    cmd: nomad job stop -purge mqtt
+  environment:
+    NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
+  changed_when: true
+  ignore_errors: yes
+
 - name: Template mqtt Nomad job file
   ansible.builtin.template:
     src: mqtt.nomad.j2


### PR DESCRIPTION
Adds a task to the `mqtt` Ansible role to stop and purge any existing `mqtt` Nomad job before attempting to deploy a new one.

This prevents "Device or resource busy" errors caused by lingering volume mounts from previous, uncleared job allocations. The task is set to ignore errors so that it doesn't fail on a clean deployment where the job doesn't yet exist.