### PR TITLE
fix(ansible): Correct Nomad client configuration logic

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -147,7 +147,7 @@
     group: root
     mode: "0644"
   become: yes
-  when: inventory_hostname not in groups['controller_nodes']
+  when: inventory_hostname in groups['workers']
   notify:
     - Restart nomad
 


### PR DESCRIPTION
Corrects the `when` condition for deploying the Nomad client configuration.

The previous logic (`inventory_hostname not in groups['controller_nodes']`) was too broad and caused a client-only configuration to be deployed on single-node "localhost" setups. This created a conflict with the primary server/client configuration file, causing the Nomad service to fail on startup.

The new logic (`inventory_hostname in groups['workers']`) is more specific and ensures the client-only configuration is only deployed to dedicated worker nodes, resolving the conflict.