### PR TITLE
Fix: Use nocache to force Docker image rebuild

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -176,8 +176,8 @@
     tag: local
     build:
       path: "{{ playbook_dir }}/../../docker/pipecatapp"
+      nocache: true
     source: build
-    force_rebuild: true
   when: pipecat_deployment_style == 'docker'
 
 - name: Ensure Nomad jobs directory exists


### PR DESCRIPTION
Replaced the unsupported `force_rebuild` parameter with the correct `build: { nocache: true }` in the `community.docker.docker_image` task. This ensures the Docker image is rebuilt on every Ansible run as intended.