### PR TITLE
fix(ansible): Resolve nomad_namespace scoping issue in pipecatapp

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -211,6 +211,7 @@
   when: verified_experts is defined and verified_experts | length > 0
   vars:
     # Define ONLY loop-specific variables here
+    nomad_namespace: "{{ nomad_namespace }}"
     job_name: "expert-{{ current_expert }}"
     service_name: "expert-api-{{ current_expert }}"
     model_list: "{{ expert_models[current_expert] | default([]) }}" # Corrected default


### PR DESCRIPTION
The 'Create expert job files from template' task was failing with an `AnsibleUndefinedVariable` error for `nomad_namespace`.

This was caused by a variable scoping issue. The `vars` block on the task created a new, local scope that shadowed the globally defined `nomad_namespace` variable.

The fix is to explicitly pass `nomad_namespace` into the task's `vars` block, making it available to the `expert.nomad.j2` template and resolving the error.