### PR TITLE
Fix(ansible): Remove redundant python_deps role inclusion

### DIFF
--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -34,10 +34,6 @@
       include_role:
         name: system_deps
 
-    - name: Install all python dependencies
-      include_role:
-        name: python_deps
-
     - name: Run application and configuration roles
       include_role:
         name: "{{ role_name }}"


### PR DESCRIPTION
This commit fixes a bug introduced during the refactoring of the `python_deps` role. The previous commit correctly moved the responsibility of Python dependency installation to the `pipecatapp` role, but it failed to remove an old, generic `include_role` call to `python_deps` from the main playbook (`playbooks/services/app_services.yaml`).

This outdated call did not pass the newly required `venv_path` and `requirements_path` variables, causing the playbook to fail with an "undefined variable" error.

This commit removes the incorrect and now-redundant `include_role` task, completing the refactoring and resolving the error.