### PR TITLE
fix(nomad): set address_mode for host network health check

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad.j2
+++ b/ansible/jobs/llamacpp-rpc.nomad.j2
@@ -43,9 +43,10 @@ job "{{ job_name | default('llamacpp-rpc-pool') }}" {
       # --- END TAGS ---
 
       check {
-        type     = "tcp"
-        interval = "15s"
-        timeout  = "5s"
+        type         = "tcp"
+        interval     = "15s"
+        timeout      = "5s"
+        address_mode = "host"
       }
     }
 

--- a/playbook_output.log.before_changes
+++ b/playbook_output.log.before_changes
@@ -1,0 +1,2993 @@
+[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
+[DEPRECATION WARNING]: DEFAULT_JINJA2_EXTENSIONS option. Reason: Jinja2 extensions have been deprecated
+Alternatives: Ansible-supported Jinja plugins (tests, filters, lookups). This feature will be removed from ansible-core version 2.23.
+
+ansible-playbook [core 2.20.0]
+  config file = /app/ansible.cfg
+  configured module search path = ['/home/jules/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
+  ansible python module location = /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible
+  ansible collection location = /home/jules/.ansible/collections:/usr/share/ansible/collections
+  executable location = /home/jules/.pyenv/versions/3.12.12/bin/ansible-playbook
+  python version = 3.12.12 (main, Oct 10 2025, 18:25:30) [GCC 13.3.0] (/home/jules/.pyenv/versions/3.12.12/bin/python)
+  jinja version = 3.1.6
+  pyyaml version = 6.0.3 (with libyaml v0.2.5)
+Using /app/ansible.cfg as config file
+setting up inventory plugins
+Loading collection ansible.builtin from
+host_list declined parsing /app/local_inventory.ini as it did not pass its verify_file() method
+script declined parsing /app/local_inventory.ini as it did not pass its verify_file() method
+auto declined parsing /app/local_inventory.ini as it did not pass its verify_file() method
+yaml declined parsing /app/local_inventory.ini as it did not pass its verify_file() method
+Set default localhost to localhost
+Parsed /app/local_inventory.ini inventory source with ini plugin
+Read `vars_file` '/app/group_vars/all.yaml'.
+Loading callback plugin default of type stdout, v2.0 from /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/plugins/callback/default.py
+Skipping callback 'minimal', as we already have a stdout callback.
+Skipping callback 'oneline', as we already have a stdout callback.
+
+PLAYBOOK: consul.yaml **********************************************************
+Positional arguments: /app/playbooks/services/consul.yaml
+verbosity: 4
+connection: ssh
+become: True
+become_method: sudo
+tags: ('all',)
+inventory: ('/app/local_inventory.ini',)
+extra_vars: ('target_user=pipecatapp', 'external_model_server=true')
+forks: 5
+1 plays in /app/playbooks/services/consul.yaml
+Read `vars_file` '/app/group_vars/all.yaml'.
+Read `vars_file` '/app/group_vars/all.yaml'.
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+PLAY [Deploy Consul] ***********************************************************
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [Gathering Facts] *********************************************************
+task path: /app/playbooks/services/consul.yaml:1
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746103.4950888-3588-190761990605479 `" && echo ansible-tmp-1762746103.4950888-3588-190761990605479="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746103.4950888-3588-190761990605479 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/setup.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmp0djh4_hy TO /home/jules/.ansible/tmp/ansible-tmp-1762746103.4950888-3588-190761990605479/AnsiballZ_setup.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746103.4950888-3588-190761990605479/ /home/jules/.ansible/tmp/ansible-tmp-1762746103.4950888-3588-190761990605479/AnsiballZ_setup.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-wtrurslsvvrxzbathhvhaxwcwsfvbqef ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746103.4950888-3588-190761990605479/AnsiballZ_setup.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746103.4950888-3588-190761990605479/ > /dev/null 2>&1 && sleep 0'
+ok: [localhost]
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [consul : Install unzip] **************************************************
+task path: /app/ansible/roles/consul/tasks/main.yaml:1
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746104.7860367-3668-251793959700266 `" && echo ansible-tmp-1762746104.7860367-3668-251793959700266="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746104.7860367-3668-251793959700266 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/apt.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmplsve4dd7 TO /home/jules/.ansible/tmp/ansible-tmp-1762746104.7860367-3668-251793959700266/AnsiballZ_apt.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746104.7860367-3668-251793959700266/ /home/jules/.ansible/tmp/ansible-tmp-1762746104.7860367-3668-251793959700266/AnsiballZ_apt.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-egllnslgmkubpgahhzxzrzzipjcytzhf ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746104.7860367-3668-251793959700266/AnsiballZ_apt.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746104.7860367-3668-251793959700266/ > /dev/null 2>&1 && sleep 0'
+ok: [localhost] => {
+    "cache_update_time": 1760123273,
+    "cache_updated": false,
+    "changed": false,
+    "invocation": {
+        "module_args": {
+            "allow_change_held_packages": false,
+            "allow_downgrade": false,
+            "allow_unauthenticated": false,
+            "auto_install_module_deps": true,
+            "autoclean": false,
+            "autoremove": false,
+            "cache_valid_time": 0,
+            "clean": false,
+            "deb": null,
+            "default_release": null,
+            "dpkg_options": "force-confdef,force-confold",
+            "fail_on_autoremove": false,
+            "force": false,
+            "force_apt_get": false,
+            "install_recommends": null,
+            "lock_timeout": 60,
+            "name": "unzip",
+            "only_upgrade": false,
+            "package": [
+                "unzip"
+            ],
+            "policy_rc_d": null,
+            "purge": false,
+            "state": "present",
+            "update_cache": null,
+            "update_cache_retries": 5,
+            "update_cache_retry_max_delay": 12,
+            "upgrade": null
+        }
+    }
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [consul : Download Consul] ************************************************
+task path: /app/ansible/roles/consul/tasks/main.yaml:7
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746108.6066394-3703-141845909399453 `" && echo ansible-tmp-1762746108.6066394-3703-141845909399453="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746108.6066394-3703-141845909399453 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/command.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmp2cxdb0_j TO /home/jules/.ansible/tmp/ansible-tmp-1762746108.6066394-3703-141845909399453/AnsiballZ_command.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746108.6066394-3703-141845909399453/ /home/jules/.ansible/tmp/ansible-tmp-1762746108.6066394-3703-141845909399453/AnsiballZ_command.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-jgpjymigzhqennuvobjtodbprwhshiqi ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746108.6066394-3703-141845909399453/AnsiballZ_command.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746108.6066394-3703-141845909399453/ > /dev/null 2>&1 && sleep 0'
+changed: [localhost] => {
+    "changed": true,
+    "cmd": [
+        "curl",
+        "-L",
+        "-o",
+        "/tmp/consul.zip",
+        "https://releases.hashicorp.com/consul/1.18.1/consul_1.18.1_linux_amd64.zip"
+    ],
+    "delta": "0:00:00.488440",
+    "end": "2025-11-10 03:41:49.589051",
+    "invocation": {
+        "module_args": {
+            "_raw_params": "curl -L -o /tmp/consul.zip https://releases.hashicorp.com/consul/1.18.1/consul_1.18.1_linux_amd64.zip",
+            "_uses_shell": false,
+            "argv": null,
+            "chdir": null,
+            "cmd": null,
+            "creates": "/tmp/consul.zip",
+            "executable": null,
+            "expand_argument_vars": true,
+            "removes": null,
+            "stdin": null,
+            "stdin_add_newline": true,
+            "strip_empty_ends": true
+        }
+    },
+    "msg": "",
+    "rc": 0,
+    "start": "2025-11-10 03:41:49.100611",
+    "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r 75 63.7M   75 48.2M    0     0   124M      0 --:--:-- --:--:-- --:--:--  124M\r100 63.7M  100 63.7M    0     0   146M      0 --:--:-- --:--:-- --:--:--  146M",
+    "stderr_lines": [
+        "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current",
+        "                                 Dload  Upload   Total   Spent    Left  Speed",
+        "",
+        "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0",
+        " 75 63.7M   75 48.2M    0     0   124M      0 --:--:-- --:--:-- --:--:--  124M",
+        "100 63.7M  100 63.7M    0     0   146M      0 --:--:-- --:--:-- --:--:--  146M"
+    ],
+    "stdout": "",
+    "stdout_lines": []
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [consul : Unzip Consul] ***************************************************
+task path: /app/ansible/roles/consul/tasks/main.yaml:13
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746109.6712604-3732-80696202807852 `" && echo ansible-tmp-1762746109.6712604-3732-80696202807852="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746109.6712604-3732-80696202807852 `" ) && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-jpinlifpteolzuvyatgmkcgpsltzxpni ; test -e /tmp/consul'"'"' && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/stat.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmpno0vjglm TO /home/jules/.ansible/tmp/ansible-tmp-1762746109.6712604-3732-80696202807852/AnsiballZ_stat.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746109.6712604-3732-80696202807852/ /home/jules/.ansible/tmp/ansible-tmp-1762746109.6712604-3732-80696202807852/AnsiballZ_stat.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-ddrlfbvsarivuzcugwwbivzaoqheagbu ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746109.6712604-3732-80696202807852/AnsiballZ_stat.py'"'"' && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/unarchive.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmpqx0x0qw3 TO /home/jules/.ansible/tmp/ansible-tmp-1762746109.6712604-3732-80696202807852/AnsiballZ_unarchive.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746109.6712604-3732-80696202807852/ /home/jules/.ansible/tmp/ansible-tmp-1762746109.6712604-3732-80696202807852/AnsiballZ_unarchive.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-jjdbxhrmyvkipxxuctejdtjivdgmeign ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746109.6712604-3732-80696202807852/AnsiballZ_unarchive.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746109.6712604-3732-80696202807852/ > /dev/null 2>&1 && sleep 0'
+changed: [localhost] => {
+    "changed": true,
+    "dest": "/tmp",
+    "diff": {
+        "prepared": ">f++++++.?? consul\n"
+    },
+    "extract_results": {
+        "cmd": [
+            "/usr/bin/unzip",
+            "-o",
+            "/tmp/consul.zip",
+            "-d",
+            "/tmp"
+        ],
+        "err": "",
+        "out": "Archive:  /tmp/consul.zip\n  inflating: /tmp/consul             \n",
+        "rc": 0
+    },
+    "gid": 0,
+    "group": "root",
+    "handler": "ZipArchive",
+    "invocation": {
+        "module_args": {
+            "attributes": null,
+            "copy": true,
+            "creates": "/tmp/consul",
+            "decrypt": true,
+            "dest": "/tmp",
+            "exclude": [],
+            "extra_opts": [],
+            "group": null,
+            "include": [],
+            "io_buffer_size": 65536,
+            "keep_newer": false,
+            "list_files": false,
+            "mode": null,
+            "owner": null,
+            "remote_src": true,
+            "selevel": null,
+            "serole": null,
+            "setype": null,
+            "seuser": null,
+            "src": "/tmp/consul.zip",
+            "unsafe_writes": false,
+            "validate_certs": true
+        }
+    },
+    "mode": "01777",
+    "owner": "root",
+    "size": 4096,
+    "src": "/tmp/consul.zip",
+    "state": "directory",
+    "uid": 0
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [consul : Move Consul to /usr/local/bin] **********************************
+task path: /app/ansible/roles/consul/tasks/main.yaml:22
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746112.9191618-3778-269639911015826 `" && echo ansible-tmp-1762746112.9191618-3778-269639911015826="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746112.9191618-3778-269639911015826 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/copy.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmp71qaqvu2 TO /home/jules/.ansible/tmp/ansible-tmp-1762746112.9191618-3778-269639911015826/AnsiballZ_copy.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746112.9191618-3778-269639911015826/ /home/jules/.ansible/tmp/ansible-tmp-1762746112.9191618-3778-269639911015826/AnsiballZ_copy.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-vauydjyzymxjyjulxnmxkyuowvcvzjac ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746112.9191618-3778-269639911015826/AnsiballZ_copy.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746112.9191618-3778-269639911015826/ > /dev/null 2>&1 && sleep 0'
+changed: [localhost] => {
+    "changed": true,
+    "checksum": "acd49319da8dbf8958b40222019ad04d4620508a",
+    "dest": "/usr/local/bin/consul",
+    "gid": 0,
+    "group": "root",
+    "invocation": {
+        "module_args": {
+            "_original_basename": null,
+            "attributes": null,
+            "backup": false,
+            "checksum": null,
+            "content": null,
+            "dest": "/usr/local/bin/consul",
+            "directory_mode": null,
+            "follow": false,
+            "force": true,
+            "group": null,
+            "local_follow": null,
+            "mode": "0755",
+            "owner": null,
+            "remote_src": true,
+            "selevel": null,
+            "serole": null,
+            "setype": null,
+            "seuser": null,
+            "src": "/tmp/consul",
+            "unsafe_writes": false,
+            "validate": null
+        }
+    },
+    "md5sum": "113cc090a2187a6d6b07b8a297cd0793",
+    "mode": "0755",
+    "owner": "root",
+    "size": 177777660,
+    "src": "/tmp/consul",
+    "state": "file",
+    "uid": 0
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [consul : Create Consul data directory] ***********************************
+task path: /app/ansible/roles/consul/tasks/main.yaml:30
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746115.647911-3805-254486119760751 `" && echo ansible-tmp-1762746115.647911-3805-254486119760751="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746115.647911-3805-254486119760751 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/file.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmprm_8naj2 TO /home/jules/.ansible/tmp/ansible-tmp-1762746115.647911-3805-254486119760751/AnsiballZ_file.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746115.647911-3805-254486119760751/ /home/jules/.ansible/tmp/ansible-tmp-1762746115.647911-3805-254486119760751/AnsiballZ_file.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-brqjukdkvkplbcvwfgjgjnkzitolmjuc ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746115.647911-3805-254486119760751/AnsiballZ_file.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746115.647911-3805-254486119760751/ > /dev/null 2>&1 && sleep 0'
+changed: [localhost] => {
+    "changed": true,
+    "gid": 0,
+    "group": "root",
+    "invocation": {
+        "module_args": {
+            "_diff_peek": null,
+            "_original_basename": null,
+            "access_time": null,
+            "access_time_format": "%Y%m%d%H%M.%S",
+            "attributes": null,
+            "follow": true,
+            "force": false,
+            "group": null,
+            "mode": "0755",
+            "modification_time": null,
+            "modification_time_format": "%Y%m%d%H%M.%S",
+            "owner": null,
+            "path": "/opt/consul",
+            "recurse": false,
+            "selevel": null,
+            "serole": null,
+            "setype": null,
+            "seuser": null,
+            "src": null,
+            "state": "directory",
+            "unsafe_writes": false
+        }
+    },
+    "mode": "0755",
+    "owner": "root",
+    "path": "/opt/consul",
+    "size": 4096,
+    "state": "directory",
+    "uid": 0
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [consul : Create Consul config directory] *********************************
+task path: /app/ansible/roles/consul/tasks/main.yaml:37
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746116.25262-3832-98619049652912 `" && echo ansible-tmp-1762746116.25262-3832-98619049652912="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746116.25262-3832-98619049652912 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/file.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmprgcr7pyp TO /home/jules/.ansible/tmp/ansible-tmp-1762746116.25262-3832-98619049652912/AnsiballZ_file.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746116.25262-3832-98619049652912/ /home/jules/.ansible/tmp/ansible-tmp-1762746116.25262-3832-98619049652912/AnsiballZ_file.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-zrxklyvntnxbwxnqvikrxdizdrzunbdd ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746116.25262-3832-98619049652912/AnsiballZ_file.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746116.25262-3832-98619049652912/ > /dev/null 2>&1 && sleep 0'
+changed: [localhost] => {
+    "changed": true,
+    "gid": 0,
+    "group": "root",
+    "invocation": {
+        "module_args": {
+            "_diff_peek": null,
+            "_original_basename": null,
+            "access_time": null,
+            "access_time_format": "%Y%m%d%H%M.%S",
+            "attributes": null,
+            "follow": true,
+            "force": false,
+            "group": null,
+            "mode": "0755",
+            "modification_time": null,
+            "modification_time_format": "%Y%m%d%H%M.%S",
+            "owner": null,
+            "path": "/etc/consul.d",
+            "recurse": false,
+            "selevel": null,
+            "serole": null,
+            "setype": null,
+            "seuser": null,
+            "src": null,
+            "state": "directory",
+            "unsafe_writes": false
+        }
+    },
+    "mode": "0755",
+    "owner": "root",
+    "path": "/etc/consul.d",
+    "size": 4096,
+    "state": "directory",
+    "uid": 0
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [consul : Copy Consul config] *********************************************
+task path: /app/ansible/roles/consul/tasks/main.yaml:44
+[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
+Origin: /app/ansible/roles/consul/templates/consul.hcl.j2
+
+Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
+
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324 `" && echo ansible-tmp-1762746116.6598563-3859-123068729282324="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/stat.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmpirqsypo9 TO /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/AnsiballZ_stat.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/ /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/AnsiballZ_stat.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-olexpaymepgqeumwgmsnolnhfdttyruc ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/AnsiballZ_stat.py'"'"' && sleep 0'
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmpivpt7fo6/consul.hcl.j2 TO /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/.source.hcl
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/ /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/.source.hcl && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/copy.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmpa7dd5if2 TO /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/AnsiballZ_copy.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/ /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/AnsiballZ_copy.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-ueikkqjzbhdbsahdlnukhubmhyldvygz ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/AnsiballZ_copy.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/ > /dev/null 2>&1 && sleep 0'
+Notification for handler restart consul has been saved.
+changed: [localhost] => {
+    "changed": true,
+    "checksum": "0076e1f94a72f2a3336f2e4e9b7195d8e6f24d80",
+    "dest": "/etc/consul.d/consul.hcl",
+    "diff": [],
+    "gid": 0,
+    "group": "root",
+    "invocation": {
+        "module_args": {
+            "_original_basename": "consul.hcl.j2",
+            "attributes": null,
+            "backup": false,
+            "checksum": "0076e1f94a72f2a3336f2e4e9b7195d8e6f24d80",
+            "content": null,
+            "dest": "/etc/consul.d/consul.hcl",
+            "directory_mode": null,
+            "follow": false,
+            "force": true,
+            "group": null,
+            "local_follow": null,
+            "mode": null,
+            "owner": null,
+            "remote_src": false,
+            "selevel": null,
+            "serole": null,
+            "setype": null,
+            "seuser": null,
+            "src": "/home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/.source.hcl",
+            "unsafe_writes": false,
+            "validate": null
+        }
+    },
+    "md5sum": "b8576326ae4ced1729b86760191cee2b",
+    "mode": "0644",
+    "owner": "root",
+    "size": 496,
+    "src": "/home/jules/.ansible/tmp/ansible-tmp-1762746116.6598563-3859-123068729282324/.source.hcl",
+    "state": "file",
+    "uid": 0
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [consul : Copy Consul systemd service file] *******************************
+task path: /app/ansible/roles/consul/tasks/main.yaml:51
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077 `" && echo ansible-tmp-1762746117.5204222-3900-166912739087077="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/stat.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmpjn9ca6z4 TO /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/AnsiballZ_stat.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/ /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/AnsiballZ_stat.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-pbtsqmdwrixphvunkldrjeflvslymcxh ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/AnsiballZ_stat.py'"'"' && sleep 0'
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmpxofzfskr/consul.service.j2 TO /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/.source.service
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/ /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/.source.service && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/copy.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmpv5qwj2eh TO /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/AnsiballZ_copy.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/ /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/AnsiballZ_copy.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-mwmtxcmfhquezrrmnkoandcwqgvumytu ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/AnsiballZ_copy.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/ > /dev/null 2>&1 && sleep 0'
+Notification for handler restart consul has been saved.
+changed: [localhost] => {
+    "changed": true,
+    "checksum": "f8ca196044ed06b5b0408fc331cde00ef832499a",
+    "dest": "/etc/systemd/system/consul.service",
+    "diff": [],
+    "gid": 0,
+    "group": "root",
+    "invocation": {
+        "module_args": {
+            "_original_basename": "consul.service.j2",
+            "attributes": null,
+            "backup": false,
+            "checksum": "f8ca196044ed06b5b0408fc331cde00ef832499a",
+            "content": null,
+            "dest": "/etc/systemd/system/consul.service",
+            "directory_mode": null,
+            "follow": false,
+            "force": true,
+            "group": null,
+            "local_follow": null,
+            "mode": null,
+            "owner": null,
+            "remote_src": false,
+            "selevel": null,
+            "serole": null,
+            "setype": null,
+            "seuser": null,
+            "src": "/home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/.source.service",
+            "unsafe_writes": false,
+            "validate": null
+        }
+    },
+    "md5sum": "88a87463422bcdc20bd1300605f60173",
+    "mode": "0644",
+    "owner": "root",
+    "size": 311,
+    "src": "/home/jules/.ansible/tmp/ansible-tmp-1762746117.5204222-3900-166912739087077/.source.service",
+    "state": "file",
+    "uid": 0
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [consul : Reload systemd to recognize new service] ************************
+task path: /app/ansible/roles/consul/tasks/main.yaml:58
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746118.2498076-3941-92589524183570 `" && echo ansible-tmp-1762746118.2498076-3941-92589524183570="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746118.2498076-3941-92589524183570 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/systemd.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmpkcrxikeu TO /home/jules/.ansible/tmp/ansible-tmp-1762746118.2498076-3941-92589524183570/AnsiballZ_systemd.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746118.2498076-3941-92589524183570/ /home/jules/.ansible/tmp/ansible-tmp-1762746118.2498076-3941-92589524183570/AnsiballZ_systemd.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-yykxbxutdxmcflzrdkomflyzcegfjbtz ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746118.2498076-3941-92589524183570/AnsiballZ_systemd.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746118.2498076-3941-92589524183570/ > /dev/null 2>&1 && sleep 0'
+ok: [localhost] => {
+    "changed": false,
+    "invocation": {
+        "module_args": {
+            "daemon_reexec": false,
+            "daemon_reload": true,
+            "enabled": null,
+            "force": null,
+            "masked": null,
+            "name": null,
+            "no_block": false,
+            "scope": "system",
+            "state": null
+        }
+    },
+    "name": null,
+    "status": {}
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [consul : Start and enable Consul service] ********************************
+task path: /app/ansible/roles/consul/tasks/main.yaml:64
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746119.4654577-3995-220550382120592 `" && echo ansible-tmp-1762746119.4654577-3995-220550382120592="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746119.4654577-3995-220550382120592 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/systemd.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmpy5xy1_ub TO /home/jules/.ansible/tmp/ansible-tmp-1762746119.4654577-3995-220550382120592/AnsiballZ_systemd.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746119.4654577-3995-220550382120592/ /home/jules/.ansible/tmp/ansible-tmp-1762746119.4654577-3995-220550382120592/AnsiballZ_systemd.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-nyxbymzgifgkzvmfygxfktdjgvlgiavl ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746119.4654577-3995-220550382120592/AnsiballZ_systemd.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746119.4654577-3995-220550382120592/ > /dev/null 2>&1 && sleep 0'
+changed: [localhost] => {
+    "changed": true,
+    "enabled": true,
+    "invocation": {
+        "module_args": {
+            "daemon_reexec": false,
+            "daemon_reload": false,
+            "enabled": true,
+            "force": null,
+            "masked": null,
+            "name": "consul",
+            "no_block": false,
+            "scope": "system",
+            "state": "started"
+        }
+    },
+    "name": "consul",
+    "state": "started",
+    "status": {
+        "ActiveEnterTimestampMonotonic": "0",
+        "ActiveExitTimestampMonotonic": "0",
+        "ActiveState": "inactive",
+        "After": "network-online.target system.slice systemd-journald.socket sysinit.target basic.target",
+        "AllowIsolate": "no",
+        "AssertResult": "no",
+        "AssertTimestampMonotonic": "0",
+        "Before": "shutdown.target",
+        "BlockIOAccounting": "no",
+        "BlockIOWeight": "[not set]",
+        "CPUAccounting": "yes",
+        "CPUAffinityFromNUMA": "no",
+        "CPUQuotaPerSecUSec": "infinity",
+        "CPUQuotaPeriodUSec": "infinity",
+        "CPUSchedulingPolicy": "0",
+        "CPUSchedulingPriority": "0",
+        "CPUSchedulingResetOnFork": "no",
+        "CPUShares": "[not set]",
+        "CPUUsageNSec": "[not set]",
+        "CPUWeight": "[not set]",
+        "CacheDirectoryMode": "0755",
+        "CanFreeze": "yes",
+        "CanIsolate": "no",
+        "CanReload": "no",
+        "CanStart": "yes",
+        "CanStop": "yes",
+        "CapabilityBoundingSet": "cap_chown cap_dac_override cap_dac_read_search cap_fowner cap_fsetid cap_kill cap_setgid cap_setuid cap_setpcap cap_linux_immutable cap_net_bind_service cap_net_broadcast cap_net_admin cap_net_raw cap_ipc_lock cap_ipc_owner cap_sys_module cap_sys_rawio cap_sys_chroot cap_sys_ptrace cap_sys_pacct cap_sys_admin cap_sys_boot cap_sys_nice cap_sys_resource cap_sys_time cap_sys_tty_config cap_mknod cap_lease cap_audit_write cap_audit_control cap_setfcap cap_mac_override cap_mac_admin cap_syslog cap_wake_alarm cap_block_suspend cap_audit_read cap_perfmon cap_bpf cap_checkpoint_restore",
+        "CleanResult": "success",
+        "CollectMode": "inactive",
+        "ConditionResult": "no",
+        "ConditionTimestampMonotonic": "0",
+        "ConfigurationDirectoryMode": "0755",
+        "Conflicts": "shutdown.target",
+        "ControlGroupId": "0",
+        "ControlPID": "0",
+        "CoredumpFilter": "0x33",
+        "CoredumpReceive": "no",
+        "DefaultDependencies": "yes",
+        "DefaultMemoryLow": "0",
+        "DefaultMemoryMin": "0",
+        "DefaultStartupMemoryLow": "0",
+        "Delegate": "no",
+        "Description": "Consul",
+        "DevicePolicy": "auto",
+        "Documentation": "https://www.consul.io/docs/",
+        "DynamicUser": "no",
+        "Environment": "HOME=/root",
+        "ExecMainCode": "0",
+        "ExecMainExitTimestampMonotonic": "0",
+        "ExecMainPID": "0",
+        "ExecMainStartTimestampMonotonic": "0",
+        "ExecMainStatus": "0",
+        "ExecStart": "{ path=/usr/local/bin/consul ; argv[]=/usr/local/bin/consul agent -config-dir=/etc/consul.d ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }",
+        "ExecStartEx": "{ path=/usr/local/bin/consul ; argv[]=/usr/local/bin/consul agent -config-dir=/etc/consul.d ; flags= ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }",
+        "ExitType": "main",
+        "ExtensionImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent",
+        "FailureAction": "none",
+        "FileDescriptorStoreMax": "0",
+        "FileDescriptorStorePreserve": "restart",
+        "FinalKillSignal": "9",
+        "FragmentPath": "/etc/systemd/system/consul.service",
+        "FreezerState": "running",
+        "GID": "[not set]",
+        "GuessMainPID": "yes",
+        "IOAccounting": "no",
+        "IOReadBytes": "[not set]",
+        "IOReadOperations": "[not set]",
+        "IOSchedulingClass": "2",
+        "IOSchedulingPriority": "4",
+        "IOWeight": "[not set]",
+        "IOWriteBytes": "[not set]",
+        "IOWriteOperations": "[not set]",
+        "IPAccounting": "no",
+        "IPEgressBytes": "[no data]",
+        "IPEgressPackets": "[no data]",
+        "IPIngressBytes": "[no data]",
+        "IPIngressPackets": "[no data]",
+        "Id": "consul.service",
+        "IgnoreOnIsolate": "no",
+        "IgnoreSIGPIPE": "yes",
+        "InactiveEnterTimestampMonotonic": "0",
+        "InactiveExitTimestampMonotonic": "0",
+        "JobRunningTimeoutUSec": "infinity",
+        "JobTimeoutAction": "none",
+        "JobTimeoutUSec": "infinity",
+        "KeyringMode": "private",
+        "KillMode": "process",
+        "KillSignal": "15",
+        "LimitAS": "infinity",
+        "LimitASSoft": "infinity",
+        "LimitCORE": "infinity",
+        "LimitCORESoft": "0",
+        "LimitCPU": "infinity",
+        "LimitCPUSoft": "infinity",
+        "LimitDATA": "infinity",
+        "LimitDATASoft": "infinity",
+        "LimitFSIZE": "infinity",
+        "LimitFSIZESoft": "infinity",
+        "LimitLOCKS": "infinity",
+        "LimitLOCKSSoft": "infinity",
+        "LimitMEMLOCK": "8388608",
+        "LimitMEMLOCKSoft": "8388608",
+        "LimitMSGQUEUE": "819200",
+        "LimitMSGQUEUESoft": "819200",
+        "LimitNICE": "0",
+        "LimitNICESoft": "0",
+        "LimitNOFILE": "524288",
+        "LimitNOFILESoft": "1024",
+        "LimitNPROC": "31821",
+        "LimitNPROCSoft": "31821",
+        "LimitRSS": "infinity",
+        "LimitRSSSoft": "infinity",
+        "LimitRTPRIO": "0",
+        "LimitRTPRIOSoft": "0",
+        "LimitRTTIME": "infinity",
+        "LimitRTTIMESoft": "infinity",
+        "LimitSIGPENDING": "31821",
+        "LimitSIGPENDINGSoft": "31821",
+        "LimitSTACK": "infinity",
+        "LimitSTACKSoft": "8388608",
+        "LoadState": "loaded",
+        "LockPersonality": "no",
+        "LogLevelMax": "-1",
+        "LogRateLimitBurst": "0",
+        "LogRateLimitIntervalUSec": "0",
+        "LogsDirectoryMode": "0755",
+        "MainPID": "0",
+        "ManagedOOMMemoryPressure": "auto",
+        "ManagedOOMMemoryPressureLimit": "0",
+        "ManagedOOMPreference": "none",
+        "ManagedOOMSwap": "auto",
+        "MemoryAccounting": "yes",
+        "MemoryAvailable": "7806865408",
+        "MemoryCurrent": "[not set]",
+        "MemoryDenyWriteExecute": "no",
+        "MemoryHigh": "infinity",
+        "MemoryKSM": "no",
+        "MemoryLimit": "infinity",
+        "MemoryLow": "0",
+        "MemoryMax": "infinity",
+        "MemoryMin": "0",
+        "MemoryPeak": "[not set]",
+        "MemoryPressureThresholdUSec": "200ms",
+        "MemoryPressureWatch": "auto",
+        "MemorySwapCurrent": "[not set]",
+        "MemorySwapMax": "infinity",
+        "MemorySwapPeak": "[not set]",
+        "MemoryZSwapCurrent": "[not set]",
+        "MemoryZSwapMax": "infinity",
+        "MountAPIVFS": "no",
+        "MountImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent",
+        "NFileDescriptorStore": "0",
+        "NRestarts": "0",
+        "NUMAPolicy": "n/a",
+        "Names": "consul.service",
+        "NeedDaemonReload": "no",
+        "Nice": "0",
+        "NoNewPrivileges": "no",
+        "NonBlocking": "no",
+        "NotifyAccess": "none",
+        "OOMPolicy": "stop",
+        "OOMScoreAdjust": "0",
+        "OnFailureJobMode": "replace",
+        "OnSuccessJobMode": "fail",
+        "Perpetual": "no",
+        "PrivateDevices": "no",
+        "PrivateIPC": "no",
+        "PrivateMounts": "no",
+        "PrivateNetwork": "no",
+        "PrivateTmp": "no",
+        "PrivateUsers": "no",
+        "ProcSubset": "all",
+        "ProtectClock": "no",
+        "ProtectControlGroups": "no",
+        "ProtectHome": "no",
+        "ProtectHostname": "no",
+        "ProtectKernelLogs": "no",
+        "ProtectKernelModules": "no",
+        "ProtectKernelTunables": "no",
+        "ProtectProc": "default",
+        "ProtectSystem": "no",
+        "RefuseManualStart": "no",
+        "RefuseManualStop": "no",
+        "ReloadResult": "success",
+        "ReloadSignal": "1",
+        "RemainAfterExit": "no",
+        "RemoveIPC": "no",
+        "Requires": "system.slice sysinit.target",
+        "Restart": "on-failure",
+        "RestartKillSignal": "15",
+        "RestartMaxDelayUSec": "infinity",
+        "RestartMode": "normal",
+        "RestartSteps": "0",
+        "RestartUSec": "2s",
+        "RestartUSecNext": "2s",
+        "RestrictNamespaces": "no",
+        "RestrictRealtime": "no",
+        "RestrictSUIDSGID": "no",
+        "Result": "success",
+        "RootDirectoryStartOnly": "no",
+        "RootEphemeral": "no",
+        "RootImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent",
+        "RuntimeDirectoryMode": "0755",
+        "RuntimeDirectoryPreserve": "no",
+        "RuntimeMaxUSec": "infinity",
+        "RuntimeRandomizedExtraUSec": "0",
+        "SameProcessGroup": "no",
+        "SecureBits": "0",
+        "SendSIGHUP": "no",
+        "SendSIGKILL": "yes",
+        "SetLoginEnvironment": "no",
+        "Slice": "system.slice",
+        "StandardError": "inherit",
+        "StandardInput": "null",
+        "StandardOutput": "journal",
+        "StartLimitAction": "none",
+        "StartLimitBurst": "5",
+        "StartLimitIntervalUSec": "10s",
+        "StartupBlockIOWeight": "[not set]",
+        "StartupCPUShares": "[not set]",
+        "StartupCPUWeight": "[not set]",
+        "StartupIOWeight": "[not set]",
+        "StartupMemoryHigh": "infinity",
+        "StartupMemoryLow": "0",
+        "StartupMemoryMax": "infinity",
+        "StartupMemorySwapMax": "infinity",
+        "StartupMemoryZSwapMax": "infinity",
+        "StateChangeTimestampMonotonic": "0",
+        "StateDirectoryMode": "0755",
+        "StatusErrno": "0",
+        "StopWhenUnneeded": "no",
+        "SubState": "dead",
+        "SuccessAction": "none",
+        "SurviveFinalKillSignal": "no",
+        "SyslogFacility": "3",
+        "SyslogLevel": "6",
+        "SyslogLevelPrefix": "yes",
+        "SyslogPriority": "30",
+        "SystemCallErrorNumber": "2147483646",
+        "TTYReset": "no",
+        "TTYVHangup": "no",
+        "TTYVTDisallocate": "no",
+        "TasksAccounting": "yes",
+        "TasksCurrent": "[not set]",
+        "TasksMax": "9546",
+        "TimeoutAbortUSec": "1min 30s",
+        "TimeoutCleanUSec": "infinity",
+        "TimeoutStartFailureMode": "terminate",
+        "TimeoutStartUSec": "1min 30s",
+        "TimeoutStopFailureMode": "terminate",
+        "TimeoutStopUSec": "1min 30s",
+        "TimerSlackNSec": "50000",
+        "Transient": "no",
+        "Type": "simple",
+        "UID": "[not set]",
+        "UMask": "0022",
+        "UnitFilePreset": "enabled",
+        "UnitFileState": "disabled",
+        "UtmpMode": "init",
+        "Wants": "network-online.target",
+        "WatchdogSignal": "6",
+        "WatchdogTimestampMonotonic": "0",
+        "WatchdogUSec": "infinity"
+    }
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+Read `vars_file` '/app/group_vars/all.yaml'.
+NOTIFIED HANDLER consul : restart consul for localhost
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+RUNNING HANDLER [consul : restart consul] **************************************
+task path: /app/ansible/roles/consul/handlers/main.yaml:1
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746120.3839672-4060-247128869507896 `" && echo ansible-tmp-1762746120.3839672-4060-247128869507896="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746120.3839672-4060-247128869507896 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/systemd.py
+<127.0.0.1> PUT /tmp/ansible-local-3585mx1v77xv/tmp295z438i TO /home/jules/.ansible/tmp/ansible-tmp-1762746120.3839672-4060-247128869507896/AnsiballZ_systemd.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746120.3839672-4060-247128869507896/ /home/jules/.ansible/tmp/ansible-tmp-1762746120.3839672-4060-247128869507896/AnsiballZ_systemd.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-pkwsikztnvsnkozkcnwwhtyhkkwyabrb ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746120.3839672-4060-247128869507896/AnsiballZ_systemd.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746120.3839672-4060-247128869507896/ > /dev/null 2>&1 && sleep 0'
+changed: [localhost] => {
+    "changed": true,
+    "invocation": {
+        "module_args": {
+            "daemon_reexec": false,
+            "daemon_reload": false,
+            "enabled": null,
+            "force": null,
+            "masked": null,
+            "name": "consul",
+            "no_block": false,
+            "scope": "system",
+            "state": "restarted"
+        }
+    },
+    "name": "consul",
+    "state": "started",
+    "status": {
+        "ActiveEnterTimestamp": "Mon 2025-11-10 03:42:00 UTC",
+        "ActiveEnterTimestampMonotonic": "262296510",
+        "ActiveExitTimestampMonotonic": "0",
+        "ActiveState": "active",
+        "After": "system.slice network-online.target basic.target systemd-journald.socket sysinit.target",
+        "AllowIsolate": "no",
+        "AssertResult": "yes",
+        "AssertTimestamp": "Mon 2025-11-10 03:42:00 UTC",
+        "AssertTimestampMonotonic": "262280253",
+        "Before": "multi-user.target shutdown.target",
+        "BlockIOAccounting": "no",
+        "BlockIOWeight": "[not set]",
+        "CPUAccounting": "yes",
+        "CPUAffinityFromNUMA": "no",
+        "CPUQuotaPerSecUSec": "infinity",
+        "CPUQuotaPeriodUSec": "infinity",
+        "CPUSchedulingPolicy": "0",
+        "CPUSchedulingPriority": "0",
+        "CPUSchedulingResetOnFork": "no",
+        "CPUShares": "[not set]",
+        "CPUUsageNSec": "202112000",
+        "CPUWeight": "[not set]",
+        "CacheDirectoryMode": "0755",
+        "CanFreeze": "yes",
+        "CanIsolate": "no",
+        "CanReload": "no",
+        "CanStart": "yes",
+        "CanStop": "yes",
+        "CapabilityBoundingSet": "cap_chown cap_dac_override cap_dac_read_search cap_fowner cap_fsetid cap_kill cap_setgid cap_setuid cap_setpcap cap_linux_immutable cap_net_bind_service cap_net_broadcast cap_net_admin cap_net_raw cap_ipc_lock cap_ipc_owner cap_sys_module cap_sys_rawio cap_sys_chroot cap_sys_ptrace cap_sys_pacct cap_sys_admin cap_sys_boot cap_sys_nice cap_sys_resource cap_sys_time cap_sys_tty_config cap_mknod cap_lease cap_audit_write cap_audit_control cap_setfcap cap_mac_override cap_mac_admin cap_syslog cap_wake_alarm cap_block_suspend cap_audit_read cap_perfmon cap_bpf cap_checkpoint_restore",
+        "CleanResult": "success",
+        "CollectMode": "inactive",
+        "ConditionResult": "yes",
+        "ConditionTimestamp": "Mon 2025-11-10 03:42:00 UTC",
+        "ConditionTimestampMonotonic": "262280251",
+        "ConfigurationDirectoryMode": "0755",
+        "Conflicts": "shutdown.target",
+        "ControlGroup": "/system.slice/consul.service",
+        "ControlGroupId": "3210",
+        "ControlPID": "0",
+        "CoredumpFilter": "0x33",
+        "CoredumpReceive": "no",
+        "DefaultDependencies": "yes",
+        "DefaultMemoryLow": "0",
+        "DefaultMemoryMin": "0",
+        "DefaultStartupMemoryLow": "0",
+        "Delegate": "no",
+        "Description": "Consul",
+        "DevicePolicy": "auto",
+        "Documentation": "https://www.consul.io/docs/",
+        "DynamicUser": "no",
+        "EffectiveCPUs": "0-3",
+        "EffectiveMemoryNodes": "0",
+        "Environment": "HOME=/root",
+        "ExecMainCode": "0",
+        "ExecMainExitTimestampMonotonic": "0",
+        "ExecMainPID": "4047",
+        "ExecMainStartTimestamp": "Mon 2025-11-10 03:42:00 UTC",
+        "ExecMainStartTimestampMonotonic": "262296230",
+        "ExecMainStatus": "0",
+        "ExecStart": "{ path=/usr/local/bin/consul ; argv[]=/usr/local/bin/consul agent -config-dir=/etc/consul.d ; ignore_errors=no ; start_time=[Mon 2025-11-10 03:42:00 UTC] ; stop_time=[n/a] ; pid=4047 ; code=(null) ; status=0/0 }",
+        "ExecStartEx": "{ path=/usr/local/bin/consul ; argv[]=/usr/local/bin/consul agent -config-dir=/etc/consul.d ; flags= ; start_time=[Mon 2025-11-10 03:42:00 UTC] ; stop_time=[n/a] ; pid=4047 ; code=(null) ; status=0/0 }",
+        "ExitType": "main",
+        "ExtensionImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent",
+        "FailureAction": "none",
+        "FileDescriptorStoreMax": "0",
+        "FileDescriptorStorePreserve": "restart",
+        "FinalKillSignal": "9",
+        "FragmentPath": "/etc/systemd/system/consul.service",
+        "FreezerState": "running",
+        "GID": "[not set]",
+        "GuessMainPID": "yes",
+        "IOAccounting": "no",
+        "IOReadBytes": "[not set]",
+        "IOReadOperations": "[not set]",
+        "IOSchedulingClass": "2",
+        "IOSchedulingPriority": "4",
+        "IOWeight": "[not set]",
+        "IOWriteBytes": "[not set]",
+        "IOWriteOperations": "[not set]",
+        "IPAccounting": "no",
+        "IPEgressBytes": "[no data]",
+        "IPEgressPackets": "[no data]",
+        "IPIngressBytes": "[no data]",
+        "IPIngressPackets": "[no data]",
+        "Id": "consul.service",
+        "IgnoreOnIsolate": "no",
+        "IgnoreSIGPIPE": "yes",
+        "InactiveEnterTimestampMonotonic": "0",
+        "InactiveExitTimestamp": "Mon 2025-11-10 03:42:00 UTC",
+        "InactiveExitTimestampMonotonic": "262296510",
+        "InvocationID": "ec9125de789642a5b843128e11afbb1d",
+        "JobRunningTimeoutUSec": "infinity",
+        "JobTimeoutAction": "none",
+        "JobTimeoutUSec": "infinity",
+        "KeyringMode": "private",
+        "KillMode": "process",
+        "KillSignal": "15",
+        "LimitAS": "infinity",
+        "LimitASSoft": "infinity",
+        "LimitCORE": "infinity",
+        "LimitCORESoft": "0",
+        "LimitCPU": "infinity",
+        "LimitCPUSoft": "infinity",
+        "LimitDATA": "infinity",
+        "LimitDATASoft": "infinity",
+        "LimitFSIZE": "infinity",
+        "LimitFSIZESoft": "infinity",
+        "LimitLOCKS": "infinity",
+        "LimitLOCKSSoft": "infinity",
+        "LimitMEMLOCK": "8388608",
+        "LimitMEMLOCKSoft": "8388608",
+        "LimitMSGQUEUE": "819200",
+        "LimitMSGQUEUESoft": "819200",
+        "LimitNICE": "0",
+        "LimitNICESoft": "0",
+        "LimitNOFILE": "524288",
+        "LimitNOFILESoft": "1024",
+        "LimitNPROC": "31821",
+        "LimitNPROCSoft": "31821",
+        "LimitRSS": "infinity",
+        "LimitRSSSoft": "infinity",
+        "LimitRTPRIO": "0",
+        "LimitRTPRIOSoft": "0",
+        "LimitRTTIME": "infinity",
+        "LimitRTTIMESoft": "infinity",
+        "LimitSIGPENDING": "31821",
+        "LimitSIGPENDINGSoft": "31821",
+        "LimitSTACK": "infinity",
+        "LimitSTACKSoft": "8388608",
+        "LoadState": "loaded",
+        "LockPersonality": "no",
+        "LogLevelMax": "-1",
+        "LogRateLimitBurst": "0",
+        "LogRateLimitIntervalUSec": "0",
+        "LogsDirectoryMode": "0755",
+        "MainPID": "4047",
+        "ManagedOOMMemoryPressure": "auto",
+        "ManagedOOMMemoryPressureLimit": "0",
+        "ManagedOOMPreference": "none",
+        "ManagedOOMSwap": "auto",
+        "MemoryAccounting": "yes",
+        "MemoryAvailable": "7790678016",
+        "MemoryCurrent": "23560192",
+        "MemoryDenyWriteExecute": "no",
+        "MemoryHigh": "infinity",
+        "MemoryKSM": "no",
+        "MemoryLimit": "infinity",
+        "MemoryLow": "0",
+        "MemoryMax": "infinity",
+        "MemoryMin": "0",
+        "MemoryPeak": "24223744",
+        "MemoryPressureThresholdUSec": "200ms",
+        "MemoryPressureWatch": "auto",
+        "MemorySwapCurrent": "0",
+        "MemorySwapMax": "infinity",
+        "MemorySwapPeak": "0",
+        "MemoryZSwapCurrent": "[not set]",
+        "MemoryZSwapMax": "infinity",
+        "MountAPIVFS": "no",
+        "MountImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent",
+        "NFileDescriptorStore": "0",
+        "NRestarts": "0",
+        "NUMAPolicy": "n/a",
+        "Names": "consul.service",
+        "NeedDaemonReload": "no",
+        "Nice": "0",
+        "NoNewPrivileges": "no",
+        "NonBlocking": "no",
+        "NotifyAccess": "none",
+        "OOMPolicy": "stop",
+        "OOMScoreAdjust": "0",
+        "OnFailureJobMode": "replace",
+        "OnSuccessJobMode": "fail",
+        "Perpetual": "no",
+        "PrivateDevices": "no",
+        "PrivateIPC": "no",
+        "PrivateMounts": "no",
+        "PrivateNetwork": "no",
+        "PrivateTmp": "no",
+        "PrivateUsers": "no",
+        "ProcSubset": "all",
+        "ProtectClock": "no",
+        "ProtectControlGroups": "no",
+        "ProtectHome": "no",
+        "ProtectHostname": "no",
+        "ProtectKernelLogs": "no",
+        "ProtectKernelModules": "no",
+        "ProtectKernelTunables": "no",
+        "ProtectProc": "default",
+        "ProtectSystem": "no",
+        "RefuseManualStart": "no",
+        "RefuseManualStop": "no",
+        "ReloadResult": "success",
+        "ReloadSignal": "1",
+        "RemainAfterExit": "no",
+        "RemoveIPC": "no",
+        "Requires": "system.slice sysinit.target",
+        "Restart": "on-failure",
+        "RestartKillSignal": "15",
+        "RestartMaxDelayUSec": "infinity",
+        "RestartMode": "normal",
+        "RestartSteps": "0",
+        "RestartUSec": "2s",
+        "RestartUSecNext": "2s",
+        "RestrictNamespaces": "no",
+        "RestrictRealtime": "no",
+        "RestrictSUIDSGID": "no",
+        "Result": "success",
+        "RootDirectoryStartOnly": "no",
+        "RootEphemeral": "no",
+        "RootImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent",
+        "RuntimeDirectoryMode": "0755",
+        "RuntimeDirectoryPreserve": "no",
+        "RuntimeMaxUSec": "infinity",
+        "RuntimeRandomizedExtraUSec": "0",
+        "SameProcessGroup": "no",
+        "SecureBits": "0",
+        "SendSIGHUP": "no",
+        "SendSIGKILL": "yes",
+        "SetLoginEnvironment": "no",
+        "Slice": "system.slice",
+        "StandardError": "inherit",
+        "StandardInput": "null",
+        "StandardOutput": "journal",
+        "StartLimitAction": "none",
+        "StartLimitBurst": "5",
+        "StartLimitIntervalUSec": "10s",
+        "StartupBlockIOWeight": "[not set]",
+        "StartupCPUShares": "[not set]",
+        "StartupCPUWeight": "[not set]",
+        "StartupIOWeight": "[not set]",
+        "StartupMemoryHigh": "infinity",
+        "StartupMemoryLow": "0",
+        "StartupMemoryMax": "infinity",
+        "StartupMemorySwapMax": "infinity",
+        "StartupMemoryZSwapMax": "infinity",
+        "StateChangeTimestamp": "Mon 2025-11-10 03:42:00 UTC",
+        "StateChangeTimestampMonotonic": "262296510",
+        "StateDirectoryMode": "0755",
+        "StatusErrno": "0",
+        "StopWhenUnneeded": "no",
+        "SubState": "running",
+        "SuccessAction": "none",
+        "SurviveFinalKillSignal": "no",
+        "SyslogFacility": "3",
+        "SyslogLevel": "6",
+        "SyslogLevelPrefix": "yes",
+        "SyslogPriority": "30",
+        "SystemCallErrorNumber": "2147483646",
+        "TTYReset": "no",
+        "TTYVHangup": "no",
+        "TTYVTDisallocate": "no",
+        "TasksAccounting": "yes",
+        "TasksCurrent": "11",
+        "TasksMax": "9546",
+        "TimeoutAbortUSec": "1min 30s",
+        "TimeoutCleanUSec": "infinity",
+        "TimeoutStartFailureMode": "terminate",
+        "TimeoutStartUSec": "1min 30s",
+        "TimeoutStopFailureMode": "terminate",
+        "TimeoutStopUSec": "1min 30s",
+        "TimerSlackNSec": "50000",
+        "Transient": "no",
+        "Type": "simple",
+        "UID": "[not set]",
+        "UMask": "0022",
+        "UnitFilePreset": "enabled",
+        "UnitFileState": "enabled",
+        "UtmpMode": "init",
+        "WantedBy": "multi-user.target",
+        "Wants": "network-online.target",
+        "WatchdogSignal": "6",
+        "WatchdogTimestampMonotonic": "0",
+        "WatchdogUSec": "0"
+    }
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=12   changed=9    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+
+[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
+[DEPRECATION WARNING]: DEFAULT_JINJA2_EXTENSIONS option. Reason: Jinja2 extensions have been deprecated
+Alternatives: Ansible-supported Jinja plugins (tests, filters, lookups). This feature will be removed from ansible-core version 2.23.
+
+ansible-playbook [core 2.20.0]
+  config file = /app/ansible.cfg
+  configured module search path = ['/home/jules/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
+  ansible python module location = /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible
+  ansible collection location = /home/jules/.ansible/collections:/usr/share/ansible/collections
+  executable location = /home/jules/.pyenv/versions/3.12.12/bin/ansible-playbook
+  python version = 3.12.12 (main, Oct 10 2025, 18:25:30) [GCC 13.3.0] (/home/jules/.pyenv/versions/3.12.12/bin/python)
+  jinja version = 3.1.6
+  pyyaml version = 6.0.3 (with libyaml v0.2.5)
+Using /app/ansible.cfg as config file
+setting up inventory plugins
+Loading collection ansible.builtin from
+host_list declined parsing /app/local_inventory.ini as it did not pass its verify_file() method
+script declined parsing /app/local_inventory.ini as it did not pass its verify_file() method
+auto declined parsing /app/local_inventory.ini as it did not pass its verify_file() method
+yaml declined parsing /app/local_inventory.ini as it did not pass its verify_file() method
+Set default localhost to localhost
+Parsed /app/local_inventory.ini inventory source with ini plugin
+Read `vars_file` '/app/group_vars/all.yaml'.
+Loading callback plugin default of type stdout, v2.0 from /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/plugins/callback/default.py
+Skipping callback 'minimal', as we already have a stdout callback.
+Skipping callback 'oneline', as we already have a stdout callback.
+
+PLAYBOOK: docker.yaml **********************************************************
+Positional arguments: /app/playbooks/services/docker.yaml
+verbosity: 4
+connection: ssh
+become: True
+become_method: sudo
+tags: ('all',)
+inventory: ('/app/local_inventory.ini',)
+extra_vars: ('target_user=pipecatapp', 'external_model_server=true')
+forks: 5
+1 plays in /app/playbooks/services/docker.yaml
+Read `vars_file` '/app/group_vars/all.yaml'.
+Read `vars_file` '/app/group_vars/all.yaml'.
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+PLAY [Deploy Docker] ***********************************************************
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [Gathering Facts] *********************************************************
+task path: /app/playbooks/services/docker.yaml:1
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746122.6024163-4106-172547489846608 `" && echo ansible-tmp-1762746122.6024163-4106-172547489846608="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746122.6024163-4106-172547489846608 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/setup.py
+<127.0.0.1> PUT /tmp/ansible-local-41031umov206/tmpmup1x34y TO /home/jules/.ansible/tmp/ansible-tmp-1762746122.6024163-4106-172547489846608/AnsiballZ_setup.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746122.6024163-4106-172547489846608/ /home/jules/.ansible/tmp/ansible-tmp-1762746122.6024163-4106-172547489846608/AnsiballZ_setup.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-gctqjapbltzsaicorigzavhsktjbkeze ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746122.6024163-4106-172547489846608/AnsiballZ_setup.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746122.6024163-4106-172547489846608/ > /dev/null 2>&1 && sleep 0'
+ok: [localhost]
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Check for docker binary] ****************************************
+task path: /app/ansible/roles/docker/tasks/main.yaml:3
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746124.025318-4186-58291237013439 `" && echo ansible-tmp-1762746124.025318-4186-58291237013439="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746124.025318-4186-58291237013439 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/stat.py
+<127.0.0.1> PUT /tmp/ansible-local-41031umov206/tmp_jzq7hx5 TO /home/jules/.ansible/tmp/ansible-tmp-1762746124.025318-4186-58291237013439/AnsiballZ_stat.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746124.025318-4186-58291237013439/ /home/jules/.ansible/tmp/ansible-tmp-1762746124.025318-4186-58291237013439/AnsiballZ_stat.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-efbvrxwpcezzfseuxyutgkiqbimopwkf ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746124.025318-4186-58291237013439/AnsiballZ_stat.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746124.025318-4186-58291237013439/ > /dev/null 2>&1 && sleep 0'
+ok: [localhost] => {
+    "changed": false,
+    "invocation": {
+        "module_args": {
+            "checksum_algorithm": "sha1",
+            "follow": false,
+            "get_attributes": true,
+            "get_checksum": true,
+            "get_mime": true,
+            "get_selinux_context": false,
+            "path": "/usr/bin/docker"
+        }
+    },
+    "stat": {
+        "atime": 1759925846.0,
+        "attr_flags": "",
+        "attributes": [],
+        "block_size": 1024,
+        "blocks": 88192,
+        "charset": "binary",
+        "checksum": "a4917157c409167e067384f311291ebc18c28bd8",
+        "ctime": 1759925846.0,
+        "dev": 18,
+        "device_type": 0,
+        "executable": true,
+        "exists": true,
+        "gid": 0,
+        "gr_name": "root",
+        "inode": 123608,
+        "isblk": false,
+        "ischr": false,
+        "isdir": false,
+        "isfifo": false,
+        "isgid": false,
+        "islnk": false,
+        "isreg": true,
+        "issock": false,
+        "isuid": false,
+        "mimetype": "application/x-pie-executable",
+        "mode": "0755",
+        "mtime": 1759925846.0,
+        "nlink": 1,
+        "path": "/usr/bin/docker",
+        "pw_name": "root",
+        "readable": true,
+        "rgrp": true,
+        "roth": true,
+        "rusr": true,
+        "size": 45153904,
+        "uid": 0,
+        "version": null,
+        "wgrp": false,
+        "woth": false,
+        "writeable": true,
+        "wusr": true,
+        "xgrp": true,
+        "xoth": true,
+        "xusr": true
+    }
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Check docker service status if binary exists] *******************
+task path: /app/ansible/roles/docker/tasks/main.yaml:7
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746126.2132735-4215-254318620527662 `" && echo ansible-tmp-1762746126.2132735-4215-254318620527662="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746126.2132735-4215-254318620527662 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/service_facts.py
+<127.0.0.1> PUT /tmp/ansible-local-41031umov206/tmpk_b1nq0p TO /home/jules/.ansible/tmp/ansible-tmp-1762746126.2132735-4215-254318620527662/AnsiballZ_service_facts.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746126.2132735-4215-254318620527662/ /home/jules/.ansible/tmp/ansible-tmp-1762746126.2132735-4215-254318620527662/AnsiballZ_service_facts.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-ynvpgzcypxurnryicslpdobbvxwrqrqz ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746126.2132735-4215-254318620527662/AnsiballZ_service_facts.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746126.2132735-4215-254318620527662/ > /dev/null 2>&1 && sleep 0'
+ok: [localhost] => {
+    "ansible_facts": {
+        "services": {
+            "NetworkManager.service": {
+                "name": "NetworkManager.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "not-found"
+            },
+            "apparmor": {
+                "name": "apparmor",
+                "source": "sysv",
+                "state": "stopped"
+            },
+            "apparmor.service": {
+                "name": "apparmor.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "enabled"
+            },
+            "apt-daily-upgrade.service": {
+                "name": "apt-daily-upgrade.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "apt-daily.service": {
+                "name": "apt-daily.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "auditd.service": {
+                "name": "auditd.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "not-found"
+            },
+            "autovt@.service": {
+                "name": "autovt@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "alias"
+            },
+            "connman.service": {
+                "name": "connman.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "not-found"
+            },
+            "console-getty.service": {
+                "name": "console-getty.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "consul.service": {
+                "name": "consul.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "enabled"
+            },
+            "container-getty@.service": {
+                "name": "container-getty@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "containerd.service": {
+                "name": "containerd.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "enabled"
+            },
+            "cryptdisks-early.service": {
+                "name": "cryptdisks-early.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "masked"
+            },
+            "cryptdisks.service": {
+                "name": "cryptdisks.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "masked"
+            },
+            "dbus": {
+                "name": "dbus",
+                "source": "sysv",
+                "state": "running"
+            },
+            "dbus-org.freedesktop.hostname1.service": {
+                "name": "dbus-org.freedesktop.hostname1.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "alias"
+            },
+            "dbus-org.freedesktop.locale1.service": {
+                "name": "dbus-org.freedesktop.locale1.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "alias"
+            },
+            "dbus-org.freedesktop.login1.service": {
+                "name": "dbus-org.freedesktop.login1.service",
+                "source": "systemd",
+                "state": "active",
+                "status": "alias"
+            },
+            "dbus-org.freedesktop.resolve1.service": {
+                "name": "dbus-org.freedesktop.resolve1.service",
+                "source": "systemd",
+                "state": "active",
+                "status": "alias"
+            },
+            "dbus-org.freedesktop.timedate1.service": {
+                "name": "dbus-org.freedesktop.timedate1.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "alias"
+            },
+            "dbus-org.freedesktop.timesync1.service": {
+                "name": "dbus-org.freedesktop.timesync1.service",
+                "source": "systemd",
+                "state": "active",
+                "status": "alias"
+            },
+            "dbus.service": {
+                "name": "dbus.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "static"
+            },
+            "debug-shell.service": {
+                "name": "debug-shell.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "devbox-setup-network.service": {
+                "name": "devbox-setup-network.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "enabled"
+            },
+            "devbox-ssh-over-vsock.service": {
+                "name": "devbox-ssh-over-vsock.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "enabled"
+            },
+            "display-manager.service": {
+                "name": "display-manager.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "not-found"
+            },
+            "docker": {
+                "name": "docker",
+                "source": "sysv",
+                "state": "running"
+            },
+            "docker.service": {
+                "name": "docker.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "enabled"
+            },
+            "dpkg-db-backup.service": {
+                "name": "dpkg-db-backup.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "e2scrub@.service": {
+                "name": "e2scrub@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "e2scrub_all.service": {
+                "name": "e2scrub_all.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "e2scrub_fail@.service": {
+                "name": "e2scrub_fail@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "e2scrub_reap.service": {
+                "name": "e2scrub_reap.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "enabled"
+            },
+            "emergency.service": {
+                "name": "emergency.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "firewalld.service": {
+                "name": "firewalld.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "not-found"
+            },
+            "fstrim.service": {
+                "name": "fstrim.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "getty-static.service": {
+                "name": "getty-static.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "getty@.service": {
+                "name": "getty@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "enabled"
+            },
+            "getty@tty1.service": {
+                "name": "getty@tty1.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "active"
+            },
+            "hwclock.service": {
+                "name": "hwclock.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "masked"
+            },
+            "initrd-cleanup.service": {
+                "name": "initrd-cleanup.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "initrd-parse-etc.service": {
+                "name": "initrd-parse-etc.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "initrd-switch-root.service": {
+                "name": "initrd-switch-root.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "initrd-udevadm-cleanup-db.service": {
+                "name": "initrd-udevadm-cleanup-db.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "kmod-static-nodes.service": {
+                "name": "kmod-static-nodes.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "kmod.service": {
+                "name": "kmod.service",
+                "source": "systemd",
+                "state": "active",
+                "status": "alias"
+            },
+            "ldconfig.service": {
+                "name": "ldconfig.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "lxc.service": {
+                "name": "lxc.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "not-found"
+            },
+            "modprobe@.service": {
+                "name": "modprobe@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "modprobe@configfs.service": {
+                "name": "modprobe@configfs.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "inactive"
+            },
+            "modprobe@dm_mod.service": {
+                "name": "modprobe@dm_mod.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "inactive"
+            },
+            "modprobe@drm.service": {
+                "name": "modprobe@drm.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "inactive"
+            },
+            "modprobe@efi_pstore.service": {
+                "name": "modprobe@efi_pstore.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "inactive"
+            },
+            "modprobe@fuse.service": {
+                "name": "modprobe@fuse.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "inactive"
+            },
+            "modprobe@loop.service": {
+                "name": "modprobe@loop.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "inactive"
+            },
+            "motd-news.service": {
+                "name": "motd-news.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "networkd-dispatcher.service": {
+                "name": "networkd-dispatcher.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "enabled"
+            },
+            "nftables.service": {
+                "name": "nftables.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "packagekit-offline-update.service": {
+                "name": "packagekit-offline-update.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "packagekit.service": {
+                "name": "packagekit.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "static"
+            },
+            "pam_namespace.service": {
+                "name": "pam_namespace.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "plymouth-quit-wait.service": {
+                "name": "plymouth-quit-wait.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "not-found"
+            },
+            "plymouth-start.service": {
+                "name": "plymouth-start.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "not-found"
+            },
+            "polkit.service": {
+                "name": "polkit.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "static"
+            },
+            "procps": {
+                "name": "procps",
+                "source": "sysv",
+                "state": "running"
+            },
+            "procps.service": {
+                "name": "procps.service",
+                "source": "systemd",
+                "state": "active",
+                "status": "alias"
+            },
+            "quotaon.service": {
+                "name": "quotaon.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "rc-local.service": {
+                "name": "rc-local.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "rescue.service": {
+                "name": "rescue.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "rsync": {
+                "name": "rsync",
+                "source": "sysv",
+                "state": "stopped"
+            },
+            "rsync.service": {
+                "name": "rsync.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "serial-getty@.service": {
+                "name": "serial-getty@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "indirect"
+            },
+            "serial-getty@ttyS0.service": {
+                "name": "serial-getty@ttyS0.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "active"
+            },
+            "ssh": {
+                "name": "ssh",
+                "source": "sysv",
+                "state": "running"
+            },
+            "ssh.service": {
+                "name": "ssh.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "enabled"
+            },
+            "sshd.service": {
+                "name": "sshd.service",
+                "source": "systemd",
+                "state": "active",
+                "status": "alias"
+            },
+            "sudo.service": {
+                "name": "sudo.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "masked"
+            },
+            "syslog.service": {
+                "name": "syslog.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "not-found"
+            },
+            "sysstat": {
+                "name": "sysstat",
+                "source": "sysv",
+                "state": "running"
+            },
+            "sysstat-collect.service": {
+                "name": "sysstat-collect.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "sysstat-summary.service": {
+                "name": "sysstat-summary.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "sysstat.service": {
+                "name": "sysstat.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "enabled"
+            },
+            "system-update-cleanup.service": {
+                "name": "system-update-cleanup.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-ask-password-console.service": {
+                "name": "systemd-ask-password-console.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-ask-password-wall.service": {
+                "name": "systemd-ask-password-wall.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-backlight@.service": {
+                "name": "systemd-backlight@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "systemd-battery-check.service": {
+                "name": "systemd-battery-check.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-binfmt.service": {
+                "name": "systemd-binfmt.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-boot-check-no-failures.service": {
+                "name": "systemd-boot-check-no-failures.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-bsod.service": {
+                "name": "systemd-bsod.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-confext.service": {
+                "name": "systemd-confext.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-exit.service": {
+                "name": "systemd-exit.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-firstboot.service": {
+                "name": "systemd-firstboot.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-fsck-root.service": {
+                "name": "systemd-fsck-root.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-fsck@.service": {
+                "name": "systemd-fsck@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "systemd-fsckd.service": {
+                "name": "systemd-fsckd.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-growfs-root.service": {
+                "name": "systemd-growfs-root.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-growfs@.service": {
+                "name": "systemd-growfs@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "systemd-halt.service": {
+                "name": "systemd-halt.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-hibernate-resume.service": {
+                "name": "systemd-hibernate-resume.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-hibernate.service": {
+                "name": "systemd-hibernate.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-hostnamed.service": {
+                "name": "systemd-hostnamed.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-hwdb-update.service": {
+                "name": "systemd-hwdb-update.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-hybrid-sleep.service": {
+                "name": "systemd-hybrid-sleep.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-initctl.service": {
+                "name": "systemd-initctl.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-journal-catalog-update.service": {
+                "name": "systemd-journal-catalog-update.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-journal-flush.service": {
+                "name": "systemd-journal-flush.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-journald.service": {
+                "name": "systemd-journald.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "static"
+            },
+            "systemd-journald@.service": {
+                "name": "systemd-journald@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "systemd-kexec.service": {
+                "name": "systemd-kexec.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-localed.service": {
+                "name": "systemd-localed.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-logind.service": {
+                "name": "systemd-logind.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "static"
+            },
+            "systemd-machine-id-commit.service": {
+                "name": "systemd-machine-id-commit.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-modules-load.service": {
+                "name": "systemd-modules-load.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-network-generator.service": {
+                "name": "systemd-network-generator.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-networkd-wait-online.service": {
+                "name": "systemd-networkd-wait-online.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-networkd-wait-online@.service": {
+                "name": "systemd-networkd-wait-online@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "disabled"
+            },
+            "systemd-networkd.service": {
+                "name": "systemd-networkd.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "disabled"
+            },
+            "systemd-oomd.service": {
+                "name": "systemd-oomd.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "not-found"
+            },
+            "systemd-pcrextend@.service": {
+                "name": "systemd-pcrextend@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "systemd-pcrfs-root.service": {
+                "name": "systemd-pcrfs-root.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-pcrfs@.service": {
+                "name": "systemd-pcrfs@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "systemd-pcrlock-file-system.service": {
+                "name": "systemd-pcrlock-file-system.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-pcrlock-firmware-code.service": {
+                "name": "systemd-pcrlock-firmware-code.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-pcrlock-firmware-config.service": {
+                "name": "systemd-pcrlock-firmware-config.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-pcrlock-machine-id.service": {
+                "name": "systemd-pcrlock-machine-id.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-pcrlock-make-policy.service": {
+                "name": "systemd-pcrlock-make-policy.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-pcrlock-secureboot-authority.service": {
+                "name": "systemd-pcrlock-secureboot-authority.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-pcrlock-secureboot-policy.service": {
+                "name": "systemd-pcrlock-secureboot-policy.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-pcrmachine.service": {
+                "name": "systemd-pcrmachine.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-pcrphase-initrd.service": {
+                "name": "systemd-pcrphase-initrd.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-pcrphase-sysinit.service": {
+                "name": "systemd-pcrphase-sysinit.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-pcrphase.service": {
+                "name": "systemd-pcrphase.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-poweroff.service": {
+                "name": "systemd-poweroff.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-pstore.service": {
+                "name": "systemd-pstore.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "enabled"
+            },
+            "systemd-quotacheck.service": {
+                "name": "systemd-quotacheck.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-random-seed.service": {
+                "name": "systemd-random-seed.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-reboot.service": {
+                "name": "systemd-reboot.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-remount-fs.service": {
+                "name": "systemd-remount-fs.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "enabled-runtime"
+            },
+            "systemd-repart.service": {
+                "name": "systemd-repart.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-resolved.service": {
+                "name": "systemd-resolved.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "enabled"
+            },
+            "systemd-rfkill.service": {
+                "name": "systemd-rfkill.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-soft-reboot.service": {
+                "name": "systemd-soft-reboot.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-storagetm.service": {
+                "name": "systemd-storagetm.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-suspend-then-hibernate.service": {
+                "name": "systemd-suspend-then-hibernate.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-suspend.service": {
+                "name": "systemd-suspend.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-sysctl.service": {
+                "name": "systemd-sysctl.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-sysext.service": {
+                "name": "systemd-sysext.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "disabled"
+            },
+            "systemd-sysext@.service": {
+                "name": "systemd-sysext@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "systemd-sysupdate-reboot.service": {
+                "name": "systemd-sysupdate-reboot.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "indirect"
+            },
+            "systemd-sysupdate.service": {
+                "name": "systemd-sysupdate.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "indirect"
+            },
+            "systemd-sysusers.service": {
+                "name": "systemd-sysusers.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-time-wait-sync.service": {
+                "name": "systemd-time-wait-sync.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "disabled"
+            },
+            "systemd-timedated.service": {
+                "name": "systemd-timedated.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "systemd-timesyncd.service": {
+                "name": "systemd-timesyncd.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "enabled"
+            },
+            "systemd-tmpfiles-clean.service": {
+                "name": "systemd-tmpfiles-clean.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-tmpfiles-setup-dev-early.service": {
+                "name": "systemd-tmpfiles-setup-dev-early.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-tmpfiles-setup-dev.service": {
+                "name": "systemd-tmpfiles-setup-dev.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-tmpfiles-setup.service": {
+                "name": "systemd-tmpfiles-setup.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-tpm2-setup-early.service": {
+                "name": "systemd-tpm2-setup-early.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-tpm2-setup.service": {
+                "name": "systemd-tpm2-setup.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-udev-settle.service": {
+                "name": "systemd-udev-settle.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-udev-trigger.service": {
+                "name": "systemd-udev-trigger.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-udevd.service": {
+                "name": "systemd-udevd.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "static"
+            },
+            "systemd-update-done.service": {
+                "name": "systemd-update-done.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-update-utmp-runlevel.service": {
+                "name": "systemd-update-utmp-runlevel.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-update-utmp.service": {
+                "name": "systemd-update-utmp.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-user-sessions.service": {
+                "name": "systemd-user-sessions.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "static"
+            },
+            "systemd-vconsole-setup.service": {
+                "name": "systemd-vconsole-setup.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "not-found"
+            },
+            "systemd-volatile-root.service": {
+                "name": "systemd-volatile-root.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "static"
+            },
+            "ubuntu-fan": {
+                "name": "ubuntu-fan",
+                "source": "sysv",
+                "state": "running"
+            },
+            "ubuntu-fan.service": {
+                "name": "ubuntu-fan.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "enabled"
+            },
+            "udev.service": {
+                "name": "udev.service",
+                "source": "systemd",
+                "state": "active",
+                "status": "alias"
+            },
+            "unattended-upgrades": {
+                "name": "unattended-upgrades",
+                "source": "sysv",
+                "state": "running"
+            },
+            "unattended-upgrades.service": {
+                "name": "unattended-upgrades.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "enabled"
+            },
+            "user-runtime-dir@.service": {
+                "name": "user-runtime-dir@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "user-runtime-dir@1001.service": {
+                "name": "user-runtime-dir@1001.service",
+                "source": "systemd",
+                "state": "stopped",
+                "status": "active"
+            },
+            "user@.service": {
+                "name": "user@.service",
+                "source": "systemd",
+                "state": "unknown",
+                "status": "static"
+            },
+            "user@1001.service": {
+                "name": "user@1001.service",
+                "source": "systemd",
+                "state": "running",
+                "status": "active"
+            },
+            "x11-common": {
+                "name": "x11-common",
+                "source": "sysv",
+                "state": "stopped"
+            },
+            "x11-common.service": {
+                "name": "x11-common.service",
+                "source": "systemd",
+                "state": "inactive",
+                "status": "masked"
+            }
+        }
+    },
+    "changed": false,
+    "invocation": {
+        "module_args": {}
+    }
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Purge any conflicting Docker and containerd packages] ***********
+task path: /app/ansible/roles/docker/tasks/main.yaml:20
+skipping: [localhost] => {
+    "changed": false,
+    "false_condition": "not docker_stat_result.stat.exists or docker_is_broken is defined",
+    "skip_reason": "Conditional result was False"
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Remove leftover Docker data directories] ************************
+task path: /app/ansible/roles/docker/tasks/main.yaml:33
+skipping: [localhost] => (item=/var/lib/docker)  => {
+    "ansible_loop_var": "docker_dir",
+    "changed": false,
+    "docker_dir": "/var/lib/docker",
+    "false_condition": "not docker_stat_result.stat.exists or docker_is_broken is defined",
+    "skip_reason": "Conditional result was False"
+}
+skipping: [localhost] => (item=/var/lib/containerd)  => {
+    "ansible_loop_var": "docker_dir",
+    "changed": false,
+    "docker_dir": "/var/lib/containerd",
+    "false_condition": "not docker_stat_result.stat.exists or docker_is_broken is defined",
+    "skip_reason": "Conditional result was False"
+}
+skipping: [localhost] => {
+    "changed": false,
+    "msg": "All items skipped"
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Ensure /etc/docker directory exists] ****************************
+task path: /app/ansible/roles/docker/tasks/main.yaml:44
+skipping: [localhost] => {
+    "changed": false,
+    "false_condition": "not docker_stat_result.stat.exists or docker_is_broken is defined",
+    "skip_reason": "Conditional result was False"
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Download the get-docker.sh script] ******************************
+task path: /app/ansible/roles/docker/tasks/main.yaml:51
+skipping: [localhost] => {
+    "changed": false,
+    "false_condition": "not docker_stat_result.stat.exists or docker_is_broken is defined",
+    "skip_reason": "Conditional result was False"
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Run the Docker installation script] *****************************
+task path: /app/ansible/roles/docker/tasks/main.yaml:57
+skipping: [localhost] => {
+    "changed": false,
+    "false_condition": "not docker_stat_result.stat.exists or docker_is_broken is defined",
+    "skip_reason": "Conditional result was False"
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Add user to the 'docker' group for rootless execution] **********
+task path: /app/ansible/roles/docker/tasks/main.yaml:62
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746128.8107672-4490-14332383809042 `" && echo ansible-tmp-1762746128.8107672-4490-14332383809042="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746128.8107672-4490-14332383809042 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/user.py
+<127.0.0.1> PUT /tmp/ansible-local-41031umov206/tmpo54h4nu3 TO /home/jules/.ansible/tmp/ansible-tmp-1762746128.8107672-4490-14332383809042/AnsiballZ_user.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746128.8107672-4490-14332383809042/ /home/jules/.ansible/tmp/ansible-tmp-1762746128.8107672-4490-14332383809042/AnsiballZ_user.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-fvqwiddbskubfoywqetbhlstapzqiami ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746128.8107672-4490-14332383809042/AnsiballZ_user.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746128.8107672-4490-14332383809042/ > /dev/null 2>&1 && sleep 0'
+changed: [localhost] => {
+    "append": true,
+    "changed": true,
+    "comment": "",
+    "group": 1002,
+    "groups": "docker",
+    "home": "/home/pipecatapp",
+    "invocation": {
+        "module_args": {
+            "append": true,
+            "authorization": null,
+            "comment": null,
+            "create_home": true,
+            "expires": null,
+            "force": false,
+            "generate_ssh_key": null,
+            "group": null,
+            "groups": [
+                "docker"
+            ],
+            "hidden": null,
+            "home": null,
+            "local": null,
+            "login_class": null,
+            "move_home": false,
+            "name": "pipecatapp",
+            "non_unique": false,
+            "password": null,
+            "password_expire_account_disable": null,
+            "password_expire_max": null,
+            "password_expire_min": null,
+            "password_expire_warn": null,
+            "password_lock": null,
+            "profile": null,
+            "remove": false,
+            "role": null,
+            "seuser": null,
+            "shell": null,
+            "skeleton": null,
+            "ssh_key_bits": 0,
+            "ssh_key_comment": "ansible-generated on devbox",
+            "ssh_key_file": null,
+            "ssh_key_passphrase": null,
+            "ssh_key_type": "rsa",
+            "state": "present",
+            "system": false,
+            "uid": null,
+            "uid_max": null,
+            "uid_min": null,
+            "umask": null,
+            "update_password": "always"
+        }
+    },
+    "move_home": false,
+    "name": "pipecatapp",
+    "shell": "/bin/bash",
+    "state": "present",
+    "uid": 1002
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Add root user to the 'docker' group] ****************************
+task path: /app/ansible/roles/docker/tasks/main.yaml:69
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746129.5662267-4526-42480438555713 `" && echo ansible-tmp-1762746129.5662267-4526-42480438555713="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746129.5662267-4526-42480438555713 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/user.py
+<127.0.0.1> PUT /tmp/ansible-local-41031umov206/tmp0s4qndd6 TO /home/jules/.ansible/tmp/ansible-tmp-1762746129.5662267-4526-42480438555713/AnsiballZ_user.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746129.5662267-4526-42480438555713/ /home/jules/.ansible/tmp/ansible-tmp-1762746129.5662267-4526-42480438555713/AnsiballZ_user.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-kfmvlkzpfkmelejofekdszpkarcjvupy ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746129.5662267-4526-42480438555713/AnsiballZ_user.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746129.5662267-4526-42480438555713/ > /dev/null 2>&1 && sleep 0'
+changed: [localhost] => {
+    "append": true,
+    "changed": true,
+    "comment": "root",
+    "group": 0,
+    "groups": "docker",
+    "home": "/root",
+    "invocation": {
+        "module_args": {
+            "append": true,
+            "authorization": null,
+            "comment": null,
+            "create_home": true,
+            "expires": null,
+            "force": false,
+            "generate_ssh_key": null,
+            "group": null,
+            "groups": [
+                "docker"
+            ],
+            "hidden": null,
+            "home": null,
+            "local": null,
+            "login_class": null,
+            "move_home": false,
+            "name": "root",
+            "non_unique": false,
+            "password": null,
+            "password_expire_account_disable": null,
+            "password_expire_max": null,
+            "password_expire_min": null,
+            "password_expire_warn": null,
+            "password_lock": null,
+            "profile": null,
+            "remove": false,
+            "role": null,
+            "seuser": null,
+            "shell": null,
+            "skeleton": null,
+            "ssh_key_bits": 0,
+            "ssh_key_comment": "ansible-generated on devbox",
+            "ssh_key_file": null,
+            "ssh_key_passphrase": null,
+            "ssh_key_type": "rsa",
+            "state": "present",
+            "system": false,
+            "uid": null,
+            "uid_max": null,
+            "uid_min": null,
+            "umask": null,
+            "update_password": "always"
+        }
+    },
+    "move_home": false,
+    "name": "root",
+    "shell": "/bin/bash",
+    "state": "present",
+    "uid": 0
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Place the Docker daemon configuration file] *********************
+task path: /app/ansible/roles/docker/tasks/main.yaml:76
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007 `" && echo ansible-tmp-1762746130.058691-4562-103018135680007="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/stat.py
+<127.0.0.1> PUT /tmp/ansible-local-41031umov206/tmpdoyfqlh2 TO /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/AnsiballZ_stat.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/ /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/AnsiballZ_stat.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-vscypbuhcknyrorzkjybpwmwnibrphxe ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/AnsiballZ_stat.py'"'"' && sleep 0'
+<127.0.0.1> PUT /tmp/ansible-local-41031umov206/tmp5_ics67x/daemon.json.j2 TO /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/.source.json
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/ /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/.source.json && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/copy.py
+<127.0.0.1> PUT /tmp/ansible-local-41031umov206/tmpoo4y2xrk TO /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/AnsiballZ_copy.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/ /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/AnsiballZ_copy.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-xdzinogxswrzazwrvldonbwclhktmkbi ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/AnsiballZ_copy.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/ > /dev/null 2>&1 && sleep 0'
+Notification for handler Restart Docker has been saved.
+changed: [localhost] => {
+    "changed": true,
+    "checksum": "97ef3cc58acf42758983ae396c69c95cd08c8d1e",
+    "dest": "/etc/docker/daemon.json",
+    "diff": [],
+    "gid": 0,
+    "group": "root",
+    "invocation": {
+        "module_args": {
+            "_original_basename": "daemon.json.j2",
+            "attributes": null,
+            "backup": false,
+            "checksum": "97ef3cc58acf42758983ae396c69c95cd08c8d1e",
+            "content": null,
+            "dest": "/etc/docker/daemon.json",
+            "directory_mode": null,
+            "follow": false,
+            "force": true,
+            "group": null,
+            "local_follow": null,
+            "mode": "0644",
+            "owner": null,
+            "remote_src": false,
+            "selevel": null,
+            "serole": null,
+            "setype": null,
+            "seuser": null,
+            "src": "/home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/.source.json",
+            "unsafe_writes": false,
+            "validate": null
+        }
+    },
+    "md5sum": "08573e7533a49d2dfe7923e141026355",
+    "mode": "0644",
+    "owner": "root",
+    "size": 126,
+    "src": "/home/jules/.ansible/tmp/ansible-tmp-1762746130.058691-4562-103018135680007/.source.json",
+    "state": "file",
+    "uid": 0
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Ensure Docker service is started and enabled] *******************
+task path: /app/ansible/roles/docker/tasks/main.yaml:84
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746130.9904435-4603-92164062178866 `" && echo ansible-tmp-1762746130.9904435-4603-92164062178866="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746130.9904435-4603-92164062178866 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/systemd.py
+<127.0.0.1> PUT /tmp/ansible-local-41031umov206/tmpuxyht88_ TO /home/jules/.ansible/tmp/ansible-tmp-1762746130.9904435-4603-92164062178866/AnsiballZ_systemd.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746130.9904435-4603-92164062178866/ /home/jules/.ansible/tmp/ansible-tmp-1762746130.9904435-4603-92164062178866/AnsiballZ_systemd.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-gxmqwsakouueusurlurlezawjhomaqgo ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746130.9904435-4603-92164062178866/AnsiballZ_systemd.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746130.9904435-4603-92164062178866/ > /dev/null 2>&1 && sleep 0'
+ok: [localhost] => {
+    "changed": false,
+    "enabled": true,
+    "invocation": {
+        "module_args": {
+            "daemon_reexec": false,
+            "daemon_reload": false,
+            "enabled": true,
+            "force": null,
+            "masked": null,
+            "name": "docker",
+            "no_block": false,
+            "scope": "system",
+            "state": "started"
+        }
+    },
+    "name": "docker",
+    "state": "started",
+    "status": {
+        "ActiveEnterTimestamp": "Mon 2025-11-10 03:37:57 UTC",
+        "ActiveEnterTimestampMonotonic": "19100268",
+        "ActiveExitTimestampMonotonic": "0",
+        "ActiveState": "active",
+        "After": "systemd-journald.socket basic.target network-online.target containerd.service nss-lookup.target firewalld.service system.slice sysinit.target time-set.target docker.socket",
+        "AllowIsolate": "no",
+        "AssertResult": "yes",
+        "AssertTimestamp": "Fri 2025-10-10 19:18:55 UTC",
+        "AssertTimestampMonotonic": "11803215",
+        "Before": "multi-user.target shutdown.target",
+        "BlockIOAccounting": "no",
+        "BlockIOWeight": "[not set]",
+        "CPUAccounting": "yes",
+        "CPUAffinityFromNUMA": "no",
+        "CPUQuotaPerSecUSec": "infinity",
+        "CPUQuotaPeriodUSec": "infinity",
+        "CPUSchedulingPolicy": "0",
+        "CPUSchedulingPriority": "0",
+        "CPUSchedulingResetOnFork": "no",
+        "CPUShares": "[not set]",
+        "CPUUsageNSec": "2621941310871000",
+        "CPUWeight": "[not set]",
+        "CacheDirectoryMode": "0755",
+        "CanFreeze": "yes",
+        "CanIsolate": "no",
+        "CanReload": "yes",
+        "CanStart": "yes",
+        "CanStop": "yes",
+        "CapabilityBoundingSet": "cap_chown cap_dac_override cap_dac_read_search cap_fowner cap_fsetid cap_kill cap_setgid cap_setuid cap_setpcap cap_linux_immutable cap_net_bind_service cap_net_broadcast cap_net_admin cap_net_raw cap_ipc_lock cap_ipc_owner cap_sys_module cap_sys_rawio cap_sys_chroot cap_sys_ptrace cap_sys_pacct cap_sys_admin cap_sys_boot cap_sys_nice cap_sys_resource cap_sys_time cap_sys_tty_config cap_mknod cap_lease cap_audit_write cap_audit_control cap_setfcap cap_mac_override cap_mac_admin cap_syslog cap_wake_alarm cap_block_suspend cap_audit_read cap_perfmon cap_bpf cap_checkpoint_restore",
+        "CleanResult": "success",
+        "CollectMode": "inactive",
+        "ConditionResult": "yes",
+        "ConditionTimestamp": "Fri 2025-10-10 19:18:55 UTC",
+        "ConditionTimestampMonotonic": "11803213",
+        "ConfigurationDirectoryMode": "0755",
+        "Conflicts": "shutdown.target",
+        "ControlGroup": "/system.slice/docker.service",
+        "ControlGroupId": "2689",
+        "ControlPID": "0",
+        "CoredumpFilter": "0x33",
+        "CoredumpReceive": "no",
+        "DefaultDependencies": "yes",
+        "DefaultMemoryLow": "0",
+        "DefaultMemoryMin": "0",
+        "DefaultStartupMemoryLow": "0",
+        "Delegate": "yes",
+        "DelegateControllers": "cpu cpuset io memory pids",
+        "Description": "Docker Application Container Engine",
+        "DevicePolicy": "auto",
+        "Documentation": "https://docs.docker.com",
+        "DynamicUser": "no",
+        "EffectiveCPUs": "0-3",
+        "EffectiveMemoryNodes": "0",
+        "ExecMainCode": "0",
+        "ExecMainExitTimestampMonotonic": "0",
+        "ExecMainPID": "921",
+        "ExecMainStartTimestamp": "Fri 2025-10-10 19:18:55 UTC",
+        "ExecMainStartTimestampMonotonic": "11805182",
+        "ExecMainStatus": "0",
+        "ExecReload": "{ path=/bin/kill ; argv[]=/bin/kill -s HUP $MAINPID ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }",
+        "ExecReloadEx": "{ path=/bin/kill ; argv[]=/bin/kill -s HUP $MAINPID ; flags= ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }",
+        "ExecStart": "{ path=/usr/bin/dockerd ; argv[]=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }",
+        "ExecStartEx": "{ path=/usr/bin/dockerd ; argv[]=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock ; flags= ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }",
+        "ExitType": "main",
+        "ExtensionImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent",
+        "FailureAction": "none",
+        "FileDescriptorStoreMax": "0",
+        "FileDescriptorStorePreserve": "restart",
+        "FinalKillSignal": "9",
+        "FragmentPath": "/usr/lib/systemd/system/docker.service",
+        "FreezerState": "running",
+        "GID": "[not set]",
+        "GuessMainPID": "yes",
+        "IOAccounting": "no",
+        "IOReadBytes": "[not set]",
+        "IOReadOperations": "[not set]",
+        "IOSchedulingClass": "2",
+        "IOSchedulingPriority": "4",
+        "IOWeight": "[not set]",
+        "IOWriteBytes": "[not set]",
+        "IOWriteOperations": "[not set]",
+        "IPAccounting": "no",
+        "IPEgressBytes": "[no data]",
+        "IPEgressPackets": "[no data]",
+        "IPIngressBytes": "[no data]",
+        "IPIngressPackets": "[no data]",
+        "Id": "docker.service",
+        "IgnoreOnIsolate": "no",
+        "IgnoreSIGPIPE": "yes",
+        "InactiveEnterTimestampMonotonic": "0",
+        "InactiveExitTimestamp": "Fri 2025-10-10 19:18:55 UTC",
+        "InactiveExitTimestampMonotonic": "11805328",
+        "InvocationID": "97317051eade4413b698e304a35a352b",
+        "JobRunningTimeoutUSec": "infinity",
+        "JobTimeoutAction": "none",
+        "JobTimeoutUSec": "infinity",
+        "KeyringMode": "private",
+        "KillMode": "process",
+        "KillSignal": "15",
+        "LimitAS": "infinity",
+        "LimitASSoft": "infinity",
+        "LimitCORE": "infinity",
+        "LimitCORESoft": "infinity",
+        "LimitCPU": "infinity",
+        "LimitCPUSoft": "infinity",
+        "LimitDATA": "infinity",
+        "LimitDATASoft": "infinity",
+        "LimitFSIZE": "infinity",
+        "LimitFSIZESoft": "infinity",
+        "LimitLOCKS": "infinity",
+        "LimitLOCKSSoft": "infinity",
+        "LimitMEMLOCK": "8388608",
+        "LimitMEMLOCKSoft": "8388608",
+        "LimitMSGQUEUE": "819200",
+        "LimitMSGQUEUESoft": "819200",
+        "LimitNICE": "0",
+        "LimitNICESoft": "0",
+        "LimitNOFILE": "524288",
+        "LimitNOFILESoft": "1024",
+        "LimitNPROC": "infinity",
+        "LimitNPROCSoft": "infinity",
+        "LimitRSS": "infinity",
+        "LimitRSSSoft": "infinity",
+        "LimitRTPRIO": "0",
+        "LimitRTPRIOSoft": "0",
+        "LimitRTTIME": "infinity",
+        "LimitRTTIMESoft": "infinity",
+        "LimitSIGPENDING": "31821",
+        "LimitSIGPENDINGSoft": "31821",
+        "LimitSTACK": "infinity",
+        "LimitSTACKSoft": "8388608",
+        "LoadState": "loaded",
+        "LockPersonality": "no",
+        "LogLevelMax": "-1",
+        "LogRateLimitBurst": "0",
+        "LogRateLimitIntervalUSec": "0",
+        "LogsDirectoryMode": "0755",
+        "MainPID": "921",
+        "ManagedOOMMemoryPressure": "auto",
+        "ManagedOOMMemoryPressureLimit": "0",
+        "ManagedOOMPreference": "none",
+        "ManagedOOMSwap": "auto",
+        "MemoryAccounting": "yes",
+        "MemoryAvailable": "7802404864",
+        "MemoryCurrent": "109932544",
+        "MemoryDenyWriteExecute": "no",
+        "MemoryHigh": "infinity",
+        "MemoryKSM": "no",
+        "MemoryLimit": "infinity",
+        "MemoryLow": "0",
+        "MemoryMax": "infinity",
+        "MemoryMin": "0",
+        "MemoryPeak": "111456256",
+        "MemoryPressureThresholdUSec": "200ms",
+        "MemoryPressureWatch": "auto",
+        "MemorySwapCurrent": "0",
+        "MemorySwapMax": "infinity",
+        "MemorySwapPeak": "0",
+        "MemoryZSwapCurrent": "[not set]",
+        "MemoryZSwapMax": "infinity",
+        "MountAPIVFS": "no",
+        "MountImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent",
+        "NFileDescriptorStore": "0",
+        "NRestarts": "0",
+        "NUMAPolicy": "n/a",
+        "Names": "docker.service",
+        "NeedDaemonReload": "no",
+        "Nice": "0",
+        "NoNewPrivileges": "no",
+        "NonBlocking": "no",
+        "NotifyAccess": "main",
+        "OOMPolicy": "continue",
+        "OOMScoreAdjust": "-500",
+        "OnFailureJobMode": "replace",
+        "OnSuccessJobMode": "fail",
+        "Perpetual": "no",
+        "PrivateDevices": "no",
+        "PrivateIPC": "no",
+        "PrivateMounts": "no",
+        "PrivateNetwork": "no",
+        "PrivateTmp": "no",
+        "PrivateUsers": "no",
+        "ProcSubset": "all",
+        "ProtectClock": "no",
+        "ProtectControlGroups": "no",
+        "ProtectHome": "no",
+        "ProtectHostname": "no",
+        "ProtectKernelLogs": "no",
+        "ProtectKernelModules": "no",
+        "ProtectKernelTunables": "no",
+        "ProtectProc": "default",
+        "ProtectSystem": "no",
+        "RefuseManualStart": "no",
+        "RefuseManualStop": "no",
+        "ReloadResult": "success",
+        "ReloadSignal": "1",
+        "RemainAfterExit": "no",
+        "RemoveIPC": "no",
+        "Requires": "docker.socket system.slice sysinit.target",
+        "Restart": "always",
+        "RestartKillSignal": "15",
+        "RestartMaxDelayUSec": "infinity",
+        "RestartMode": "normal",
+        "RestartSteps": "0",
+        "RestartUSec": "2s",
+        "RestartUSecNext": "2s",
+        "RestrictNamespaces": "no",
+        "RestrictRealtime": "no",
+        "RestrictSUIDSGID": "no",
+        "Result": "success",
+        "RootDirectoryStartOnly": "no",
+        "RootEphemeral": "no",
+        "RootImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent",
+        "RuntimeDirectoryMode": "0755",
+        "RuntimeDirectoryPreserve": "no",
+        "RuntimeMaxUSec": "infinity",
+        "RuntimeRandomizedExtraUSec": "0",
+        "SameProcessGroup": "no",
+        "SecureBits": "0",
+        "SendSIGHUP": "no",
+        "SendSIGKILL": "yes",
+        "SetLoginEnvironment": "no",
+        "Slice": "system.slice",
+        "StandardError": "inherit",
+        "StandardInput": "null",
+        "StandardOutput": "journal",
+        "StartLimitAction": "none",
+        "StartLimitBurst": "3",
+        "StartLimitIntervalUSec": "1min",
+        "StartupBlockIOWeight": "[not set]",
+        "StartupCPUShares": "[not set]",
+        "StartupCPUWeight": "[not set]",
+        "StartupIOWeight": "[not set]",
+        "StartupMemoryHigh": "infinity",
+        "StartupMemoryLow": "0",
+        "StartupMemoryMax": "infinity",
+        "StartupMemorySwapMax": "infinity",
+        "StartupMemoryZSwapMax": "infinity",
+        "StateChangeTimestamp": "Mon 2025-11-10 03:37:57 UTC",
+        "StateChangeTimestampMonotonic": "19100268",
+        "StateDirectoryMode": "0755",
+        "StatusErrno": "0",
+        "StopWhenUnneeded": "no",
+        "SubState": "running",
+        "SuccessAction": "none",
+        "SurviveFinalKillSignal": "no",
+        "SyslogFacility": "3",
+        "SyslogLevel": "6",
+        "SyslogLevelPrefix": "yes",
+        "SyslogPriority": "30",
+        "SystemCallErrorNumber": "2147483646",
+        "TTYReset": "no",
+        "TTYVHangup": "no",
+        "TTYVTDisallocate": "no",
+        "TasksAccounting": "yes",
+        "TasksCurrent": "10",
+        "TasksMax": "infinity",
+        "TimeoutAbortUSec": "1min 30s",
+        "TimeoutCleanUSec": "infinity",
+        "TimeoutStartFailureMode": "terminate",
+        "TimeoutStartUSec": "infinity",
+        "TimeoutStopFailureMode": "terminate",
+        "TimeoutStopUSec": "1min 30s",
+        "TimerSlackNSec": "50000",
+        "Transient": "no",
+        "TriggeredBy": "docker.socket",
+        "Type": "notify",
+        "UID": "[not set]",
+        "UMask": "0022",
+        "UnitFilePreset": "enabled",
+        "UnitFileState": "enabled",
+        "UtmpMode": "init",
+        "WantedBy": "multi-user.target",
+        "Wants": "network-online.target containerd.service",
+        "WatchdogSignal": "6",
+        "WatchdogTimestampMonotonic": "0",
+        "WatchdogUSec": "0"
+    }
+}
+Read `vars_file` '/app/group_vars/all.yaml'.
+
+TASK [docker : Load pipecatapp image] ******************************************
+task path: /app/ansible/roles/docker/tasks/main.yaml:91
+<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: jules
+<127.0.0.1> EXEC /bin/sh -c 'echo ~jules && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jules/.ansible/tmp `"&& mkdir "` echo /home/jules/.ansible/tmp/ansible-tmp-1762746131.9866483-4632-266687821349788 `" && echo ansible-tmp-1762746131.9866483-4632-266687821349788="` echo /home/jules/.ansible/tmp/ansible-tmp-1762746131.9866483-4632-266687821349788 `" ) && sleep 0'
+Using module file /home/jules/.pyenv/versions/3.12.12/lib/python3.12/site-packages/ansible/modules/command.py
+<127.0.0.1> PUT /tmp/ansible-local-41031umov206/tmpu5q0i7u3 TO /home/jules/.ansible/tmp/ansible-tmp-1762746131.9866483-4632-266687821349788/AnsiballZ_command.py
+<127.0.0.1> EXEC /bin/sh -c 'chmod u+rwx /home/jules/.ansible/tmp/ansible-tmp-1762746131.9866483-4632-266687821349788/ /home/jules/.ansible/tmp/ansible-tmp-1762746131.9866483-4632-266687821349788/AnsiballZ_command.py && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-fpxyfkiayreyaibohibzhepomxziuqxz ; /usr/bin/python3 /home/jules/.ansible/tmp/ansible-tmp-1762746131.9866483-4632-266687821349788/AnsiballZ_command.py'"'"' && sleep 0'
+<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/jules/.ansible/tmp/ansible-tmp-1762746131.9866483-4632-266687821349788/ > /dev/null 2>&1 && sleep 0'
+[ERROR]: Task failed: Module failed: non-zero return code
+Origin: /app/ansible/roles/docker/tasks/main.yaml:91:3
+
+89   become: yes
+90
+91 - name: Load pipecatapp image
+     ^ column 3
+
+fatal: [localhost]: FAILED! => {
+    "changed": true,
+    "cmd": [
+        "docker",
+        "load",
+        "-i",
+        "/tmp/pipecatapp.tar"
+    ],
+    "delta": "0:00:00.035187",
+    "end": "2025-11-10 03:42:12.561853",
+    "invocation": {
+        "module_args": {
+            "_raw_params": null,
+            "_uses_shell": false,
+            "argv": null,
+            "chdir": null,
+            "cmd": "docker load -i /tmp/pipecatapp.tar",
+            "creates": null,
+            "executable": null,
+            "expand_argument_vars": true,
+            "removes": null,
+            "stdin": null,
+            "stdin_add_newline": true,
+            "strip_empty_ends": true
+        }
+    },
+    "msg": "non-zero return code",
+    "rc": 1,
+    "start": "2025-11-10 03:42:12.526666",
+    "stderr": "open /tmp/pipecatapp.tar: no such file or directory",
+    "stderr_lines": [
+        "open /tmp/pipecatapp.tar: no such file or directory"
+    ],
+    "stdout": "",
+    "stdout_lines": []
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=7    changed=3    unreachable=0    failed=1    skipped=5    rescued=0    ignored=0


### PR DESCRIPTION
Set address_mode = "host" in the Consul service health check for the llamacpp-rpc Nomad job.

When a Nomad job uses `network { mode = "host" }`, the health check defaults to checking 127.0.0.1 within the task's network namespace, which can fail. Explicitly setting `address_mode = "host"` ensures the check targets the host's IP address where the service is actually listening.

This resolves a deployment timeout issue where the job would continuously fail its health check and be restarted until the deployment deadline was exceeded.