### PR TITLE
fix(health): Decouple health check from RAG tool

### DIFF
--- a/ansible/roles/pipecatapp/files/web_server.py
+++ b/ansible/roles/pipecatapp/files/web_server.py
@@ -134,7 +134,7 @@ async def get_status():
 @app.get("/health", summary="Health Check", description="Provides a health check endpoint. It returns a 200 OK if the agent is initialized and ready, otherwise a 503 Service Unavailable. This is used by Nomad for service health checks.", tags=["System"])
 async def get_health():
     """A health check endpoint that verifies the agent is fully initialized."""
-    if twin_service_instance and twin_service_instance.router_llm and twin_service_instance.tools.get("rag").is_ready:
+    if twin_service_instance and twin_service_instance.router_llm:
         return JSONResponse(content={"status": "ok"})
     else:
         return JSONResponse(status_code=503, content={"status": "initializing"})


### PR DESCRIPTION
The application's `/health` endpoint was returning a 503 Service Unavailable error because it was waiting for the RAG (Retrieval-Augmented Generation) tool to become ready.

The RAG tool's initialization is a long-running process that involves scanning the file system and building a FAISS index. This was causing the health check to fail, even when the core components of the application were ready.

This change decouples the health check from the RAG tool's readiness. The `/health` endpoint now returns a 200 OK as long as the main service instance and its router LLM are initialized. This ensures that the service is considered healthy by the orchestrator (e.g., Nomad) while the RAG tool continues to build its knowledge base in the background.