### PR TITLE
feat: Create dedicated user for the application

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -193,8 +193,8 @@
   ansible.builtin.file:
     path: /opt/pipecatapp
     state: directory
-    owner: "{{ target_user | default('loki') }}"
-    group: "{{ target_user | default('loki') }}"
+    owner: "{{ target_user | default('pipecatapp') }}"
+    group: "{{ target_user | default('pipecatapp') }}"
     mode: '0755'
   become: yes
 
@@ -202,8 +202,8 @@
   ansible.builtin.file:
     path: /opt/nomad/volumes
     state: directory
-    owner: "{{ target_user | default('loki') }}"
-    group: "{{ target_user | default('loki') }}"
+    owner: "{{ target_user | default('pipecatapp') }}"
+    group: "{{ target_user | default('pipecatapp') }}"
     mode: '0755'
   become: yes
 
@@ -211,8 +211,8 @@
   ansible.builtin.file:
     path: "/opt/nomad/volumes/{{ item }}"
     state: directory
-    owner: "{{ target_user | default('loki') }}"
-    group: "{{ target_user | default('loki') }}"
+    owner: "{{ target_user | default('pipecatapp') }}"
+    group: "{{ target_user | default('pipecatapp') }}"
     mode: '0755'
   loop:
     - mqtt-data

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -91,12 +91,12 @@ ls -l /opt/pipecatapp
 # --- Build Ansible arguments ---
 if [ "$UPDATE_USER" = true ]; then
     echo "--user flag detected, updating user"
-    ANSIBLE_ARGS+=(--extra-vars "target_user=loki")
+    ANSIBLE_ARGS+=(--extra-vars "target_user=pipecatapp")
 else
     # FIXED: This was a conflicting 'if' block before
     echo "--user flag not detected, using default"
-    ANSIBLE_ARGS+=(--extra-vars "target_user=loki")
-    # (If the default is different, change 'loki' here, or remove the 'else' block)
+    ANSIBLE_ARGS+=(--extra-vars "target_user=pipecatapp")
+    # (If the default is different, change 'pipecatapp' here, or remove the 'else' block)
 fi
 
 # FIXED: Correct 'if' statement spacing

--- a/deploy_app.yaml
+++ b/deploy_app.yaml
@@ -1,13 +1,13 @@
 - name: Deploy Pipecat App
   hosts: all
-  remote_user: "{{ target_user | default('loki') }}"
+  remote_user: "{{ target_user | default('pipecatapp') }}"
   become: yes
 
   vars_files:
     - group_vars/models.yaml
 
   vars:
-    target_user: "loki"
+    target_user: "pipecatapp"
 
   roles:
     - role: pipecatapp

--- a/fix_cluster.yaml
+++ b/fix_cluster.yaml
@@ -96,7 +96,7 @@
       ansible.builtin.include_role:
         name: nomad
       vars:
-        target_user: loki
+        target_user: pipecatapp
 
     - name: Start Consul service
       ansible.builtin.service:

--- a/heal_cluster.yaml
+++ b/heal_cluster.yaml
@@ -9,7 +9,7 @@
     - group_vars/models.yaml
 
   vars:
-    target_user: "loki"
+    target_user: "pipecatapp"
 
   tasks:
     - name: Ensure llamacpp-rpc job is running

--- a/host_vars/localhost.yaml
+++ b/host_vars/localhost.yaml
@@ -1,4 +1,4 @@
-target_user: loki
+target_user: pipecatapp
 # BEGIN ANSIBLE MANAGED BLOCK
 mac_address: "bc:5f:f4:44:2f:0e"
 # END ANSIBLE MANAGED BLOCK

--- a/testing/test_run.sh
+++ b/testing/test_run.sh
@@ -589,7 +589,7 @@ cd whisper.cpp/
   135  sudo cat munge/munge.key
   136  cd ~
   137  ls
-  138  scp ./munge.key loki@pop-os:~/
+  138  scp ./munge.key pipecatapp@pop-os:~/
   139  ls
   140  cd llama.cpp/
   141  ls


### PR DESCRIPTION
Creates a dedicated user `pipecatapp` for the application to run under. This improves security and isolates the application's files.

- Updates the `bootstrap.sh` script to set the `target_user` variable to `pipecatapp`.
- The `common_setup.yaml` playbook dynamically creates the user specified by the `target_user` variable.
- Replaces all other hardcoded "loki" user references with "pipecatapp" throughout the codebase.