### PR TITLE
The Nomad service was failing to start on localhost deployments becau…

### DIFF
--- a/ansible/roles/nomad/templates/nomad.hcl.server.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.server.j2
@@ -15,3 +15,20 @@ server {
 client {
   enabled = true
 }
+
+plugin "docker" {
+  config {
+    volumes {
+      enabled = true
+    }
+    allow_caps = ["NET_RAW", "NET_ADMIN", "SETUID", "SETGID", "CHOWN"]
+  }
+}
+
+plugin "raw_exec" {
+  enabled = true
+}
+
+plugin "exec" {
+  enabled = true
+}


### PR DESCRIPTION
…se the server configuration was missing the required `plugin` blocks for the `docker`, `raw_exec`, and `exec` drivers. This change adds the missing plugin configurations to the `nomad.hcl.server.j2` template to resolve the issue.