### PR TITLE
fix(ansible): Render Nomad job templates before running

### DIFF
--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -25,12 +25,18 @@
         loop_var: item
 
 
+    - name: Create Expert Orchestrator job files
+      ansible.builtin.template:
+        src: "{{ playbook_dir }}/../../ansible/jobs/expert.nomad.j2"
+        dest: "/tmp/expert-{{ item }}.nomad"
+      loop: "{{ experts }}"
+
     - name: Deploy the Expert Orchestrator services
       ansible.builtin.command: >
         nomad job run
         -var="job_name=expert-{{ item }}"
         -var="service_name=expert-api-{{ item }}"
         -var="rpc_pool_job_name=llamacpp-rpc-pool"
-                {{ playbook_dir }}/../../ansible/jobs/expert.nomad.j2
+        /tmp/expert-{{ item }}.nomad
       loop: "{{ experts }}"
       changed_when: true


### PR DESCRIPTION
The `ai_experts.yaml` playbook was failing because it passed a Jinja2 template file (`expert.nomad.j2`) directly to the `nomad job run` command. The Nomad CLI cannot parse Jinja2 syntax, leading to an "Unsupported operator" error.

This commit resolves the issue by introducing a task that uses the `ansible.builtin.template` module to render the `.j2` file into a static HCL file in the `/tmp` directory. The subsequent `nomad job run` command is updated to execute against this rendered file, ensuring Nomad receives a valid job specification.