### PR TITLE
fix(ansible): Add health checks for pipecat and expert jobs

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -303,6 +303,17 @@
   changed_when: router_job_run.rc == 0
   ignore_errors: yes
 
+- name: Wait for the pipecat-app service to be healthy in Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8500/v1/health/service/pipecat-app"
+    return_content: yes
+  register: pipecat_health
+  until: >
+    pipecat_health.json is defined and
+    pipecat_health.json | map(attribute='Checks') | flatten | selectattr('Status', 'equalto', 'passing') | list | length > 0
+  retries: 60
+  delay: 10
+  changed_when: false
 
 - name: Wait for the router service to be healthy in Consul
   ansible.builtin.uri:

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -150,3 +150,17 @@
       loop: "{{ experts }}"
       changed_when: true
       when: benchmark_results is defined
+
+    - name: Wait for the expert services to be healthy in Consul
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:8500/v1/health/service/expert-api-{{ item }}"
+        return_content: yes
+      register: expert_health
+      until: >
+        expert_health.json is defined and
+        expert_health.json | map(attribute='Checks') | flatten | selectattr('Status', 'equalto', 'passing') | list | length > 0
+      retries: 60
+      delay: 10
+      loop: "{{ experts }}"
+      changed_when: false
+      when: benchmark_results is defined


### PR DESCRIPTION
The `bootstrap.sh` script was failing because the `pipecat-app` and `expert` Nomad jobs were not becoming healthy before the progress deadline was exceeded.

This was due to a race condition where the Ansible playbook did not wait for the services to be fully initialized before proceeding.

This change adds explicit health checks to the `pipecatapp` role and the `ai_experts.yaml` playbook. The playbooks now poll the Consul health API and wait for the services to report a "passing" status before continuing. This ensures that the services are fully started and healthy, resolving the timeout issue.