### PR TITLE
fix(ansible): Resolve multiple cascading errors in pipecatapp role

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -265,7 +265,7 @@
 
 - name: Wait for Nomad API to be ready
   ansible.builtin.uri:
-    url: "http://{{ advertise_ip }}:4646/v1/status/leader"
+    url: "http://{{ ansible_default_ipv4.address }}:4646/v1/status/leader"
     method: GET
     status_code: 200
   register: nomad_api_status
@@ -280,7 +280,7 @@
   changed_when: "pipecat_job_stop_status.rc == 0"
   failed_when: false
   environment:
-    NOMAD_ADDR: "http://{{ advertise_ip }}:4646"
+    NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
 
 - name: Flush handlers to ensure service is enabled and started
   ansible.builtin.meta: flush_handlers
@@ -289,7 +289,7 @@
   ansible.builtin.command:
     cmd: nomad job run /opt/nomad/jobs/router.nomad
   environment:
-    NOMAD_ADDR: "http://{{ advertise_ip }}:4646"
+    NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
   register: router_job_run
   changed_when: router_job_run.rc == 0
   ignore_errors: yes
@@ -298,7 +298,7 @@
   ansible.builtin.command:
     cmd: nomad job run /opt/nomad/jobs/pipecatapp.nomad
   environment:
-    NOMAD_ADDR: "http://{{ advertise_ip }}:4646"
+    NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
   register: router_job_run
   changed_when: router_job_run.rc == 0
   ignore_errors: yes


### PR DESCRIPTION
This commit addresses a series of five distinct but related errors that caused the Ansible playbook to fail.

1.  **Resolves `AnsibleUndefinedVariable` for `nomad_namespace`:** A variable scoping issue was shadowing the globally-defined `nomad_namespace` variable. The fix explicitly passes this variable into the task's local `vars` scope.

2.  **Resolves `TypeError` on `round` filter:** The `avg_tokens` variable was being treated as `AnsibleUnsafeText`. The fix is to cast the variable to a float using the `| float` filter before rounding.

3.  **Resolves `AnsibleUndefinedVariable` for `expert_benchmark_data`:** The Nomad job template (`expert.nomad.j2`) contained old logic using a non-existent variable. The fix removes this redundant logic from the template, which now correctly uses the `avg_tokens` variable provided by the task.

4.  **Resolves `AnsibleUndefinedVariable` for `rpc_pool_job_name`:** The template required the `rpc_pool_job_name` variable, which was not being provided. The fix adds this variable to the task's `vars` block with a default value.

5.  **Resolves IPv6 URL error in `uri` module:** The "Wait for Nomad API" task was failing because the `advertise_ip` variable was resolving to an unformatted IPv6 address, creating a malformed URL. The fix is to replace this variable with the `ansible_default_ipv4.address` fact in all Nomad API tasks to ensure a valid URL is always used.