### PR TITLE
feat(bootstrap): Add --home-assistant-debug flag

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -74,6 +74,10 @@ while [[ $# -gt 0 ]]; do
         ANSIBLE_ARGS+=(--extra-vars "pipecat_deployment_style=docker")
         shift
         ;;
+        --home-assistant-debug)
+        ANSIBLE_ARGS+=(--extra-vars "home_assistant_debug_mode=true")
+        shift
+        ;;
         *)
         echo "Unknown option: $1"
         # (You could add a usage/help function here)


### PR DESCRIPTION
Adds a `--home-assistant-debug` flag to the `bootstrap.sh` script.

When this flag is used, it sets the `home_assistant_debug_mode` Ansible variable to `true`, which prevents the Home Assistant Nomad job from being rescheduled if it fails. This is useful for debugging.