### PR TITLE
feat: Make docker role user tasks idempotent

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -137,7 +137,7 @@ These tasks are focused on addressing the brittleness of the deployment process 
         creates: /opt/llama.cpp-build/build/bin/llama-server # This line prevents re-running
     ```
 
-- [ ] **Use `when` clauses for state checks:** Before making a change, verify if it's necessary. For instance, when adding a user to the `docker` group, first check if the user is already a member to prevent the task from showing "changed" on every run.
+- [x] **Use `when` clauses for state checks:** Before making a change, verify if it's necessary. For instance, when adding a user to the `docker` group, first check if the user is already a member to prevent the task from showing "changed" on every run.
 - [ ] **Audit all roles for idempotency:** Systematically review every task in every role (`common`, `docker`, `nomad`, `consul`, etc.) and apply idempotency checks where they are missing.
 - [ ] **Convert `command` and `shell` to Ansible modules where possible:** Replace generic shell commands with dedicated Ansible modules (e.g., `ansible.builtin.user`, `ansible.builtin.file`, `community.general.nmcli`), as these modules are inherently idempotent.
 

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -59,12 +59,29 @@
         cmd: /tmp/get-docker.sh
       become: true
 
+- name: Check if target_user is in the docker group
+  ansible.builtin.command:
+    cmd: "groups {{ target_user }}"
+  register: target_user_groups
+  changed_when: false
+  become: true
+  check_mode: no
+
 - name: Add user to the 'docker' group for rootless execution
   ansible.builtin.user:
     name: "{{ target_user }}"
     groups: docker
     append: yes
   become: true
+  when: "'docker' not in target_user_groups.stdout"
+
+- name: Check if root is in the docker group
+  ansible.builtin.command:
+    cmd: "groups root"
+  register: root_user_groups
+  changed_when: false
+  become: true
+  check_mode: no
 
 - name: Add root user to the 'docker' group
   ansible.builtin.user:
@@ -72,6 +89,7 @@
     groups: docker
     append: yes
   become: true
+  when: "'docker' not in root_user_groups.stdout"
 
 - name: Place the Docker daemon configuration file
   ansible.builtin.template:


### PR DESCRIPTION
Adds checks to the docker role to determine if the target_user and root are already in the docker group before attempting to add them.

This prevents the tasks from reporting "changed" on every run of the playbook.