### PR TITLE
fix(ansible): make consul version check robust

### DIFF
--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -12,7 +12,7 @@
 
 - name: Set installed Consul version fact
   set_fact:
-    installed_consul_version: "{{ consul_version_output.stdout | regex_search('Consul v([0-9]+\\.[0-9]+\\.[0-9]+)', '\\\\1') | first | default('0.0.0') }}"
+    installed_consul_version: "{{ (consul_version_output.stdout | regex_search('Consul v([0-9]+\\.[0-9]+\\.[0-9]+)', '\\\\1') | first) if consul_version_output.rc == 0 else '0.0.0' }}"
 
 - name: Download Consul
   command: "curl -L -o /tmp/consul.zip {{ consul_zip_url }}"


### PR DESCRIPTION
The 'Check installed Consul version' task would fail if the 'consul' command was not found, causing the subsequent regex_search to fail on a None value.

This change makes the version fact conditional on the return code of the command. If the command fails, the version is set to '0.0.0', ensuring the installation proceeds correctly.