### PR TITLE
feat: Add vllm as a new expert

### DIFF
--- a/ansible/jobs/vllm.nomad.j2
+++ b/ansible/jobs/vllm.nomad.j2
@@ -1,0 +1,61 @@
+job "vllm-server-{{ model.name }}" {
+  datacenters = ["dc1"]
+  namespace   = "{{ nomad_namespace | default('default') }}"
+
+  meta {
+    model_name    = "{{ model.name }}"
+    model_filename= "{{ model.filename }}"
+    memory_mb   = "{{ model.memory_mb }}"
+  }
+
+  group "vllm-server" {
+    count = 1
+
+    network {
+      mode = "host"
+      port "http" {
+        to = 8000
+      }
+    }
+
+    service {
+      name     = "vllm-server-{{ model.name }}"
+      provider = "consul"
+      port     = "http"
+
+      tags = [
+        "vllm-server",
+        "model={{ model.filename }}"
+      ]
+
+      check {
+        type     = "http"
+        path     = "/health"
+        interval = "15s"
+        timeout  = "5s"
+        address_mode = "host"
+      }
+    }
+
+    task "vllm-api-server" {
+      driver = "docker"
+
+      config {
+        image = "vllm/vllm-openai:latest"
+        ports = ["http"]
+        args = [
+          "--model", "{{ model.filename }}",
+          "--host", "0.0.0.0"
+        ]
+      }
+
+      resources {
+        cpu    = 2000
+        memory = {{ model.memory_mb }}
+        device "cuda" {
+          count = 1
+        }
+      }
+    }
+  }
+}

--- a/ansible/tasks/run_single_vllm_job.yaml
+++ b/ansible/tasks/run_single_vllm_job.yaml
@@ -1,0 +1,20 @@
+- name: Template vllm job for {{ model_item.filename }}
+  ansible.builtin.template:
+    src: ../../jobs/vllm.nomad.j2
+    dest: "/tmp/vllm-{{ model_item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
+    mode: '0644'
+  vars:
+    model: "{{ model_item }}"
+
+- name: Run vllm job for {{ model_item.filename }}
+  ansible.builtin.command:
+    cmd: "nomad job run /tmp/vllm-{{ model_item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
+  register: vllm_job_run
+  changed_when: "'Eval ID' in vllm_job_run.stdout"
+  environment:
+    NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
+
+- name: Clean up temporary job file for {{ model_item.filename }}
+  ansible.builtin.file:
+    path: "/tmp/vllm-{{ model_item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
+    state: absent

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -79,6 +79,7 @@ experts:
   - coding
   - math
   - extract
+  - vllm
 
 # --- PXE Boot Configuration ---
 

--- a/group_vars/models.yaml
+++ b/group_vars/models.yaml
@@ -37,6 +37,11 @@ expert_models:
       filename: "Phi-3-mini-4k-instruct-Q4_K_M.gguf"
       memory_mb: 4096
 
+vllm_expert_models:
+  - name: "vllm-main"
+    filename: "meta-llama/Llama-2-7b-hf"
+    memory_mb: 8192
+
 # A list of voices for the PiperTTSService to use, in order of preference.
 tts_voices:
   - name: "en_US-l2arctic-medium"

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -13,4 +13,5 @@
 - import_playbook: playbooks/services/model_services.yaml
 - import_playbook: playbooks/services/core_ai_services.yaml
 - import_playbook: playbooks/services/ai_experts.yaml
+- import_playbook: playbooks/services/vllm_experts.yaml
 - import_playbook: playbooks/services/final_verification.yaml

--- a/playbooks/services/vllm_experts.yaml
+++ b/playbooks/services/vllm_experts.yaml
@@ -1,0 +1,12 @@
+- name: Deploy vLLM AI Experts
+  hosts: controller_nodes[0]
+  connection: local
+  gather_facts: no
+  become: no
+
+  tasks:
+    - name: Template and run vllm nomad job for each model
+      ansible.builtin.include_tasks: ../../ansible/tasks/run_single_vllm_job.yaml
+      loop: "{{ vllm_expert_models | default([]) }}"
+      loop_control:
+        loop_var: model_item


### PR DESCRIPTION
This commit introduces vllm as a new expert service, providing an alternative to the existing llama.cpp implementation.

The following changes are included:
- A new `vllm.nomad.j2` template to run the vllm server as a Docker container.
- A new `vllm_experts.yaml` playbook to deploy vllm services.
- Updates to `group_vars/models.yaml` and `group_vars/all.yaml` to include vllm as a new expert option.