### PR TITLE
Fix(ansible): Define avg_tokens to resolve template error

### DIFF
--- a/ansible/tasks/create_expert_job.yaml
+++ b/ansible/tasks/create_expert_job.yaml
@@ -10,9 +10,10 @@
     model_list: "{{ expert_models[current_expert] | default([]) }}" # Corrected default
     worker_count: 1
     rpc_pool_job_name: "llamacpp-rpc-pool"
+    avg_tokens: "{{ (expert_benchmark_data.get(current_expert, {})).get('avg_tokens', 0) | float | round(2) }}"
     # DO NOT redefine ansible_memtotal_mb here
     current_expert_tags:
       - "expert={{ current_expert }}"
-      - "avg_tps={{ expert_benchmark_data[current_expert].avg_tokens | float | round(2) }}"
+      - "avg_tps={{ avg_tokens }}"
       - "memory_mb={{ ansible_memtotal_mb }}"
       - "models={{ model_list | map(attribute='filename') | join(',') }}"


### PR DESCRIPTION
Resolves a `TypeError` in the `expert.nomad.j2` template caused by the `avg_tokens` variable being undefined.

This change:
- Adds the `avg_tokens` variable to the `create_expert_job.yaml` task.
- Uses a robust method (`.get()`) to access benchmark data, preventing errors if data is missing for a given expert.
- Simplifies the `avg_tps` tag definition to reuse the new `avg_tokens` variable.