### PR TITLE
fix(home-assistant): Set correct ownership on config directory

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -2,8 +2,9 @@
   ansible.builtin.file:
     path: /opt/nomad/volumes/ha-config
     state: directory
-
-    mode: '0777'
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0755'
   become: yes
 
 - name: Template home-assistant Nomad job file


### PR DESCRIPTION
The Home Assistant container was failing to start due to a `PermissionError` when trying to create a lock file in its `/config` directory.

This was caused by the host directory, mounted at `/config`, being owned by `root`, while the container process ran as the non-root `ansible_user`.

This commit fixes the issue by updating the Ansible task that creates the host directory (`/opt/nomad/volumes/ha-config`) to set the `owner` and `group` to the `ansible_user`. It also tightens the directory permissions from `0777` to a more secure `0755`.