### PR TITLE
feat(consul): Harden Consul Configuration

### DIFF
--- a/ansible/roles/consul/tasks/acl.yaml
+++ b/ansible/roles/consul/tasks/acl.yaml
@@ -1,0 +1,31 @@
+- name: Bootstrap ACLs
+  block:
+    - name: Check if ACLs are already bootstrapped
+      stat:
+        path: "{{ consul_config_dir }}/acl_bootstrapped"
+      register: acl_bootstrapped
+      become: yes
+
+    - name: Bootstrap ACLs
+      command: "consul acl bootstrap"
+      register: acl_bootstrap_result
+      when: not acl_bootstrapped.stat.exists
+      become: yes
+
+    - name: Store management token
+      copy:
+        content: "{{ (acl_bootstrap_result.stdout | from_json).SecretID }}"
+        dest: "{{ consul_config_dir }}/management_token"
+        mode: '0600'
+      when: not acl_bootstrapped.stat.exists
+      become: yes
+
+    - name: Mark ACLs as bootstrapped
+      file:
+        path: "{{ consul_config_dir }}/acl_bootstrapped"
+        state: touch
+      when: not acl_bootstrapped.stat.exists
+      become: yes
+  when: "'controller_nodes' in groups and groups['controller_nodes'] | length > 0"
+  run_once: true
+  delegate_to: "{{ groups['controller_nodes'][0] }}"

--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -41,6 +41,67 @@
     mode: '0755'
   become: yes
 
+- name: Generate certificates on localhost
+  block:
+    - name: Create local certs directory
+      file:
+        path: "{{ role_path }}/files/certs"
+        state: directory
+
+    - name: Generate CA key
+      command: "openssl genrsa -out {{ role_path }}/files/certs/ca.key 2048"
+      args:
+        creates: "{{ role_path }}/files/certs/ca.key"
+
+    - name: Generate CA certificate
+      command: "openssl req -new -x509 -days 3650 -key {{ role_path }}/files/certs/ca.key -out {{ role_path }}/files/certs/ca.pem -subj '/CN=Consul CA'"
+      args:
+        creates: "{{ role_path }}/files/certs/ca.pem"
+
+    - name: Generate server keys for controller nodes
+      command: "openssl genrsa -out {{ role_path }}/files/certs/{{ item }}.key 2048"
+      args:
+        creates: "{{ role_path }}/files/certs/{{ item }}.key"
+      loop: "{{ groups['controller_nodes'] }}"
+
+    - name: Generate server CSRs for controller nodes
+      command: "openssl req -new -key {{ role_path }}/files/certs/{{ item }}.key -out {{ role_path }}/files/certs/{{ item }}.csr -subj '/CN=server.consul'"
+      args:
+        creates: "{{ role_path }}/files/certs/{{ item }}.csr"
+      loop: "{{ groups['controller_nodes'] }}"
+
+    - name: Sign server certificates for controller nodes
+      command: "openssl x509 -req -in {{ role_path }}/files/certs/{{ item }}.csr -CA {{ role_path }}/files/certs/ca.pem -CAkey {{ role_path }}/files/certs/ca.key -CAcreateserial -out {{ role_path }}/files/certs/{{ item }}.pem -days 365"
+      args:
+        creates: "{{ role_path }}/files/certs/{{ item }}.pem"
+      loop: "{{ groups['controller_nodes'] }}"
+
+    - name: Generate client keys for client nodes
+      command: "openssl genrsa -out {{ role_path }}/files/certs/{{ item }}.key 2048"
+      args:
+        creates: "{{ role_path }}/files/certs/{{ item }}.key"
+      loop: "{{ query('inventory_hostnames', 'all:!controller_nodes') }}"
+
+    - name: Generate client CSRs for client nodes
+      command: "openssl req -new -key {{ role_path }}/files/certs/{{ item }}.key -out {{ role_path }}/files/certs/{{ item }}.csr -subj '/CN=client.consul'"
+      args:
+        creates: "{{ role_path }}/files/certs/{{ item }}.csr"
+      loop: "{{ query('inventory_hostnames', 'all:!controller_nodes') }}"
+
+    - name: Sign client certificates for client nodes
+      command: "openssl x509 -req -in {{ role_path }}/files/certs/{{ item }}.csr -CA {{ role_path }}/files/certs/ca.pem -CAkey {{ role_path }}/files/certs/ca.key -CAcreateserial -out {{ role_path }}/files/certs/{{ item }}.pem -days 365"
+      args:
+        creates: "{{ role_path }}/files/certs/{{ item }}.pem"
+      loop: "{{ query('inventory_hostnames', 'all:!controller_nodes') }}"
+  delegate_to: localhost
+  run_once: true
+
+- name: Include TLS tasks
+  include_tasks: tls.yaml
+
+- name: Include ACL tasks
+  include_tasks: acl.yaml
+
 - name: Copy Consul config
   template:
     src: consul.hcl.j2

--- a/ansible/roles/consul/tasks/tls.yaml
+++ b/ansible/roles/consul/tasks/tls.yaml
@@ -1,0 +1,28 @@
+- name: Copy CA certificate to all nodes
+  copy:
+    src: "{{ role_path }}/files/certs/ca.pem"
+    dest: "{{ consul_config_dir }}/ca.pem"
+    mode: '0644'
+  become: yes
+
+- name: Copy node certificate and key to each node
+  copy:
+    src: "{{ role_path }}/files/certs/{{ inventory_hostname }}.{{ item }}"
+    dest: "{{ consul_config_dir }}/{{ item }}"
+    mode: '0600'
+  loop:
+    - key
+    - pem
+  become: yes
+
+- name: Rename node certificate to cert.pem
+  command: "mv {{ consul_config_dir }}/{{ inventory_hostname }}.pem {{ consul_config_dir }}/cert.pem"
+  args:
+    creates: "{{ consul_config_dir }}/cert.pem"
+  become: yes
+
+- name: Rename node key to key.pem
+  command: "mv {{ consul_config_dir }}/{{ inventory_hostname }}.key {{ consul_config_dir }}/key.pem"
+  args:
+    creates: "{{ consul_config_dir }}/key.pem"
+  become: yes

--- a/ansible/roles/consul/templates/consul.hcl.j2
+++ b/ansible/roles/consul/templates/consul.hcl.j2
@@ -1,6 +1,25 @@
 data_dir = "{{ consul_data_dir }}"
 bind_addr = "{{ ansible_default_ipv4.address }}"
 client_addr = "0.0.0.0"
+leave_on_terminate = true
+
+verify_incoming = true
+verify_outgoing = true
+verify_server_hostname = true
+ca_file = "{{ consul_config_dir }}/ca.pem"
+cert_file = "{{ consul_config_dir }}/cert.pem"
+key_file = "{{ consul_config_dir }}/key.pem"
+
+acl = {
+  enabled = true
+  default_policy = "deny"
+  down_policy = "extend-cache"
+}
+
+telemetry {
+  prometheus_retention_time = "24h"
+  disable_hostname = true
+}
 
 # Enable the UI
 ui_config {


### PR DESCRIPTION
This commit enhances the security and observability of the Consul cluster by:

- Enabling TLS encryption for all agent communication to prevent eavesdropping.
- Implementing ACLs with a default-deny policy to enforce granular access control.
- Adding telemetry configurations to enable monitoring with Prometheus.

The Ansible role for Consul has been significantly refactored to:

- Generate a single CA and unique node certificates on the Ansible controller to establish a proper chain of trust.
- Ensure all certificate and ACL bootstrapping tasks are idempotent, preventing failures on subsequent runs.
- Secure the ACL management token by setting restrictive file permissions.