### PR TITLE
refactor(pipecat): Unify deployment, fix model paths, and switch STT …

### DIFF
--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -47,6 +47,7 @@ job "{{ job_name | default('pipecat-app') }}" {
 
       config {
         image = "pipecatapp:latest"
+        force_pull = false
         ports = ["http"]
         # Mount volumes for models and config. Models are read-only.
         # Assumes /app is the WORKDIR in the container, where pipecat_config.json will be placed.

--- a/group_vars/models.yaml
+++ b/group_vars/models.yaml
@@ -79,8 +79,8 @@ stt_models:
 
 
 # The provider and name of the STT model to be used by the pipecat-app
-active_stt_provider: "faster-whisper"
-active_stt_model_name: "tiny.en"
+active_stt_provider: "whisper.cpp"
+active_stt_model_name: "whisper-large-v3"
 
 # Vision models
 vision_models:


### PR DESCRIPTION
…provider

This commit resolves a critical deployment failure for the `pipecat-app` service, refactors the deployment process for improved flexibility and maintainability, and switches the active STT provider from `faster-whisper` to `whisper.cpp`.

Key changes:
- Switches the `active_stt_provider` to `whisper.cpp` and sets the `active_stt_model_name` to `whisper-large-v3` in `group_vars/models.yaml`.
- Corrects a "Model directory not found" error by renaming the `faster-whisper-tiny.en` model to `tiny.en` to align the model name with the path expected by the application.
- Adds `force_pull = false` to the Docker driver config to ensure Nomad uses the locally-built image.
- Unifies the `pipecat-app` deployment to support both `raw_exec` and `docker` modes, controlled by a new `pipecat_deployment_style` Ansible variable.
- Moves the Docker image build process from `bootstrap.sh` into a conditional task in the `pipecat` Ansible role.
- Consolidates three different `start_pipecat.sh` scripts into a single, unified Jinja2 template with conditional logic for logging.
- Deletes the now-redundant static Nomad job file and startup scripts.
- Includes a fix for the Nomad service health checks by setting `address_mode = "host"` for both `pipecat-app` and `router` services.

This refactoring centralizes the deployment logic within Ansible, removes redundant files, and provides a more robust and maintainable system.