### PR TITLE
feat: Add tags to all Ansible playbooks

### DIFF
--- a/playbooks/common_setup.yaml
+++ b/playbooks/common_setup.yaml
@@ -2,6 +2,9 @@
   hosts: all
   become: yes # We are already root
 
+  tags:
+    - common-setup
+
   vars_files:
     - "{{ playbook_dir }}/../group_vars/all.yaml"
     - "{{ playbook_dir }}/../group_vars/models.yaml"
@@ -9,21 +12,29 @@
 
   tasks:
     - name: Ensure the sudo package is installed
+      tags:
+        - sudo
       ansible.builtin.apt:
         name: sudo
         state: present
 
     - name: Ensure the rsync package is installed
+      tags:
+        - rsync
       ansible.builtin.apt:
         name: rsync
         state: present
 
     - name: Ensure the sudo group exists
+      tags:
+        - sudo
       ansible.builtin.group:
         name: sudo
         state: present
 
     - name: Create the '{{ target_user }}' account with sudo access
+      tags:
+        - user
       ansible.builtin.user:
         name: "{{ target_user }}"
         shell: /bin/bash
@@ -31,12 +42,16 @@
         append: yes
 
     - name: Set correct permissions for the user's home directory
+      tags:
+        - user
       ansible.builtin.file:
         path: "/home/{{ target_user }}"
         state: directory
         mode: '0755'
 
     - name: Allow '{{ target_user }}' to have passwordless sudo access
+      tags:
+        - sudo
       ansible.builtin.lineinfile:
         path: "/etc/sudoers.d/ansible-{{ target_user }}-nopasswd"
         line: "{{ target_user }} ALL=(ALL) NOPASSWD: ALL"

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -4,6 +4,9 @@
   gather_facts: yes
   become: no
 
+  tags:
+    - ai-experts
+
   vars:
     experts: "{{ expert_models.keys() | reject('equalto', 'router') | list }}"
     expected_worker_count: "{{ ((groups['workers'] | default([]) | length) if (groups['workers'] | default([]) | length) > 0 else 1) | int }}"
@@ -18,11 +21,15 @@
       loop: "{{ expert_models.keys() | list }}"
       loop_control:
         loop_var: item
+      tags:
+        - deploy-gpu-provider
 
     - name: Check for benchmark log file
       stat:
         path: /var/log/llama_benchmarks.jsonl
       register: benchmark_log_stat
+      tags:
+        - benchmark
 
     - name: Read and parse benchmark results
       block:
@@ -58,12 +65,16 @@
           ansible.builtin.set_fact:
             benchmark_results: []
       when: benchmark_log_stat.stat.exists
+      tags:
+        - benchmark
 
     - name: Identify successful models from benchmarks
       ansible.builtin.set_fact:
         cacheable: true
         successful_models: "{{ benchmark_results | selectattr('status', 'equalto', 'success') | map(attribute='model') | list }}"
       when: benchmark_results is defined
+      tags:
+        - benchmark
 
     - name: Identify verified experts by checking their models against benchmark results
       ansible.builtin.set_fact:
@@ -78,10 +89,14 @@
         # Check if any of the expert's models are in the list of successful models
         is_verified: "{{ expert_model_files | intersect(successful_models) | length > 0 }}"
       when: is_verified and benchmark_results is defined
+      tags:
+        - benchmark
 
     - name: Initialize expert_benchmark_data as an empty dictionary
       ansible.builtin.set_fact:
         expert_benchmark_data: {}
+      tags:
+        - benchmark
 
     - name: Populate expert_benchmark_data with default values for all experts
       ansible.builtin.set_fact:
@@ -89,6 +104,8 @@
       loop: "{{ experts }}"
       loop_control:
         loop_var: item
+      tags:
+        - benchmark
 
     - name: Calculate benchmark data and average tokens per second for each expert
       ansible.builtin.set_fact:
@@ -125,6 +142,8 @@
       loop_control:
         loop_var: item
       when: benchmark_results is defined and benchmark_results | length > 0 and benchmark_results is defined
+      tags:
+        - benchmark
 
     - name: Wait for the llamacpp-rpc-pool service to be healthy in Consul
       ansible.builtin.uri:
@@ -138,6 +157,8 @@
       delay: 10
       changed_when: false
       when: benchmark_results is defined
