### PR TITLE
Fix: Correctly get Home Assistant container user ID

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -52,14 +52,21 @@
   async: 300 # Max runtime for the command itself (submit shouldn't take long)
   poll: 0    # Fire and forget - don't wait for command completion
 
-- name: DEBUG - Get Home Assistant container user ID
+- name: Get Home Assistant allocation ID
+  ansible.builtin.shell:
+    cmd: nomad job status -t "{{ '{{' }} .ID {{ '}}' }}" home-assistant | head -n 1
+  register: ha_alloc_id
+  changed_when: false
+  become: no
+
+- name: Get Home Assistant container user ID
   ansible.builtin.command:
-    cmd: nomad alloc exec -task home-assistant $(nomad job status -t "{{ '{{' }} .ID {{ '}}' }}" home-assistant | head -n 1) -- stat -c '%u:%g' /
+    cmd: "nomad alloc exec -task home-assistant {{ ha_alloc_id.stdout }} -- stat -c '%u:%g' /"
   register: ha_user_id
   changed_when: false
   become: no
   ignore_errors: true
 
-- name: DEBUG - Display Home Assistant container user ID
+- name: Display Home Assistant container user ID
   ansible.builtin.debug:
     var: ha_user_id.stdout


### PR DESCRIPTION
The Ansible task to get the Home Assistant container user ID was failing because it used shell-specific command substitution (`$()`) within an `ansible.builtin.command` task, which does not run in a shell.

This change refactors the single failing task into two more robust tasks:
1.  An `ansible.builtin.shell` task is used to correctly capture the Nomad allocation ID.
2.  An `ansible.builtin.command` task then uses the captured allocation ID to execute the `nomad alloc exec` command.

This approach is more readable, reliable, and follows Ansible best practices.