### PR TITLE
Fix(home-assistant): Correct directory permissions to resolve startup…

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -2,7 +2,7 @@
   ansible.builtin.file:
     path: /opt/nomad/volumes/ha-config
     state: directory
-    mode: '0755'
+    mode: '0775'
   become: yes
 
 - name: Set ownership for Home Assistant config directory


### PR DESCRIPTION
… error

The Home Assistant container was failing to start due to a "Permission denied" error when attempting to create the `/config/deps` directory.

This was caused by the host directory `/opt/nomad/volumes/ha-config` having `0755` permissions, which did not grant write access to the group.

This commit changes the directory mode to `0775` in the Ansible role, allowing the container's group to write to the configuration directory and enabling Home Assistant to start correctly.