+      tags:
+        - healthcheck
 
     - name: Create Expert Orchestrator job files
       include_tasks:
@@ -146,6 +167,8 @@
       loop_control:
         loop_var: current_expert
       when: benchmark_results is defined
+      tags:
+        - deploy-expert
 
     - name: Deploy the Expert Orchestrator services
       ansible.builtin.command: >
@@ -157,6 +180,8 @@
       loop: "{{ experts }}"
       changed_when: true
       when: benchmark_results is defined
+      tags:
+        - deploy-expert
 
     - name: Wait for the expert services to be healthy in Consul
       ansible.builtin.uri:
@@ -171,3 +196,5 @@
       loop: "{{ experts }}"
       changed_when: false
       when: benchmark_results is defined
+      tags:
+        - healthcheck

--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -3,9 +3,14 @@
   remote_user: "{{ target_user }}"
   become: yes
 
+  tags:
+    - app-services
+
   tasks:
     - name: Flush handlers to ensure Nomad is restarted with new config
       ansible.builtin.meta: flush_handlers
+      tags:
+        - always
 
     - name: Wait for a Consul leader to be elected
       ansible.builtin.uri:
@@ -16,6 +21,8 @@
       retries: 12
       delay: 5
       ignore_errors: yes
+      tags:
+        - consul
 
     - name: Fail gracefully if no Consul leader is found
       ansible.builtin.fail:
@@ -24,14 +31,20 @@
           This usually means the `bootstrap_expect` value in your Consul configuration is
           higher than the number of server nodes available.
       when: consul_leader_status.skipped is not defined and (consul_leader_status.failed or consul_leader_status.content == '""')
+      tags:
+        - consul
 
     - name: Install system dependencies
       ansible.builtin.include_role:
         name: system_deps
+      tags:
+        - system_deps
 
     - name: Install all python dependencies
       ansible.builtin.include_role:
         name: python_deps
+      tags:
+        - python_deps
 
     - name: Run pre-Home Assistant application roles
       ansible.builtin.include_role:
@@ -40,6 +53,8 @@
         - mqtt
       loop_control:
         loop_var: role_name
+      tags:
+        - mqtt
 
     - name: Deploy Home Assistant with error handling
       block:
@@ -52,6 +67,8 @@
         - name: Fail the playbook after diagnostics
           ansible.builtin.fail:
             msg: "Home Assistant deployment failed. Diagnostic log has been created."
+      tags:
+        - home_assistant
 
     - name: Run post-Home Assistant application roles
       ansible.builtin.include_role:
@@ -69,5 +86,12 @@
       loop_control:
         loop_var: role_name
       tags:
-        - tool_server
+        - provisioning_api
+        - desktop_extras
+        - paddler
+        - vision
+        - power_manager
         - world_model_service
+        - tool_server
+        - llxprt_code
+        - claude_clone

--- a/playbooks/services/consul.yaml
+++ b/playbooks/services/consul.yaml
@@ -3,5 +3,10 @@
   remote_user: "{{ target_user }}"
   become: yes
 
-  roles:
+  tags:
     - consul
+
+  roles:
+    - role: consul
+      tags:
+        - consul

--- a/playbooks/services/core_ai_services.yaml
+++ b/playbooks/services/core_ai_services.yaml
@@ -3,7 +3,16 @@
   connection: local
   gather_facts: yes
 
+  tags:
+    - core-ai-services
+
   roles:
     - role: bootstrap_agent
+      tags:
+        - bootstrap_agent
     - role: term_everything
+      tags:
+        - term_everything
     - role: pipecatapp
+      tags:
+        - pipecatapp

--- a/playbooks/services/core_infra.yaml
+++ b/playbooks/services/core_infra.yaml
@@ -2,17 +2,26 @@
   remote_user: "{{ target_user }}"
   become: yes
 
+  tags:
+    - core-infra
+
   pre_tasks:
     - name: Ensure rsync is installed for synchronization tasks
+      tags:
+        - rsync
       ansible.builtin.apt:
         name: rsync
         state: present
         update_cache: yes
 
     - name: Check connectivity to all nodes
+      tags:
+        - ping
       ansible.builtin.ping:
 
     - name: Distribute control repository to all nodes
+      tags:
+        - sync
       ansible.posix.synchronize:
         src: "{{ playbook_dir }}/../../"
         dest: /opt/cluster-infra/
