### PR TITLE
Fix: Correct invalid lifecycle block in tool_server.nomad.j2

### DIFF
--- a/ansible/roles/tool_server/templates/tool_server.nomad.j2
+++ b/ansible/roles/tool_server/templates/tool_server.nomad.j2
@@ -26,24 +26,11 @@ job "tool-server" {
           "/opt/pipecatapp:/app"
         ]
 
-        command = "python"
-        args = ["/app/tool_server.py"]
-      }
-
-      lifecycle {
-        hook = "prestart"
-        sidecar = false
-        task {
-          driver = "docker"
-          config {
-            image = "python:3.12-slim"
-            volumes = [
-              "/opt/pipecatapp:/app"
-            ]
-            command = "pip"
-            args = ["install", "-r", "/app/ansible/roles/python_deps/files/requirements.txt"]
-          }
-        }
+        command = "bash"
+        args = [
+          "-c",
+          "pip install -r /app/ansible/roles/python_deps/files/requirements.txt && python /app/tool_server.py"
+        ]
       }
 
       service {


### PR DESCRIPTION
The `tool_server` Ansible task was failing due to a syntax error in the generated Nomad job file. The `lifecycle` block contained a nested `task` block, which is not supported by Nomad.

This commit resolves the issue by removing the invalid `lifecycle` block and incorporating the dependency installation step directly into the main task's command. This ensures the correct syntax while preserving the intended functionality.