### PR TITLE
fix(home-assistant): Remove user directive from Nomad job

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -41,8 +41,6 @@ job "home-assistant" {
     task "home-assistant" {
       driver = "docker"
 
-      user = "{{ home_assistant_uid | default(568) }}:{{ home_assistant_gid | default(568) }}"
-
       config {
         image = "homeassistant/home-assistant:stable"
         ports = ["http"]


### PR DESCRIPTION
Removes the `user` directive from the Home Assistant Nomad job template. This allows the container to start with the default user (root), which is necessary for the `s6-overlay` init system to function correctly. The container itself will handle dropping privileges after its initial setup.

This fixes the "Permission denied" errors that were preventing the Home Assistant container from starting.