### PR TITLE
fix(nomad): correct health check for world_model_service

### DIFF
--- a/ansible/roles/world_model_service/world_model.nomad.j2
+++ b/ansible/roles/world_model_service/world_model.nomad.j2
@@ -54,6 +54,7 @@ job "world-model-service" {
           path     = "/state"
           interval = "10s"
           timeout  = "2s"
+          address_mode = "host"
         }
       }
     }


### PR DESCRIPTION
The Nomad job for the world_model_service was failing to deploy due to a 'progress deadline' error. This was caused by a misconfigured health check in the Nomad job definition.

When a Nomad job uses host networking, the health check must be configured to target the host's network interface. Without this, the check defaults to the container's internal IP, which is incorrect in this setup.

This commit adds `address_mode = 'host'` to the service's health check configuration, ensuring the check targets the host's IP and allowing the job to become healthy and deploy successfully.