### PR TITLE
Fix: Refactor expert.nomad.j2 to remove unsupported 'do' tag

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -50,15 +50,17 @@ job "{{ job_name }}" {
       config {
         image = "alpine:latest"
         ports = ["http"]
-{% set args_list = [] %}
-{% do args_list.append("--expert-id=" ~ job_name) %}
-{% for model in model_list %}
-{% do args_list.append("--model=" ~ (model | to_json)) %}
-{% endfor %}
-{% do args_list.append("--rpc-pool-job-name=" ~ rpc_pool_job_name) %}
-{% do args_list.append("--avg-tokens=" ~ avg_tokens) %}
-
-        args = {{ args_list | to_json }}
+        {% set command_args = [
+          '--expert-id=' ~ job_name,
+        ] %}
+        {% for model in model_list %}
+          {% set command_args = command_args + ['--model=' ~ (model | to_json)] %}
+        {% endfor %}
+        {% set command_args = command_args + [
+          '--rpc-pool-job-name=' ~ rpc_pool_job_name,
+          '--avg-tokens=' ~ avg_tokens,
+        ] %}
+        args = {{ command_args | to_json }}
       }
 
       resources {


### PR DESCRIPTION
The `pipecatapp` role was failing with a `jinja2.exceptions.TemplateSyntaxError` for an "Encountered unknown tag 'do'".

This error occurs because the Jinja2 `do` extension is not enabled in Ansible's default templating environment.

This commit refactors the `args` list construction in the `expert.nomad.j2` template to use list concatenation instead of the `{% do ... %}` block. This achieves the same result using syntax that is compatible with the standard Jinja2 library, resolving the playbook failure.