### PR TITLE
feat(home-assistant): Add bootstrap flag for debug mode

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -116,12 +116,20 @@ job "home-assistant" {
       }
 
       # Restart policy: makes the service resilient to crashes.
+      {% if home_assistant_debug_mode %}
+      # In debug mode, prevent restarts to inspect the failed task.
+      restart {
+        attempts = 0
+        mode     = "fail"
+      }
+      {% else %}
       restart {
         attempts = 5
         interval = "30m"
         delay    = "15s"
         mode     = "delay"
       }
+      {% endif %}
 
       # Allow graceful shutdown to reduce DB corruption risk
       shutdown_delay = "15s"


### PR DESCRIPTION
Adds a `--home-assistant-debug` flag to the `bootstrap.sh` script and implements the corresponding debug logic in the Home Assistant Nomad job.

When the `--home-assistant-debug` flag is used, the `bootstrap.sh` script now passes the `home_assistant_debug_mode=true` variable to Ansible.

The `home_assistant.nomad.j2` template has been updated to use this variable. When `home_assistant_debug_mode` is true, it disables both the `reschedule` block at the group level and the `restart` block at the task level. This prevents a failed Home Assistant allocation from being replaced or restarted, allowing for easier inspection and debugging of the failed state.