### PR TITLE
Fix(ansible): Resolve Nomad and Consul startup failures

### DIFF
--- a/ansible/roles/consul/templates/consul.hcl.j2
+++ b/ansible/roles/consul/templates/consul.hcl.j2
@@ -8,7 +8,7 @@ ui_config {
 }
 
 # For a server, we need to specify the bootstrap_expect
-{% if "'controller_nodes' in group_names" %}
+{% if 'controller_nodes' in group_names %}
 server = true
 # In a single-node setup (like when using the bootstrap.sh script),
 # the inventory will only contain one host. In this case, we must set

--- a/ansible/roles/nomad/templates/nomad.hcl.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.j2
@@ -38,6 +38,7 @@ plugin "exec" {
 
 client {
   enabled = true
+  servers = ["127.0.0.1"]
 
   host_volume "pipecatapp" {
     path      = "/opt/pipecatapp"


### PR DESCRIPTION
This commit resolves a critical failure in the `bootstrap.sh` script where the Nomad service would fail to start due to misconfigurations in both the Consul and Nomad Ansible roles.

The root causes were:

1.  A Jinja2 syntax error in `ansible/roles/consul/templates/consul.hcl.j2` that caused all nodes to be configured as Consul servers, preventing the service from starting correctly.
2.  A missing `servers` parameter in the `client` block of `ansible/roles/nomad/templates/nomad.hcl.j2`, which is required for a single-node Nomad cluster to operate as both a server and a client.

This commit corrects the Jinja2 syntax and adds the necessary `servers` parameter, allowing the `bootstrap.sh` script to complete successfully.