### PR TITLE
Fix linting errors in YAML and Markdown files

### DIFF
--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -80,7 +80,7 @@
     mode: '0644'
   become: true
   notify: Restart Docker
-  
+
 - name: Ensure Docker service is started and enabled
   ansible.builtin.systemd:
     name: docker

--- a/playbooks/services/core_infra.yaml
+++ b/playbooks/services/core_infra.yaml
@@ -33,4 +33,3 @@
   roles:
     - system_deps
     - common
-

--- a/prompt_engineering/agents/architecture_review.md
+++ b/prompt_engineering/agents/architecture_review.md
@@ -24,5 +24,5 @@ This agent can delegate tasks to specialized sub-agents to handle specific aspec
 
 ## Backing LLM Model
 
-* **Model:** `claude-3-opus`
-* **Reasoning:** A powerful model is essential for this agent to understand the complexities of software architecture, reason about abstract design principles, and provide insightful recommendations. The ability to process large amounts of code is also critical.
+- **Model:** `claude-3-opus`
+- **Reasoning:** A powerful model is essential for this agent to understand the complexities of software architecture, reason about abstract design principles, and provide insightful recommendations. The ability to process large amounts of code is also critical.

--- a/prompt_engineering/agents/code_clean_up.md
+++ b/prompt_engineering/agents/code_clean_up.md
@@ -24,5 +24,5 @@ This agent can delegate tasks to specialized sub-agents to handle specific aspec
 
 ## Backing LLM Model
 
-* **Model:** `claude-3-sonnet`
-* **Reasoning:** While still a very capable model, `claude-3-sonnet` offers a good balance of performance and efficiency for tasks like refactoring and code cleanup that are often less complex than initial architecture or debugging. This makes it a cost-effective choice for this role.
+- **Model:** `claude-3-sonnet`
+- **Reasoning:** While still a very capable model, `claude-3-sonnet` offers a good balance of performance and efficiency for tasks like refactoring and code cleanup that are often less complex than initial architecture or debugging. This makes it a cost-effective choice for this role.

--- a/prompt_engineering/agents/debug_and_analysis.md
+++ b/prompt_engineering/agents/debug_and_analysis.md
@@ -25,5 +25,5 @@ This agent can delegate tasks to specialized sub-agents to handle specific aspec
 
 ## Backing LLM Model
 
-* **Model:** `claude-3-opus`
-* **Reasoning:** Debugging and analysis require strong logical deduction, pattern recognition, and problem-solving skills. A powerful model is essential for this agent to effectively diagnose complex issues and devise effective solutions.
+- **Model:** `claude-3-opus`
+- **Reasoning:** Debugging and analysis require strong logical deduction, pattern recognition, and problem-solving skills. A powerful model is essential for this agent to effectively diagnose complex issues and devise effective solutions.

--- a/prompt_engineering/agents/new_task_review.md
+++ b/prompt_engineering/agents/new_task_review.md
@@ -24,5 +24,5 @@ This agent can delegate tasks to specialized sub-agents to handle specific aspec
 
 ## Backing LLM Model
 
-* **Model:** `claude-3-opus`
-* **Reasoning:** This agent needs a powerful model to understand the nuances of code quality, identify potential issues, and provide constructive feedback. The ability to reason about code and its implications is crucial for this role.
+- **Model:** `claude-3-opus`
+- **Reasoning:** This agent needs a powerful model to understand the nuances of code quality, identify potential issues, and provide constructive feedback. The ability to reason about code and its implications is crucial for this role.

--- a/prompt_engineering/agents/problem_scope_framing.md
+++ b/prompt_engineering/agents/problem_scope_framing.md
@@ -24,5 +24,5 @@ This agent can delegate tasks to specialized sub-agents to handle specific aspec
 
 ## Backing LLM Model
 
-* **Model:** `claude-3-opus`
-* **Reasoning:** This agent requires a powerful and nuanced model to understand complex user requests, reason about code, and formulate insightful clarifying questions. The larger context window is also beneficial for analyzing large codebases.
+- **Model:** `claude-3-opus`
+- **Reasoning:** This agent requires a powerful and nuanced model to understand complex user requests, reason about code, and formulate insightful clarifying questions. The larger context window is also beneficial for analyzing large codebases.


### PR DESCRIPTION
This commit addresses several linting issues that were causing the CI build to fail:

- Removes a trailing space in `ansible/roles/docker/tasks/main.yaml`.
- Removes an extra blank line at the end of `playbooks/services/core_infra.yaml`.
- Changes the unordered list style from asterisks to dashes in all markdown files under `prompt_engineering/agents/` to comply with markdownlint rules.