### PR TITLE
fix(ansible): Remove ignore_errors from model download tasks

### DIFF
--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -59,7 +59,6 @@
   become: yes
   loop_control:
     loop_var: item
-  ignore_errors: yes
 # ---------------------------------------------------------------------------- #
 #                                  STT Models                                  #
 # ---------------------------------------------------------------------------- #
@@ -107,7 +106,6 @@
   become: yes
   loop_control:
     loop_var: item
-  ignore_errors: yes
 # ---------------------------------------------------------------------------- #
 #                                  TTS Models                                  #
 # ---------------------------------------------------------------------------- #
@@ -135,7 +133,6 @@
   become: yes
   loop_control:
     loop_var: item
-  ignore_errors: yes
 # ---------------------------------------------------------------------------- #
 #                                 Vision Models                                #
 # ---------------------------------------------------------------------------- #
@@ -170,7 +167,6 @@
   become: yes
   loop_control:
     loop_var: item
-  ignore_errors: yes
 - name: Download all Vision models (Hub-based) if they do not exist
   ansible.builtin.command:
     cmd: >
@@ -182,7 +178,6 @@
   become: yes
   loop_control:
     loop_var: item
-  ignore_errors: yes
 # ---------------------------------------------------------------------------- #
 #                               Embedding Models                               #
 # ---------------------------------------------------------------------------- #
@@ -211,4 +206,3 @@
   become: yes
   loop_control:
     loop_var: item
-  ignore_errors: yes


### PR DESCRIPTION
The `download_models` Ansible role was silently ignoring failures in the model download tasks due to the `ignore_errors: yes` directive. This was causing the `pipecat` application to crash at startup because the required STT models were not being downloaded.

This commit removes the `ignore_errors: yes` directive from all model download tasks in the `download_models` role. This ensures that the playbook will now fail loudly if any of the model downloads fail, making it easier to diagnose and fix the underlying issue.