### PR TITLE
Fix(ansible): Use short-form argument for rpc-server

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad.j2
+++ b/ansible/jobs/llamacpp-rpc.nomad.j2
@@ -56,7 +56,7 @@ job "{{ job_name | default('llamacpp-rpc-pool') }}" {
         command = "/bin/bash"
         args = [
           "-c",
-          "/usr/local/bin/rpc-server --model /opt/nomad/models/llm/{{ model.filename }} -H 0.0.0.0 -p $NOMAD_PORT_rpc"
+          "/usr/local/bin/rpc-server -m /opt/nomad/models/llm/{{ model.filename }} -H 0.0.0.0 -p $NOMAD_PORT_rpc"
         ]
       }
 


### PR DESCRIPTION
The `rpc-server` executable from `llama.cpp` was updated and now requires the short-form `-m` argument to specify the model file. The previous long-form `--model` argument was causing the server to fail on startup, leading to Nomad job failures with a "progress deadline exceeded" error.

This commit updates the `llamacpp-rpc.nomad.j2` template to use the correct `-m` argument, ensuring the `rpc-server` starts successfully.