### PR TITLE
refactor(ansible): Centralize vars_files and fix role paths

### DIFF
--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Copy requirements.txt for docker build
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/roles/python_deps/files/requirements.txt"
+    src: "{{ role_path }}/../python_deps/files/requirements.txt"
     dest: "/opt/pipecatapp/requirements.txt"
     owner: root
     group: root

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -1,3 +1,9 @@
+- hosts: all
+  vars_files:
+    - group_vars/all.yaml
+    - group_vars/models.yaml
+    - group_vars/external_experts.yaml
+
 - import_playbook: playbooks/common_setup.yaml
 - import_playbook: playbooks/services/core_infra.yaml
 - import_playbook: playbooks/services/consul.yaml

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -4,12 +4,6 @@
   gather_facts: yes
   become: no
 
-  vars_files:
-    - '{{ playbook_dir }}/../../group_vars/all.yaml'
-    - '{{ playbook_dir }}/../../group_vars/models.yaml'
-    - '{{ playbook_dir }}/../../group_vars/external_experts.yaml'
-
-
   vars:
     experts: "{{ expert_models.keys() | reject('equalto', 'router') | list }}"
     expected_worker_count: "{{ ((groups['workers'] | default([]) | length) if (groups['workers'] | default([]) | length) > 0 else 1) | int }}"

--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -3,11 +3,6 @@
   remote_user: "{{ target_user }}"
   become: yes
 
-  vars_files:
-    - "{{ playbook_dir }}/../../group_vars/all.yaml"
-    - "{{ playbook_dir }}/../../group_vars/models.yaml"
-    - "{{ playbook_dir }}/../../group_vars/external_experts.yaml"
-
   tasks:
     - name: Flush handlers to ensure Nomad is restarted with new config
       ansible.builtin.meta: flush_handlers

--- a/playbooks/services/consul.yaml
+++ b/playbooks/services/consul.yaml
@@ -3,8 +3,5 @@
   remote_user: "{{ target_user }}"
   become: yes
 
-  vars_files:
-    - "{{ playbook_dir }}/../../group_vars/all.yaml"
-
   roles:
     - consul

--- a/playbooks/services/core_ai_services.yaml
+++ b/playbooks/services/core_ai_services.yaml
@@ -3,11 +3,6 @@
   connection: local
   gather_facts: yes
 
-  vars_files:
-    - "{{ playbook_dir }}/../../group_vars/all.yaml"
-    - "{{ playbook_dir }}/../../group_vars/models.yaml"
-    - "{{ playbook_dir }}/../../group_vars/external_experts.yaml"
-
   roles:
     - role: bootstrap_agent
     - role: term_everything

--- a/playbooks/services/core_infra.yaml
+++ b/playbooks/services/core_infra.yaml
@@ -2,9 +2,6 @@
   remote_user: "{{ target_user }}"
   become: yes
 
-  vars_files:
-    - "{{ playbook_dir }}/../../group_vars/all.yaml"
-
   pre_tasks:
     - name: Ensure rsync is installed for synchronization tasks
       ansible.builtin.apt:

--- a/playbooks/services/docker.yaml
+++ b/playbooks/services/docker.yaml
@@ -3,8 +3,5 @@
   remote_user: "{{ target_user }}"
   become: yes
 
-  vars_files:
-    - "{{ playbook_dir }}/../../group_vars/all.yaml"
-
   roles:
     - docker

--- a/playbooks/services/model_services.yaml
+++ b/playbooks/services/model_services.yaml
@@ -2,10 +2,6 @@
   hosts: all
   remote_user: "{{ target_user }}"
   become: yes
-  vars_files:
-    - "{{ playbook_dir }}/../../group_vars/all.yaml"
-    - "{{ playbook_dir }}/../../group_vars/models.yaml"
-    - "{{ playbook_dir }}/../../group_vars/external_experts.yaml"
 
   tasks:
     - name: Populate Consul KV with configuration

--- a/playbooks/services/nomad.yaml
+++ b/playbooks/services/nomad.yaml
@@ -3,8 +3,5 @@
   remote_user: "{{ target_user }}"
   become: yes
 
-  vars_files:
-    - "{{ playbook_dir }}/../../group_vars/all.yaml"
-
   roles:
     - nomad


### PR DESCRIPTION
This commit addresses two related issues in the Ansible playbooks:

1.  **Fragile Pathing:** Multiple sub-playbooks in `playbooks/services/` were using `vars_files` with a relative path of `../../` to access the `group_vars` directory. This made the playbooks dependent on a specific execution directory and hard to maintain.

2.  **Incorrect Role Path:** The `tool_server` role was using an incorrect path to access `requirements.txt` from the sibling `python_deps` role.

This commit refactors the playbooks to be more robust and maintainable:

-   All `vars_files` declarations have been removed from the sub-playbooks.
-   A single, top-level `vars_files` declaration has been added to the main `playbook.yaml`. This makes the variables globally available to all imported playbooks and roles.
-   The `tool_server` role now uses the `role_path` variable to correctly locate the `requirements.txt` file, making the path relative to the role itself and independent of the playbook's location.