### PR TITLE
fix(nomad): Separate server and client configurations

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -115,15 +115,25 @@
   meta: flush_handlers
 
 
-- name: Deploy the Nomad configuration from template
+- name: Deploy Nomad server configuration for controller nodes
   ansible.builtin.template:
-    src: nomad.hcl.j2
-    dest: /etc/nomad.d/nomad.hcl
+    src: server.hcl.j2
+    dest: /etc/nomad.d/server.hcl
     owner: root
     group: root
-    mode: '0644'
-  vars:
-    is_controller: "{{ true if inventory_hostname in groups['controller_nodes'] else false }}"
+    mode: "0644"
+  become: yes
+  when: inventory_hostname in groups['controller_nodes']
+  notify:
+    - Restart nomad
+
+- name: Deploy Nomad client configuration
+  ansible.builtin.template:
+    src: client.hcl.j2
+    dest: /etc/nomad.d/client.hcl
+    owner: root
+    group: root
+    mode: "0644"
   become: yes
   notify:
     - Restart nomad

--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -7,13 +7,6 @@ advertise {
   serf = "{{ ansible_default_ipv4.address }}"
 }
 
-{% if is_controller is defined and is_controller %}
-server {
-  enabled = true
-  bootstrap_expect = {{ nomad_bootstrap_expect }}
-}
-{% endif %}
-
 consul {
   address = "127.0.0.1:8500"
 }

--- a/ansible/roles/nomad/templates/server.hcl.j2
+++ b/ansible/roles/nomad/templates/server.hcl.j2
@@ -1,0 +1,37 @@
+data_dir  = "{{ nomad_data_dir }}"
+bind_addr = "0.0.0.0" # Listen on all interfaces
+
+advertise {
+  http = "{{ ansible_default_ipv4.address }}"
+  rpc  = "{{ ansible_default_ipv4.address }}"
+  serf = "{{ ansible_default_ipv4.address }}"
+}
+
+{% if is_controller is defined and is_controller %}
+server {
+  enabled = true
+  bootstrap_expect = {{ nomad_bootstrap_expect }}
+}
+{% endif %}
+
+consul {
+  address = "127.0.0.1:8500"
+}
+
+plugin "docker" {
+  config {
+    volumes {
+      enabled = true
+    }
+    allow_caps = ["NET_RAW", "NET_ADMIN", "SETUID", "SETGID", "CHOWN"]
+    pull_policy = "if-not-present"
+  }
+}
+
+plugin "raw_exec" {
+  enabled = true
+}
+
+plugin "exec" {
+  enabled = true
+}


### PR DESCRIPTION
The Nomad service was failing to start because the configuration template (`nomad.hcl.j2`) was generating a single `nomad.hcl` file containing both `server` and `client` blocks. This is an invalid configuration and prevented the Nomad agent from starting.

This commit separates the configuration into two distinct templates:
- `server.hcl.j2`: Contains only the server configuration and is deployed to `/etc/nomad.d/server.hcl` on controller nodes.
- `client.hcl.j2`: Contains only the client configuration and is deployed to `/etc/nomad.d/client.hcl` on all nodes.

The Ansible task in `ansible/roles/nomad/tasks/main.yaml` has been updated to handle the conditional deployment of these new templates. This resolves the "Connection refused" error during the bootstrap process.