@@ -21,6 +30,8 @@
       when: inventory_hostname != 'localhost'
 
     - name: Synchronize control repository for local bootstrap
+      tags:
+        - sync
       ansible.posix.synchronize:
         src: "{{ playbook_dir }}/../../"
         dest: /opt/cluster-infra/
@@ -28,5 +39,9 @@
           - "--exclude=.git"
       when: inventory_hostname == 'localhost'
   roles:
-    - system_deps
-    - common
+    - role: system_deps
+      tags:
+        - system_deps
+    - role: common
+      tags:
+        - common

--- a/playbooks/services/docker.yaml
+++ b/playbooks/services/docker.yaml
@@ -3,5 +3,10 @@
   remote_user: "{{ target_user }}"
   become: yes
 
-  roles:
+  tags:
     - docker
+
+  roles:
+    - role: docker
+      tags:
+        - docker

--- a/playbooks/services/final_verification.yaml
+++ b/playbooks/services/final_verification.yaml
@@ -2,6 +2,8 @@
   hosts: all
   become: no
   gather_facts: no
+  tags:
+    - final-verification
   tasks:
     - name: Check if the Consul service is running
       ansible.builtin.systemd:
@@ -11,6 +13,8 @@
       changed_when: false
       ignore_errors: yes # We'll provide a better error message in the next task
       when: not ansible_check_mode
+      tags:
+        - consul-health
 
     - name: Fail gracefully if Consul service is not running
       ansible.builtin.fail:
@@ -20,6 +24,8 @@
           Please check the service logs by running 'journalctl -u consul.service' on the target node.
           Status details: {{ consul_service_status }}
       when: consul_service_status.skipped is not defined and consul_service_status.failed and not ansible_check_mode
+      tags:
+        - consul-health
 
     - name: Wait for a Consul leader to be elected
       ansible.builtin.uri:
@@ -31,6 +37,8 @@
       delay: 5
       ignore_errors: yes
       when: not ansible_check_mode
+      tags:
+        - consul-health
 
     - name: Fail gracefully if no Consul leader is found
       ansible.builtin.fail:
@@ -41,3 +49,5 @@
           - For a single-node setup, ensure `bootstrap_expect` is 1.
           - For a multi-node setup, ensure enough controller nodes are running to form a quorum.
       when: consul_leader_status.skipped is not defined and (consul_leader_status.failed or consul_leader_status.content == '""') and not ansible_check_mode
+      tags:
+        - consul-health

--- a/playbooks/services/model_services.yaml
+++ b/playbooks/services/model_services.yaml
@@ -3,11 +3,16 @@
   remote_user: "{{ target_user }}"
   become: yes
 
+  tags:
+    - model-services
+
   tasks:
     - name: Populate Consul KV with configuration
       include_role:
         name: config_manager
       run_once: true
+      tags:
+        - config_manager
 
     - name: Run model-dependent roles
       include_role:
@@ -19,7 +24,12 @@
       loop_control:
         loop_var: role_name
       when: not external_model_server
-      tags: llama_cpp
+      tags:
+        - download_models
+        - llama_cpp
+        - whisper_cpp
 
     - name: Flush handlers to ensure all services are started
       meta: flush_handlers
+      tags:
+        - always

--- a/playbooks/services/nomad.yaml
+++ b/playbooks/services/nomad.yaml
@@ -3,5 +3,10 @@
   remote_user: "{{ target_user }}"
   become: yes
 
-  roles:
+  tags:
     - nomad
+
+  roles:
+    - role: nomad
+      tags:
+        - nomad

--- a/playbooks/services/vllm_experts.yaml
+++ b/playbooks/services/vllm_experts.yaml
@@ -4,9 +4,14 @@
   gather_facts: no
   become: no
 
+  tags:
+    - vllm-experts
+
   tasks:
     - name: Template and run vllm nomad job for each model
       ansible.builtin.include_tasks: ../../ansible/tasks/run_single_vllm_job.yaml
       loop: "{{ vllm_expert_models | default([]) }}"
       loop_control:
         loop_var: model_item
+      tags:
+        - run-vllm-job


### PR DESCRIPTION
This change adds tags to all Ansible playbooks, roles, and tasks to allow for more granular control over playbook execution. This addresses the user's request to "add tags to everything possible."