### PR TITLE
fix(ansible): Enable Jinja2 'do' extension

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,6 +2,7 @@
 fact_caching = jsonfile
 fact_caching_connection = /tmp/ansible_facts_cache
 fact_caching_timeout = 86400
+jinja2_extensions = jinja2.ext.do
 local_tmp = /tmp
 system_tmpdirs = /var/tmp
 roles_path = ./ansible/roles


### PR DESCRIPTION
Enables the `jinja2.ext.do` extension in `ansible.cfg` to allow the use of `{% do %}` statements in Jinja2 templates.

This resolves a `jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'do'` error that was occurring during the execution of the `pipecatapp` role.