### PR TITLE
Fix mqtt deployment failure

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -39,6 +39,12 @@
     recurse: yes
   become: yes
 
+- name: Restart nomad to pick up volume ownership
+  ansible.builtin.service:
+    name: nomad
+    state: restarted
+  become: yes
+
 - name: Purge mqtt job
   ansible.builtin.command:
     cmd: nomad job stop -purge mqtt


### PR DESCRIPTION
The mqtt service was failing to deploy due to a race condition where the mosquitto container would start before the correct ownership was applied to the `/opt/nomad/volumes/mqtt-data` directory. This prevented the container from writing necessary data and becoming healthy.

This change resolves the issue by adding a task to the mqtt Ansible role to restart the Nomad service after setting the directory ownership, ensuring the volume is mounted with the correct permissions.