### PR TITLE
Fix: Remove incorrect docker load task

### DIFF
--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -88,8 +88,4 @@
     enabled: yes
   become: yes
 
-- name: Load pipecatapp image
-  ansible.builtin.command:
-    cmd: docker load -i /tmp/pipecatapp.tar
-  become: yes
 

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -180,6 +180,7 @@
     source: build
   when: pipecat_deployment_style == 'docker'
 
+
 - name: Ensure Nomad jobs directory exists
   ansible.builtin.file:
     path: /opt/nomad/jobs


### PR DESCRIPTION
The ansible playbook was failing during the execution of the 'docker' role because it was trying to load a docker image from `/tmp/pipecatapp.tar` which did not exist.

This was happening because the `docker load` task was in the wrong place. The `pipecatapp` image is built later in the `pipecatapp` role.

This commit removes the `docker load` task from the `docker` role, which resolves the error. The image is already available locally after the `docker build` step in the `pipecatapp` role, so no further action is needed.