### PR TITLE
fix(nomad): Correct pipecat-app health check address mode

### DIFF
--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -16,10 +16,11 @@ job "{{ job_name | default('pipecat-app') }}" {
       provider = "consul"
 
       check {
-        type     = "http"
-        path     = "/health"
-        interval = "10s"
-        timeout  = "2s"
+        type         = "http"
+        path         = "/health"
+        interval     = "10s"
+        timeout      = "2s"
+        address_mode = "host"
       }
     }
 


### PR DESCRIPTION
Set address_mode to "host" in the pipecat-app Nomad job to ensure the health check targets the host's IP address.

This is necessary when the service is configured with `network { mode = "host" }`, as the default health check behavior would otherwise attempt to connect to the allocation's internal IP, which is not the correct address for a host-networked service. This change resolves the failing health check and allows the service to become healthy in Consul.