### PR TITLE
The MQTT service was inaccessible from external clients because it wa…

### DIFF
--- a/ansible/roles/mqtt/templates/mqtt.nomad.j2
+++ b/ansible/roles/mqtt/templates/mqtt.nomad.j2
@@ -7,7 +7,7 @@ job "mqtt" {
 
     network {
       port "mqtt" {
-        to = 1883
+        static = 1883
       }
       port "ws" {
         to = 9001


### PR DESCRIPTION
…s using a dynamic port mapping. This change updates the Nomad job to use a static port, ensuring the service is always available on port 1883.