### PR TITLE
Fix(ansible): Exclude router from AI expert deployment

### DIFF
--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -11,7 +11,7 @@
 
 
   vars:
-    experts: "{{ expert_models.keys() | list }}"
+    experts: "{{ expert_models.keys() | reject('equalto', 'router') | list }}"
     expected_worker_count: "{{ ((groups['workers'] | default([]) | length) if (groups['workers'] | default([]) | length) > 0 else 1) | int }}"
     # This creates a new list containing only the first model object from each expert's list.
     # The template needs the full object (name, filename, memory_mb, etc.), not just the name.


### PR DESCRIPTION
The `playbooks/services/ai_experts.yaml` playbook was hanging during the "Deploy the Expert Orchestrator services" task. This was caused by the playbook incorrectly attempting to deploy the `router` job, which is a special case and is handled by a different part of the deployment process.

This change modifies the playbook to explicitly exclude the `router` from the list of experts it deploys, preventing the misconfigured job from being created and resolving the hang.