### PR TITLE
Fix(mqtt): Resolve persistent Nomad job deployment failure

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -39,11 +39,18 @@
     recurse: yes
   become: yes
 
-- name: Restart nomad to pick up volume ownership
-  ansible.builtin.service:
-    name: nomad
-    state: restarted
+- name: Set ownership for Mosquitto directories
+  ansible.builtin.file:
+    path: /opt/nomad/volumes/mqtt-data
+    state: directory
+    owner: "1883"
+    group: "1883"
+    recurse: yes
   become: yes
+  notify: Restart nomad
+
+- name: Flush handlers to ensure nomad is restarted and ready
+  ansible.builtin.meta: flush_handlers
 
 - name: Purge mqtt job
   ansible.builtin.command:

--- a/ansible/roles/mqtt/templates/mqtt.nomad.j2
+++ b/ansible/roles/mqtt/templates/mqtt.nomad.j2
@@ -37,7 +37,7 @@ job "mqtt" {
       driver = "docker"
 
       config {
-        image = "ccr.ccs.tencentyun.com/library/eclipse-mosquitto:2"
+        image = "eclipse-mosquitto:2"
         ports = ["mqtt", "ws"]
         cap_add = ["SETUID", "SETGID", "CHOWN"]
 


### PR DESCRIPTION
This commit addresses a cascade of issues causing the `mqtt` Nomad job to fail with a "Failed due to progress deadline" error.

The key changes include:
- Correcting the Docker image path in the Nomad job template to use the official public `eclipse-mosquitto` image instead of an inaccessible private registry.
- Replacing a direct Nomad service restart with a `notify` handler in the Ansible role. This resolves a race condition where the deployment would fail because the Nomad API was not yet available after a restart.