### PR TITLE
fix(home-assistant): Fix startup and runtime permissions

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -41,8 +41,6 @@ job "home-assistant" {
     task "home-assistant" {
       driver = "docker"
 
-      user = "{{ home_assistant_uid | default(568) }}:{{ home_assistant_gid | default(568) }}"
-
       config {
         image = "homeassistant/home-assistant:stable"
         ports = ["http"]


### PR DESCRIPTION
This commit resolves two distinct permission errors that were preventing the Home Assistant container from starting and running correctly.

1.  **s6-overlay startup errors:** The container's `s6-overlay` init system requires root privileges to create necessary directories at startup. Forcing the container to start as a non-root user via the Nomad `user` directive was causing `Permission denied` errors. This is fixed by removing the `user` directive from the Nomad job template, allowing the container to start as its default user (`root`).

2.  **Application permission errors:** After starting as `root`, the Home Assistant application drops privileges to a non-root user. This user then needs write access to the `/config` volume. This is fixed by ensuring the host directory permissions are set to `0775` and applied recursively, granting group-level write access.

This two-part solution allows the container to initialize correctly as `root` and then run securely as a non-root user with the necessary volume permissions.