### PR TITLE
Fix(nomad): Resolve race condition in Nomad service installation

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -112,6 +112,9 @@
     - Reload systemd
     - Restart nomad
 
+- name: Force immediate handler flush to ensure systemd is reloaded
+  meta: flush_handlers
+
 - name: Deploy Nomad server configuration for controller nodes
   ansible.builtin.template:
     src: server.hcl.j2


### PR DESCRIPTION
This commit fixes a race condition in the `nomad` Ansible role that prevented the Nomad service from starting correctly.

The playbook was attempting to start the `nomad` service before the `systemd` daemon had been reloaded to recognize the newly created `nomad.service` file. This resulted in a "Unit not found" error, which in turn caused all Nomad jobs, including `mqtt`, to fail with a "progress deadline" error.

The fix adds a `meta: flush_handlers` task immediately after the `nomad.service` file is created. This ensures that `systemd` is reloaded at that point in the playbook, eliminating the race condition and allowing the Nomad service to start reliably.