### PR TITLE
fix(home_assistant): Set correct ownership for config volume

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -5,6 +5,15 @@
     mode: '0755'
   become: yes
 
+- name: Set ownership for Home Assistant config directory
+  ansible.builtin.file:
+    path: /opt/nomad/volumes/ha-config
+    state: directory
+    owner: "8123"
+    group: "8123"
+    recurse: yes
+  become: yes
+
 - name: Template home-assistant Nomad job file
   ansible.builtin.template:
     src: home_assistant.nomad.j2


### PR DESCRIPTION
The Home Assistant container was failing to start due to a permission error when trying to write to its /config directory. This was caused by the host volume at /opt/nomad/volumes/ha-config being owned by root.

This change adds an Ansible task to set the ownership of the host volume to UID/GID 8123, which is the default for the Home Assistant container, resolving the permission issue.