### PR TITLE
Fix(ansible): Copy requirements.txt to tool-server build context

### DIFF
--- a/ansible/roles/tool_server/Dockerfile
+++ b/ansible/roles/tool_server/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /app
 
 COPY . .
 
-RUN pip install --no-cache-dir -r ansible/roles/python_deps/files/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 CMD ["python", "tool_server.py"]

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -1,4 +1,13 @@
 ---
+- name: Copy requirements.txt for docker build
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/roles/python_deps/files/requirements.txt"
+    dest: "/opt/pipecatapp/requirements.txt"
+    owner: root
+    group: root
+    mode: '0644'
+  become: yes
+
 - name: Build tool-server docker image
   community.docker.docker_image:
     name: tool-server:latest


### PR DESCRIPTION
The tool-server Docker image build was failing because the `requirements.txt` file was not present in the build context (`/opt/pipecatapp`), causing the `pip install` command to fail.

This commit resolves the issue by:
1.  Adding an `ansible.builtin.copy` task to the `tool_server` role to copy `requirements.txt` into the build context before the image is built.
2.  Updating the `Dockerfile` to reference `requirements.txt` from the root of the build context, simplifying the path.