### PR TITLE
Fix(home-assistant): Correct user parameter location in Nomad job

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -41,6 +41,8 @@ job "home-assistant" {
     task "home-assistant" {
       driver = "docker"
 
+      user = "{{ home_assistant_uid | default(1000) }}:{{ home_assistant_gid | default(1000) }}"
+
       config {
         image = "homeassistant/home-assistant:stable"
         ports = ["http"]
@@ -48,7 +50,6 @@ job "home-assistant" {
           "/etc/localtime:/etc/localtime:ro",
         ]
         cap_add = ["NET_RAW", "NET_ADMIN"]
-        user    = "{{ home_assistant_uid | default(1000) }}:{{ home_assistant_gid | default(1000) }}"
       }
 
       env {


### PR DESCRIPTION
The 'user' parameter in the Home Assistant Nomad job was incorrectly placed inside the 'config' block. According to the Nomad documentation, it should be a direct child of the 'task' block.

This change moves the 'user' parameter to the correct location, resolving the Nomad job validation error.