### PR TITLE
Fix tool-server Docker build failure by installing PyAV dependencies

### DIFF
--- a/ansible/roles/tool_server/Dockerfile
+++ b/ansible/roles/tool_server/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY . .
 
+RUN apt-get update && apt-get install -y pkg-config libavdevice-dev ffmpeg
 RUN pip install --no-cache-dir -r requirements.txt
 
 CMD ["python", "tool_server.py"]


### PR DESCRIPTION
The Docker build for the `tool-server` was failing because the `av` Python package requires `pkg-config`, `ffmpeg`, and `libavdevice-dev` to be installed on the system.

This change adds a `RUN` command to the `Dockerfile` to install these dependencies before `pip install` is run.