### PR TITLE
Fix(ansible): Disable GPU offloading for rpc-server

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad.j2
+++ b/ansible/jobs/llamacpp-rpc.nomad.j2
@@ -56,7 +56,7 @@ job "{{ job_name | default('llamacpp-rpc-pool') }}" {
         command = "/bin/bash"
         args = [
           "-c",
-          "/usr/local/bin/rpc-server -m /opt/nomad/models/llm/{{ model.filename }} -H 0.0.0.0 -p $NOMAD_PORT_rpc"
+          "/usr/local/bin/rpc-server -m /opt/nomad/models/llm/{{ model.filename }} -H 0.0.0.0 -p $NOMAD_PORT_rpc -ngl 0"
         ]
       }
 


### PR DESCRIPTION
The `rpc-server` from `llama.cpp` now defaults to offloading model layers to a GPU. However, the Ansible role that builds the executable does not enable GPU support, causing the `rpc-server` to crash on startup when it fails to find a GPU backend. This leads to Nomad job failures with a "progress deadline exceeded" error.

This commit adds the `-ngl 0` flag to the `rpc-server` command in the `llamacpp-rpc.nomad.j2` template. This explicitly disables GPU offloading, forcing the server to run in CPU-only mode and preventing the crash.