### PR TITLE
fix(ansible): Fix Home Assistant container permissions

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -39,10 +39,10 @@ job "home-assistant" {
     }
 
     task "home-assistant" {
+      user = "{{ ansible_user_id }}"
       driver = "docker"
 
       config {
-        user = "{{ ansible_user_id }}"
         image = "homeassistant/home-assistant:stable"
         ports = ["http"]
         volumes = [


### PR DESCRIPTION
Resolves a `PermissionError` on startup by ensuring the Home Assistant container runs with the same UID as the owner of the host volume.

- Removes the Ansible task that incorrectly attempted to `chown` the configuration directory to a hardcoded UID.
- Modifies the Nomad job template to explicitly set the container's `user` at the `task` level, which is the correct syntax for the Nomad Docker driver.

This makes the permissions robust and dynamic, avoiding issues with UID mismatches between the host and the container.