### PR TITLE
feat(agent): add and configure llxprt-code tool

### DIFF
--- a/ansible/roles/llxprt_code/tasks/main.yaml
+++ b/ansible/roles/llxprt_code/tasks/main.yaml
@@ -1,0 +1,22 @@
+---
+- name: Clone llxprt-code repository
+  ansible.builtin.git:
+    repo: 'https://github.com/vybestack/llxprt-code.git'
+    dest: /opt/llxprt-code
+    version: main
+
+- name: Install llxprt-code dependencies
+  ansible.builtin.npm:
+    path: /opt/llxprt-code
+    state: present
+
+- name: Install llxprt-code globally
+  ansible.builtin.npm:
+    path: /opt/llxprt-code
+    state: present
+    global: yes
+
+- name: Configure llxprt-code
+  ansible.builtin.template:
+    src: llxprt-code.env.j2
+    dest: /opt/llxprt-code/.env

--- a/ansible/roles/llxprt_code/templates/llxprt-code.env.j2
+++ b/ansible/roles/llxprt_code/templates/llxprt-code.env.j2
@@ -1,0 +1,3 @@
+LLXPRT_PROVIDER=openai
+LLXPRT_BASEURL="http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ hostvars[inventory_hostname]['pipecat_port'] }}"
+LLXPRT_API_KEY={{ openai_api_key }}

--- a/ansible/roles/pipecatapp/files/app.py
+++ b/ansible/roles/pipecatapp/files/app.py
@@ -44,6 +44,7 @@ from tools.rag_tool import RAG_Tool
 from tools.ha_tool import HA_Tool
 from tools.git_tool import Git_Tool
 from tools.orchestrator_tool import OrchestratorTool
+from tools.llxprt_code_tool import LLxprt_Code_Tool
 
 import uvicorn
 
@@ -550,6 +551,7 @@ class TwinService(FrameProcessor):
             ),
             "git": Git_Tool(),
             "orchestrator": OrchestratorTool(),
+            "llxprt_code": LLxprt_Code_Tool(),
         }
 
         if self.app_config.get("use_summarizer", False):

--- a/ansible/roles/pipecatapp/files/tools/llxprt_code_tool.py
+++ b/ansible/roles/pipecatapp/files/tools/llxprt_code_tool.py
@@ -1,0 +1,54 @@
+import subprocess
+import os
+import shlex
+from dotenv import load_dotenv
+
+class LLxprt_Code_Tool:
+    """A tool for running llxprt-code commands.
+
+    This class provides a method to execute `llxprt` commands from
+    within the agent's environment.
+
+    Attributes:
+        description (str): A brief description of the tool's purpose.
+        name (str): The name of the tool.
+    """
+    def __init__(self):
+        """Initializes the LLxprt_Code_Tool."""
+        self.description = "Run a llxprt-code command."
+        self.name = "llxprt_code_tool"
+
+    def run(self, command: str) -> str:
+        """Runs a llxprt-code command.
+
+        Args:
+            command (str): The command to run.
+
+        Returns:
+            str: A string containing the output of the command, or an
+                error message if the run fails or times out.
+        """
+        if not command:
+            return "Error: command cannot be empty."
+
+        try:
+            load_dotenv("/opt/llxprt-code/.env")
+            command_parts = ["llxprt"] + shlex.split(command)
+            process = subprocess.run(
+                command_parts,
+                capture_output=True,
+                text=True,
+                timeout=300
+            )
+
+            if process.returncode == 0:
+                return f"llxprt-code command run completed successfully.\nOutput:\n{process.stdout}"
+            else:
+                return f"llxprt-code command run failed with return code {process.returncode}.\nSTDOUT:\n{process.stdout}\nSTDERR:\n{process.stderr}"
+
+        except subprocess.TimeoutExpired as e:
+            return f"Error: llxprt-code command run timed out after 5 minutes.\nSTDOUT:\n{e.stdout}\nSTDERR:\n{e.stderr}"
+        except FileNotFoundError:
+            return "Error: `llxprt` command not found. Is it installed and in the system's PATH?"
+        except Exception as e:
+            return f"An unexpected error occurred while trying to run llxprt-code: {e}"

