### PR TITLE
Refactor tool-server deployment to use a pre-built Docker image

### DIFF
--- a/ansible/roles/tool_server/Dockerfile
+++ b/ansible/roles/tool_server/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir -r ansible/roles/python_deps/files/requirements.txt
+
+CMD ["python", "tool_server.py"]

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -1,4 +1,14 @@
 ---
+- name: Build tool-server docker image
+  community.docker.docker_image:
+    name: tool-server:latest
+    build:
+      path: /opt/pipecatapp
+      dockerfile: "{{ role_path }}/Dockerfile"
+    source: build
+    force_source: yes
+  become: yes
+
 - name: Template tool-server.nomad job file
   ansible.builtin.template:
     src: tool_server.nomad.j2

--- a/ansible/roles/tool_server/templates/tool_server.nomad.j2
+++ b/ansible/roles/tool_server/templates/tool_server.nomad.j2
@@ -15,22 +15,12 @@ job "tool-server" {
       driver = "docker"
 
       config {
-        image = "python:3.12-slim"
+        image = "tool-server:latest"
         ports = ["http"]
 
         env {
           TOOL_SERVER_API_KEY = "{{ openai_api_key }}"
         }
-
-        volumes = [
-          "/opt/pipecatapp:/app"
-        ]
-
-        command = "bash"
-        args = [
-          "-c",
-          "pip install -r /app/ansible/roles/python_deps/files/requirements.txt && python /app/tool_server.py"
-        ]
       }
 
       service {


### PR DESCRIPTION
The tool-server Nomad job was failing to deploy because the application was taking too long to start. This was caused by the installation of Python dependencies at container startup.

This change refactors the deployment process to use a pre-built Docker image with all dependencies included. A Dockerfile has been added to the tool_server Ansible role, and the role has been updated to build the image before deploying the job. The Nomad job file has also been updated to use the new image and a simplified startup command.