### PR TITLE
fix(home-assistant): Resolve container permission error

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -2,8 +2,8 @@
   ansible.builtin.file:
     path: /opt/nomad/volumes/ha-config
     state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
+    owner: "{{ home_assistant_uid | default(1000) }}"
+    group: "{{ home_assistant_gid | default(1000) }}"
     mode: '0755'
   become: yes
 

--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -39,7 +39,6 @@ job "home-assistant" {
     }
 
     task "home-assistant" {
-      user = "{{ ansible_user_id }}"
       driver = "docker"
 
       config {


### PR DESCRIPTION
Removes the user override from the Nomad job and sets the host directory ownership to match the container's default UID/GID.

This prevents the `PermissionError: [Errno 13] Permission denied: '/config/.ha_run.lock'` that occurs when Home Assistant tries to start.