--- a/ansible/roles/pipecatapp/files/tools/test_llxprt_code_tool.py
+++ b/ansible/roles/pipecatapp/files/tools/test_llxprt_code_tool.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import subprocess
+
+# Assume llxprt_code_tool is in the same directory
+from .llxprt_code_tool import LLxprt_Code_Tool
+
+class TestLLxprtCodeTool(unittest.TestCase):
+
+    def setUp(self):
+        """Set up the tool instance before each test."""
+        self.llxprt_tool = LLxprt_Code_Tool()
+
+    @patch('subprocess.run')
+    def test_run_success(self, mock_run):
+        """Test a successful command execution."""
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_process.stdout = "Command finished successfully."
+        mock_process.stderr = ""
+        mock_run.return_value = mock_process
+
+        result = self.llxprt_tool.run('command')
+
+        self.assertIn("llxprt-code command run completed successfully", result)
+        self.assertIn("Command finished successfully", result)
+        mock_run.assert_called_once_with(
+            ['llxprt', 'command'],
+            capture_output=True,
+            text=True,
+            timeout=300
+        )
+
+    @patch('subprocess.run')
+    def test_run_with_args_success(self, mock_run):
+        """Test a successful command execution with arguments."""
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_process.stdout = "Command finished successfully."
+        mock_process.stderr = ""
+        mock_run.return_value = mock_process
+
+        result = self.llxprt_tool.run('review --file=foo.py')
+
+        self.assertIn("llxprt-code command run completed successfully", result)
+        self.assertIn("Command finished successfully", result)
+        mock_run.assert_called_once_with(
+            ['llxprt', 'review', '--file=foo.py'],
+            capture_output=True,
+            text=True,
+            timeout=300
+        )
+
+    @patch('subprocess.run')
+    def test_run_failure(self, mock_run):
+        """Test a failed command execution."""
+        mock_process = MagicMock()
+        mock_process.returncode = 1
+        mock_process.stdout = "Something went wrong."
+        mock_process.stderr = "Error details."
+        mock_run.return_value = mock_process
+
+        result = self.llxprt_tool.run('command')
+
+        self.assertIn("llxprt-code command run failed with return code 1", result)
+        self.assertIn("STDOUT:\nSomething went wrong.", result)
+        self.assertIn("STDERR:\nError details.", result)
+
+    @patch('subprocess.run', side_effect=subprocess.TimeoutExpired(cmd="llxprt", timeout=300, output="Timed out stdout.", stderr="Timed out stderr."))
+    def test_run_timeout(self, mock_run):
+        """Test a command execution that times out."""
+        result = self.llxprt_tool.run('command')
+        self.assertIn("Error: llxprt-code command run timed out after 5 minutes.", result)
+        self.assertIn("STDOUT:\nTimed out stdout.", result)
+        self.assertIn("STDERR:\nTimed out stderr.", result)
+
+    @patch('subprocess.run', side_effect=FileNotFoundError)
+    def test_command_not_found(self, mock_run):
+        """Test when the llxprt command is not found."""
+        result = self.llxprt_tool.run('command')
+        self.assertEqual(result, "Error: `llxprt` command not found. Is it installed and in the system's PATH?")
+
+    def test_empty_command(self):
+        """Test when an empty command is provided."""
+        result = self.llxprt_tool.run('')
+        self.assertEqual(result, "Error: command cannot be empty.")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -50,5 +50,6 @@
         - vision
         - power_manager
         - world_model_service
+        - llxprt_code
       loop_control:
         loop_var: role_name


### PR DESCRIPTION
Adds a new `llxprt-code` tool to the agent's toolset. This tool allows the agent to execute `llxprt-code` commands, expanding its capabilities for interacting with the development environment.

This change includes:
- A new Ansible role, `llxprt_code`, that clones the `llxprt-code` repository, installs its dependencies, and makes the `llxprt` command available system-wide.
- A configuration task that creates a `.env` file for `llxprt-code`, pointing it to the local LLM servers and using the appropriate API keys.
- A Python tool wrapper, `LLxprt_Code_Tool`, that loads the configuration and executes `llxprt` commands as a subprocess.
- Unit tests for the new tool to ensure it functions correctly.
- Integration of the new tool into the agent's toolset.