### PR TITLE
feat: Implement conditional PXE server role selection

### DIFF
--- a/pxe_setup.yaml
+++ b/pxe_setup.yaml
@@ -1,4 +1,13 @@
-- hosts: localhost
+---
+- hosts: pxe_server
   become: yes
-  roles:
-    - pxe_server
+  tasks:
+    - name: Include Debian PXE role
+      include_role:
+        name: pxe_server
+      when: pxe_os == 'debian'
+
+    - name: Include NixOS PXE role
+      include_role:
+        name: nixos_pxe_server
+      when: pxe_os == 'nixos'


### PR DESCRIPTION
This commit updates the `pxe_setup.yaml` playbook to conditionally include either the `pxe_server` (Debian) or `nixos_pxe_server` (NixOS) role based on the `pxe_os` variable defined in `group_vars/all.yaml`.

This brings the playbook's functionality in line with the documentation, allowing the user to select the desired operating system for the PXE boot environment.