### PR TITLE
fix(home-assistant): Correct permissions for config directory

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -4,7 +4,8 @@
     state: directory
     owner: "{{ home_assistant_uid | default(568) }}"
     group: "{{ home_assistant_gid | default(568) }}"
-    mode: '0755'
+    mode: '0775'
+    recurse: yes
   become: yes
 
 - name: Template home-assistant Nomad job file

--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -41,6 +41,8 @@ job "home-assistant" {
     task "home-assistant" {
       driver = "docker"
 
+      user = "{{ home_assistant_uid | default(568) }}:{{ home_assistant_gid | default(568) }}"
+
       config {
         image = "homeassistant/home-assistant:stable"
         ports = ["http"]


### PR DESCRIPTION
Sets the mode of the Home Assistant configuration directory to `0775` and applies the ownership recursively. This ensures that the Home Assistant process, running as a non-root user within the correct group, has the necessary permissions to write to its configuration directory.

This resolves the `PermissionError: [Errno 13] Permission denied` error that occurred on startup, without resorting to insecure practices like running the container as root or using world-writable permissions.