### PR TITLE
Fix(mqtt): Allow mqtt container to use default entrypoint

### DIFF
--- a/ansible/roles/mqtt/templates/mqtt.nomad.j2
+++ b/ansible/roles/mqtt/templates/mqtt.nomad.j2
@@ -41,12 +41,9 @@ job "mqtt" {
         ports = ["mqtt", "ws"]
         cap_add = ["SETUID", "SETGID", "CHOWN"]
 
-        # The entrypoint is overridden to explicitly load the config file.
-        # The config file itself is created by Ansible and placed in the host volume.
-        # The entrypoint is overridden to explicitly load the config file.
-        # The config file itself is created by Ansible and placed in the host volume.
-        command = "mosquitto"
-        args = ["-c", "/mosquitto/mosquitto.conf"]
+        # By not specifying a command, we allow the container to use its
+        # default entrypoint, which is a script that correctly initializes the
+        # Mosquitto service, including setting file permissions.
       }
 
       volume_mount {


### PR DESCRIPTION
The mqtt Nomad job was failing to start because the `command` and `args` in the job file were overriding the default entrypoint of the `eclipse-mosquitto` Docker image. This default entrypoint is a script that handles necessary setup, including file permissions.

By removing the `command` and `args` overrides, the container can now use its native entrypoint, which resolves the startup failures. This allows the `mqtt` job to deploy successfully, which in turn unblocks the `world_model_service` job.