### PR TITLE
Fix(nomad): Resolve startup regression caused by invalid config

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -36,7 +36,7 @@
     (existing_nomad_version.stdout is defined and
     new_nomad_version.stdout is defined and
     existing_nomad_version.stdout != new_nomad_version.stdout) and
-    cleanup_services
+    (cleanup_services | bool)
   block:
     - name: Stop Nomad service
       ansible.builtin.systemd:
@@ -110,6 +110,7 @@
   become: yes
   notify:
     - Reload systemd
+    - Restart nomad
 
 - name: Ensure handlers run now #
   meta: flush_handlers
@@ -124,6 +125,14 @@
     mode: "0644"
   become: yes
   when: inventory_hostname in groups['controller_nodes']
+  notify:
+    - Restart nomad
+
+- name: Copy Nomad config for local bootstrap
+  ansible.builtin.template:
+    src: nomad.hcl.server.j2
+    dest: "{{ nomad_config_dir }}/nomad.hcl"
+  when: "inventory_hostname == 'localhost' and 'controller' not in group_names and 'workers' not in group_names"
   notify:
     - Restart nomad
 

--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -17,7 +17,6 @@ plugin "docker" {
       enabled = true
     }
     allow_caps = ["NET_RAW", "NET_ADMIN", "SETUID", "SETGID", "CHOWN"]
-    pull_policy = "if-not-present"
   }
 }
 

--- a/ansible/roles/nomad/templates/server.hcl.j2
+++ b/ansible/roles/nomad/templates/server.hcl.j2
@@ -24,7 +24,6 @@ plugin "docker" {
       enabled = true
     }
     allow_caps = ["NET_RAW", "NET_ADMIN", "SETUID", "SETGID", "CHOWN"]
-    pull_policy = "if-not-present"
   }
 }
 


### PR DESCRIPTION
The Nomad service was failing to start due to an invalid `pull_policy` configuration in the Docker plugin settings. This was present in both the client and server configuration templates.

This commit removes the invalid `pull_policy` from `client.hcl.j2` and `server.hcl.j2`.

Additionally, a task has been added to the Nomad Ansible role to explicitly create a server configuration file when the playbook is run on `localhost`. This handles the single-node bootstrap scenario and prevents the service from failing due to a missing configuration file.