### PR TITLE
feat(agent): add llxprt-code tool with secure MCP server

### DIFF
--- a/ansible/roles/llxprt_code/tasks/main.yaml
+++ b/ansible/roles/llxprt_code/tasks/main.yaml
@@ -16,7 +16,25 @@
     state: present
     global: yes
 
+- name: Discover tool-server-api address
+  ansible.builtin.uri:
+    url: "http://localhost:8500/v1/health/service/tool-server-api?passing"
+    return_content: yes
+  register: tool_server_service
+  until: tool_server_service.json | length > 0
+  retries: 12
+  delay: 5
+
 - name: Configure llxprt-code
   ansible.builtin.template:
     src: llxprt-code.env.j2
     dest: /opt/llxprt-code/.env
+
+- name: Template MCP config
+  ansible.builtin.template:
+    src: mcp_config.json.j2
+    dest: /tmp/mcp_config.json
+
+- name: Add MCP server to llxprt-code
+  ansible.builtin.command: llxprt mcp add-json tool-server /tmp/mcp_config.json
+  changed_when: true

--- a/ansible/roles/llxprt_code/templates/mcp_config.json.j2
+++ b/ansible/roles/llxprt_code/templates/mcp_config.json.j2
@@ -1,0 +1,10 @@
+{
+  "type": "stdio",
+  "command": "npx",
+  "args": [
+    "mcp-remote@latest",
+    "http://{{ (tool_server_service.json[0].Service.Address) }}:{{ (tool_server_service.json[0].Service.Port) }}/run_tool/",
+    "--header",
+    "Authorization: Bearer {{ openai_api_key }}"
+  ]
+}

--- a/ansible/roles/pipecatapp/files/tool_server.py
+++ b/ansible/roles/pipecatapp/files/tool_server.py
@@ -1,0 +1,101 @@
+import uvicorn
+from fastapi import FastAPI, HTTPException, Header
+from pydantic import BaseModel
+import inspect
+import os
+from typing import Optional
+
+from tools.ssh_tool import SSH_Tool
+from tools.desktop_control_tool import DesktopControlTool
+from tools.code_runner_tool import CodeRunnerTool
+from tools.web_browser_tool import WebBrowserTool
+from tools.ansible_tool import Ansible_Tool
+from tools.power_tool import Power_Tool
+from tools.summarizer_tool import SummarizerTool
+from tools.term_everything_tool import TermEverythingTool
+from tools.rag_tool import RAG_Tool
+from tools.ha_tool import HA_Tool
+from tools.git_tool import Git_Tool
+from tools.orchestrator_tool import OrchestratorTool
+
+app = FastAPI()
+
+class ToolRequest(BaseModel):
+    tool: str
+    method: str
+    args: dict = {}
+
+# Instantiate all available tools
+tools = {
+    "ssh": SSH_Tool(),
+    "desktop_control": DesktopControlTool(),
+    "code_runner": CodeRunnerTool(),
+    "web_browser": WebBrowserTool(),
+    "ansible": Ansible_Tool(),
+    "power": Power_Tool(),
+    "term_everything": TermEverythingTool(app_image_path="/opt/mcp/termeverything.AppImage"),
+    "rag": RAG_Tool(base_dir="/"),
+    "ha": HA_Tool(ha_url=None, ha_token=None), # These will be configured later if needed
+    "git": Git_Tool(),
+    "orchestrator": OrchestratorTool(),
+}
+
+API_KEY = os.getenv("TOOL_SERVER_API_KEY")
+
+@app.post("/run_tool/")
+async def run_tool(request: ToolRequest, authorization: Optional[str] = Header(None)):
+    """
+    Executes a method on a specified tool with the given arguments.
+    """
+    if not API_KEY:
+        raise HTTPException(status_code=500, detail="API key not configured on server.")
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header is missing.")
+
+    try:
+        auth_type, token = authorization.split()
+        if auth_type.lower() != "bearer" or token != API_KEY:
+            raise HTTPException(status_code=403, detail="Invalid credentials.")
+    except ValueError:
+        raise HTTPException(status_code=401, detail="Invalid authorization header format.")
+
+    if request.tool not in tools:
+        raise HTTPException(status_code=404, detail=f"Tool '{request.tool}' not found.")
+
+    tool_instance = tools[request.tool]
+
+    if not hasattr(tool_instance, request.method):
+        raise HTTPException(status_code=404, detail=f"Method '{request.method}' not found on tool '{request.tool}'.")
+
+    method = getattr(tool_instance, request.method)
+
+    if not callable(method) or request.method.startswith("_"):
+        raise HTTPException(status_code=403, detail=f"Method '{request.method}' is not a public callable method.")
+
+    try:
+        # For simplicity, this example assumes synchronous tool methods.
+        # If any tool methods were async, this would need to be awaited.
+        result = method(**request.args)
+        return {"result": result}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error executing tool: {str(e)}")
+
+@app.get("/tools/")
+async def list_tools():
+    """
+    Returns a list of available tools and their methods.
+    """
+    available_tools = {}
+    for tool_name, tool_instance in tools.items():
+        methods = {}
+        for method_name, method in inspect.getmembers(tool_instance, predicate=inspect.ismethod):
+            if not method_name.startswith('_'):
+                methods[method_name] = {
+                    "doc": method.__doc__,
+                    "args": inspect.getfullargspec(method).args[1:] # Exclude 'self'
+                }
+        available_tools[tool_name] = methods
+    return available_tools
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -1,0 +1,9 @@
+---
+- name: Template tool-server.nomad job file
+  ansible.builtin.template:
+    src: tool_server.nomad.j2
+    dest: /opt/nomad/jobs/tool_server.nomad
+
+- name: Run tool-server nomad job
+  ansible.builtin.command: nomad job run /opt/nomad/jobs/tool_server.nomad
+  changed_when: true

