### PR TITLE
Fix Nomad playbook for missing inventory groups

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -126,7 +126,7 @@
   vars:
     is_controller: true
   become: yes
-  when: inventory_hostname in groups['controller_nodes']
+  when: "'controller_nodes' in groups and inventory_hostname in groups['controller_nodes']"
   notify:
     - Restart nomad
 
@@ -147,7 +147,7 @@
     group: root
     mode: "0644"
   become: yes
-  when: inventory_hostname in groups['workers']
+  when: "'workers' in groups and inventory_hostname in groups['workers']"
   notify:
     - Restart nomad
 


### PR DESCRIPTION
The `ansible/roles/nomad/tasks/main.yaml` playbook was failing when the `workers` or `controller_nodes` groups were not defined in the inventory. This was causing the `bootstrap.sh` script to fail during a single-node setup.

This commit fixes the issue by adding a check to verify the existence of the group before checking for the hostname's membership. The `when` conditions are updated to be `"'<group_name>' in groups and inventory_hostname in groups['<group_name>']"`.