### PR TITLE
Fix: Correct arguments for rpc-server in Nomad job

### DIFF
--- a/ansible/jobs/llamacpp-rpc.nomad.j2
+++ b/ansible/jobs/llamacpp-rpc.nomad.j2
@@ -57,7 +57,7 @@ job "{{ job_name | default('llamacpp-rpc-pool') }}" {
         command = "/bin/bash"
         args = [
           "-c",
-          "/usr/local/bin/rpc-server -m /opt/nomad/models/llm/{{ model.filename }} -H 0.0.0.0 -p $NOMAD_PORT_rpc -ngl 0"
+          "/usr/local/bin/rpc-server -H 0.0.0.0 -p $NOMAD_PORT_rpc"
         ]
       }
 


### PR DESCRIPTION
The rpc-server executable was being called with the '-m' and '-ngl' arguments, which are not supported and caused the job to fail on startup.

This commit removes the unsupported arguments from the command in the llamacpp-rpc.nomad.j2 template.

The rpc-server is designed to be a generic worker that gets assigned a model at runtime by the orchestrator via Consul service discovery, so it does not need a model specified at launch.