### PR TITLE
feat: Add autoscaling to Nomad expert job

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -31,6 +31,26 @@ job "{{ job_name }}" {
   group "{{ job_name }}-group" {
     count = 1
 
+    scaling {
+      enabled = true
+      min     = 1
+      max     = 10
+
+      policy {
+        cooldown = "1m"
+        evaluation_interval = "30s"
+
+        check "cpu_usage" {
+          source = "nomad"
+          query  = "avg(nomad.client.allocs.cpu.total_percent)"
+
+          strategy "target-value" {
+            target = 70
+          }
+        }
+      }
+    }
+
     update {
       max_parallel = 1
       progress_deadline = "15m"


### PR DESCRIPTION
This commit adds a scaling policy to the `expert.nomad.j2` job file. The policy is configured to scale the number of instances between 1 and 10, based on CPU utilization, with a target of 70%. This will allow the service to handle varying loads more efficiently.