### PR TITLE
Fix(bootstrap): Install community.docker Ansible collection

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -265,7 +265,7 @@ fi
 
 # Install Ansible collections
 echo "Installing Ansible collections..."
-"$ANSIBLE_GALAXY_EXEC" collection install community.general ansible.posix
+"$ANSIBLE_GALAXY_EXEC" collection install community.general ansible.posix community.docker
 
 # --- Handle Nomad job purge ---
 if [ "$PURGE_JOBS" = true ]; then


### PR DESCRIPTION
The `bootstrap.sh` script was failing with the error: `Error loading plugin 'community.docker.docker_image': No module named 'ansible_collections.community.docker'`

This occurred because the `community.docker` Ansible collection was not being installed before the `ansible-playbook` command was executed.

This commit adds `community.docker` to the list of collections installed by `ansible-galaxy` in the `bootstrap.sh` script, resolving the module loading error.