### PR TITLE
fix(app): Sanitize faster-whisper model name to prevent HFValidationE…

### DIFF
--- a/ansible/roles/pipecatapp/files/app.py
+++ b/ansible/roles/pipecatapp/files/app.py
@@ -829,6 +829,9 @@ async def main():
     if stt_service_name == "faster-whisper":
         stt_provider = app_config.get("active_stt_provider", "faster-whisper")
         stt_model_name = app_config.get("active_stt_model_name", "tiny.en")
+        # Sanitize the model name if it contains the provider name as a prefix
+        if stt_model_name.startswith(f"{stt_provider}-"):
+            stt_model_name = stt_model_name[len(stt_provider) + 1:]
         model_path = f"/opt/nomad/models/stt/{stt_provider}/{stt_model_name}"
         stt = FasterWhisperSTTService(model_path=model_path, sample_rate=sample_rate)
         logging.info(f"Configured FasterWhisper for STT with model '{model_path}' and sample rate {sample_rate}Hz.")


### PR DESCRIPTION
…rror

The faster_whisper library was incorrectly interpreting a local model path as a Hugging Face repository ID, causing a validation error at startup. This was due to the model name in the configuration containing a redundant prefix (e.g., "faster-whisper-tiny.en").

This change adds logic to sanitize the model name by stripping the prefix before constructing the path, ensuring the correct local model directory is used and preventing the crash.