### PR TITLE
The `client.options` block for enabling task drivers was deprecated i…

### DIFF
--- a/ansible/roles/nomad/templates/nomad.hcl.client.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.client.j2
@@ -18,12 +18,21 @@ plugin "docker" {
     allow_caps = ["NET_RAW", "NET_ADMIN", "SETUID", "SETGID", "CHOWN"]
   }
 }
+
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+
+plugin "exec" {
+  config {
+    enabled = true
+  }
+}
+
 client {
   enabled = true
-  options = {
-    "driver.raw_exec.enable" = "1",
-    "driver.exec.enable"     = "1"
-  }
 
   preemption {
     enabled = true


### PR DESCRIPTION
…n Nomad v1.0 and is no longer supported in v1.7.5, causing the Nomad agent to fail on startup.

This commit replaces the deprecated `options` with the correct `plugin` block syntax for the `exec` and `raw_exec` drivers in the client configuration template.