### PR TITLE
This commit configures the Home Assistant service to run with a dedic…

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -2,8 +2,8 @@
   ansible.builtin.file:
     path: /opt/nomad/volumes/ha-config
     state: directory
-    owner: "568"
-    group: "568"
+    owner: "{{ home_assistant_uid | default(568) }}"
+    group: "{{ home_assistant_gid | default(568) }}"
     mode: '0755'
   become: yes
 

--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -41,6 +41,8 @@ job "home-assistant" {
     task "home-assistant" {
       driver = "docker"
 
+      user = "{{ home_assistant_uid | default(568) }}:{{ home_assistant_gid | default(568) }}"
+
       config {
         image = "homeassistant/home-assistant:stable"
         ports = ["http"]

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -50,6 +50,13 @@ pipecat_api_keys: ""
 # For now, we'll place it here for simplicity.
 openai_api_key: "sk-your_openai_api_key_here"
 
+# Home Assistant User and Group IDs
+# These should match the user ID and group ID that the Home Assistant
+# container runs as. This ensures that the configuration files on the
+# host have the correct ownership. The default is 568.
+home_assistant_uid: 568
+home_assistant_gid: 568
+
 # Home Assistant Long-Lived Access Token
 # 1. Go to your Home Assistant UI -> Your Profile (bottom left)
 # 2. Scroll down to "Long-Lived Access Tokens"


### PR DESCRIPTION
…ated user and group ID.

Specifically, it:
- Adds `home_assistant_uid` and `home_assistant_gid` variables to `group_vars/all.yaml` and sets their default value to `568`.
- Updates the `home_assistant` Ansible role to use these variables to set the ownership of the configuration directory.
- Configures the Home Assistant Nomad job to run the container with the specified user and group ID.

This change improves security by running the Home Assistant container with a non-root user and makes the user and group IDs easily configurable.