--- a/ansible/roles/tool_server/templates/tool_server.nomad.j2
+++ b/ansible/roles/tool_server/templates/tool_server.nomad.j2
@@ -1,0 +1,62 @@
+job "tool-server" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "tool-server-group" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 8001
+      }
+    }
+
+    task "tool-server-task" {
+      driver = "docker"
+
+      config {
+        image = "python:3.12-slim"
+        ports = ["http"]
+
+        env {
+          TOOL_SERVER_API_KEY = "{{ openai_api_key }}"
+        }
+
+        volumes = [
+          "/opt/pipecatapp:/app"
+        ]
+
+        command = "python"
+        args = ["/app/tool_server.py"]
+      }
+
+      lifecycle {
+        hook = "prestart"
+        sidecar = false
+        task {
+          driver = "docker"
+          config {
+            image = "python:3.12-slim"
+            volumes = [
+              "/opt/pipecatapp:/app"
+            ]
+            command = "pip"
+            args = ["install", "-r", "/app/ansible/roles/python_deps/files/requirements.txt"]
+          }
+        }
+      }
+
+      service {
+        name = "tool-server-api"
+        port = "http"
+
+        check {
+          type     = "http"
+          path     = "/tools/"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}

--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -50,6 +50,7 @@
         - vision
         - power_manager
         - world_model_service
+        - tool_server
         - llxprt_code
       loop_control:
         loop_var: role_name


### PR DESCRIPTION
Adds a new `llxprt-code` tool to the agent's toolset and configures it to use a new, secure MCP server that exposes the agent's existing tools.

This change includes:
- A new `tool_server.py` FastAPI application that exposes the agent's tools over a REST API. This API is secured with API key authentication.
- A new Ansible role, `tool_server`, to deploy the tool server as a Nomad job.
- Updates to the `llxprt_code` Ansible role to automatically configure `llxprt-code` to use the new tool server as an MCP endpoint.
- A Python tool wrapper, `LLxprt_Code_Tool`, that allows the agent to execute `llxprt-code` commands.
- Unit tests for the new tool to ensure it functions correctly.