### PR TITLE
fix(pipecat): Correct model path and unify deployment

### DIFF
--- a/group_vars/models.yaml
+++ b/group_vars/models.yaml
@@ -74,13 +74,13 @@ stt_models:
       url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin"
       filename: "ggml-large-v3.bin"
   faster-whisper:
-    - name: "faster-whisper-tiny.en"
+    - name: "tiny.en"
       repo_id: "Systran/faster-whisper-tiny.en"
 
 
 # The provider and name of the STT model to be used by the pipecat-app
 active_stt_provider: "faster-whisper"
-active_stt_model_name: "faster-whisper-tiny.en"
+active_stt_model_name: "tiny.en"
 
 # Vision models
 vision_models:


### PR DESCRIPTION
This commit resolves a critical deployment failure for the `pipecat-app` service and refactors the deployment process for improved flexibility and maintainability.

The primary fix corrects a "Model directory not found" error by renaming the `faster-whisper-tiny.en` model to `tiny.en` in `group_vars/models.yaml`. This aligns the model name with the path expected by the application, allowing the STT service to initialize correctly and the application to become healthy.

This commit also includes the following refactoring:
- Unifies the `pipecat-app` deployment to support both `raw_exec` and `docker` modes, controlled by a new `pipecat_deployment_style` Ansible variable.
- Moves the Docker build process from `bootstrap.sh` into a conditional task in the `pipecat` Ansible role.
- Consolidates multiple `start_pipecat.sh` scripts into a single, unified Jinja2 template.
- Includes a fix for the Nomad service health checks by setting `address_mode = "host"` for both `pipecat-app` and `router` services.