### PR TITLE
Add playbooks for cluster status and node promotion

### DIFF
--- a/playbooks/cluster_status.yaml
+++ b/playbooks/cluster_status.yaml
@@ -1,0 +1,41 @@
+---
+- hosts: localhost
+  gather_facts: no
+  become: no
+
+  vars:
+    consul_api_url: "http://127.0.0.1:8500/v1/agent/members"
+    nomad_api_url: "http://127.0.0.1:4646/v1/nodes"
+
+  tasks:
+    - name: "Check Consul Cluster Members"
+      ansible.builtin.uri:
+        url: "{{ consul_api_url }}"
+      register: consul_members_result
+
+    - name: "Parse Consul Members"
+      ansible.builtin.set_fact:
+        consul_servers: "{{ consul_members_result.json | selectattr('Tags.role', 'equalto', 'consul') | list }}"
+        consul_clients: "{{ consul_members_result.json | selectattr('Tags.role', 'ne', 'consul') | list }}"
+
+    - name: "Check Nomad Cluster Members"
+      ansible.builtin.uri:
+        url: "{{ nomad_api_url }}"
+      register: nomad_nodes_result
+
+    - name: "Parse Nomad Members"
+      ansible.builtin.set_fact:
+        nomad_servers: "{{ nomad_nodes_result.json | selectattr('Server', 'equalto', true) | list }}"
+        nomad_clients: "{{ nomad_nodes_result.json | selectattr('Server', 'equalto', false) | list }}"
+
+    - name: "Display Cluster Status"
+      ansible.builtin.debug:
+        msg: |
+          --- Cluster Status ---
+          Consul:
+            - Servers: {{ consul_servers | length }}
+            - Clients: {{ consul_clients | length }}
+          Nomad:
+            - Servers: {{ nomad_servers | length }}
+            - Clients: {{ nomad_clients | length }}
+          ----------------------

--- a/playbooks/promote_to_controller.yaml
+++ b/playbooks/promote_to_controller.yaml
@@ -1,0 +1,27 @@
+---
+- hosts: all
+  become: yes
+  gather_facts: yes
+
+  tasks:
+    - name: "Promote Node to Controller"
+      ansible.builtin.debug:
+        msg: "Promoting {{ inventory_hostname }} to a controller."
+
+    - name: "Re-configure Consul as a Server"
+      ansible.builtin.include_role:
+        name: consul
+      vars:
+        consul_mode: "server"
+        consul_server: true
+
+    - name: "Re-configure Nomad as a Server"
+      ansible.builtin.include_role:
+        name: nomad
+      vars:
+        nomad_mode: "server"
+        nomad_server: true
+
+    - name: "Promotion Complete"
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} has been promoted to a controller. Please allow a few minutes for the cluster to stabilize."


### PR DESCRIPTION
This change introduces two new foundational playbooks for cluster management, as part of a larger effort to enable more dynamic and automated cluster operations.

- `playbooks/cluster_status.yaml`: This playbook queries the Consul and Nomad APIs to provide a high-level, node-oriented summary of the cluster's health. It reports the number of active servers and clients for both services.

- `playbooks/promote_to_controller.yaml`: This playbook is designed to re-provision an existing worker node as a controller. It does this by re-running the `consul` and `nomad` roles on the target node with variables that configure them in "server" mode.