### PR TITLE
fix(nomad): Correct health check address mode for host networking

### DIFF
--- a/ansible/jobs/router.nomad.j2
+++ b/ansible/jobs/router.nomad.j2
@@ -26,11 +26,12 @@ job "router" {
       port     = "http"
 
       check {
-        type     = "http"
-        port     = "http"
-        path     = "/health"
-        interval = "15s"
-        timeout  = "5s"
+        type         = "http"
+        port         = "http"
+        path         = "/health"
+        interval     = "15s"
+        timeout      = "5s"
+        address_mode = "host"
       }
     }
 


### PR DESCRIPTION
Sets `address_mode = "host"` in the health checks for both the `pipecat-app` and `router` Nomad jobs.

When a service uses `network { mode = "host" }`, the health check must target the host's IP address, not the allocation's internal IP. This change ensures that Consul can correctly monitor the health of these services, resolving the deployment failures.