### PR TITLE
Fix(nomad): set address_mode for tool-server health check

### DIFF
--- a/ansible/roles/tool_server/templates/tool_server.nomad.j2
+++ b/ansible/roles/tool_server/templates/tool_server.nomad.j2
@@ -29,10 +29,11 @@ job "tool-server" {
         port = "http"
 
         check {
-          type     = "http"
-          path     = "/tools/"
-          interval = "10s"
-          timeout  = "2s"
+          type         = "http"
+          path         = "/tools/"
+          interval     = "10s"
+          timeout      = "2s"
+          address_mode = "host"
         }
       }
     }


### PR DESCRIPTION
The tool-server Nomad job was failing to deploy because its health check never passed. This was happening because the health check was targeting the container's internal IP address instead of the host's IP, where the service port is exposed.

This commit fixes the issue by adding `address_mode = "host"` to the service's health check configuration in the `tool_server.nomad.j2` template. This ensures the health check correctly targets the host's network interface, allowing the deployment to succeed.