### PR TITLE
feat: Add bootstrap flag to control Consul/Nomad cleanup

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -33,9 +33,10 @@
 
 - name: Reset Nomad state if version has changed
   when: >
-    existing_nomad_version.stdout is defined and
+    (existing_nomad_version.stdout is defined and
     new_nomad_version.stdout is defined and
-    existing_nomad_version.stdout != new_nomad_version.stdout
+    existing_nomad_version.stdout != new_nomad_version.stdout) and
+    cleanup_services
   block:
     - name: Stop Nomad service
       ansible.builtin.systemd:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,6 +10,7 @@
 CLEAN_REPO=false
 DEBUG_MODE=false
 EXTERNAL_MODEL_SERVER=false
+LEAVE_SERVICES_RUNNING=false
 PURGE_JOBS=false
 CONTINUE_RUN=false
 ROLE="all" # Default role
@@ -47,6 +48,10 @@ while [[ $# -gt 0 ]]; do
         ;;
         --debug)
         DEBUG_MODE=true
+        shift
+        ;;
+        --leave-services-running)
+        LEAVE_SERVICES_RUNNING=true
         shift
         ;;
         --external-model-server)
@@ -147,6 +152,14 @@ fi
 
 if [ "$PURGE_JOBS" = true ]; then
     ANSIBLE_ARGS+=(--extra-vars "purge_jobs=true")
+fi
+
+if [ "$LEAVE_SERVICES_RUNNING" = true ]; then
+    echo "✅ --leave-services-running detected. Nomad and Consul data will not be cleaned up."
+    ANSIBLE_ARGS+=(--extra-vars "cleanup_services=false")
+else
+    echo "🧹 Nomad and Consul data will be cleaned up by default. Use --leave-services-running to prevent this."
+    ANSIBLE_ARGS+=(--extra-vars "cleanup_services=true")
 fi
 # --- Now you can use the ANSIBLE_ARGS array ---
 echo "---"

--- a/fix_cluster.yaml
+++ b/fix_cluster.yaml
@@ -78,15 +78,22 @@
         - stop_consul_service.failed == true
         - not stop_consul_service.msg.startswith('Could not find the requested service')
 
+    - name: Skip data cleanup if --leave-services-running is used
+      ansible.builtin.debug:
+        msg: "Skipping cleanup of Consul and Nomad data directories."
+      when: not cleanup_services
+
     - name: Remove Nomad data directory to reset state
       ansible.builtin.file:
         path: /opt/nomad/data
         state: absent
+      when: cleanup_services
 
     - name: Remove Consul data directory to reset state
       ansible.builtin.file:
         path: /opt/consul/data
         state: absent
+      when: cleanup_services
 
     - name: Re-apply Consul role to configure as a server
       ansible.builtin.include_role:

--- a/promote_controller.yaml
+++ b/promote_controller.yaml
@@ -55,15 +55,22 @@
         state: stopped
       ignore_errors: true
 
+    - name: Skip data cleanup if --leave-services-running is used
+      ansible.builtin.debug:
+        msg: "Skipping cleanup of Consul and Nomad data directories."
+      when: not cleanup_services
+
     - name: Clean Consul data directory
       ansible.builtin.file:
         path: "/opt/consul"
         state: absent
+      when: cleanup_services
 
     - name: Clean Nomad data directory
       ansible.builtin.file:
         path: "/opt/nomad"
         state: absent
+      when: cleanup_services
 
   roles:
     - role: consul


### PR DESCRIPTION
Introduces a `--leave-services-running` flag to the `bootstrap.sh` script.

This flag sets an Ansible variable `cleanup_services` to `false`, which prevents the cleanup tasks for Consul and Nomad from running. This is useful for debugging, as it allows developers to re-run the bootstrap script without losing the state of these services.

The following playbooks were updated to respect the `cleanup_services` flag:
- `ansible/roles/nomad/tasks/main.yaml`
- `promote_controller.yaml`
- `fix_cluster.yaml`