### PR TITLE
fix(ci): Pass arguments to ansible_diff.sh

### DIFF
--- a/scripts/test_playbooks_dry_run.sh
+++ b/scripts/test_playbooks_dry_run.sh
@@ -19,7 +19,7 @@ PLAYBOOKS=(
 # Run the tests
 for playbook in "${PLAYBOOKS[@]}"; do
     echo "Testing playbook: $playbook"
-    ./scripts/ansible_diff.sh "$playbook"
+    ./scripts/ansible_diff.sh "$playbook" "$@"
 done
 
 echo "All playbooks tested successfully!"


### PR DESCRIPTION
The ansible_diff.sh script was not receiving the --update-baseline flag from the ci_ansible_check.sh script because the test_playbooks_dry_run.sh script was not forwarding its arguments. This change ensures that arguments are passed through, allowing the CI to create baseline logs when they are missing.