### PR TITLE
fix(ansible): Make Consul version detection more robust

### DIFF
--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -12,7 +12,7 @@
 
 - name: Set installed Consul version fact
   set_fact:
-    installed_consul_version: "{{ (consul_version_output.stdout | regex_search('Consul v([0-9]+\\.[0-9]+\\.[0-9]+)', '\\\\1') | first) if consul_version_output.rc == 0 else '0.0.0' }}"
+    installed_consul_version: "{{ (consul_version_output.stdout | regex_search('Consul v([0-9]+\\.[0-9]+\\.[0-9]+)', '\\\\1') or ['0.0.0']) | first }}"
 
 - name: Download Consul
   command: "curl -L -o /tmp/consul.zip {{ consul_zip_url }}"


### PR DESCRIPTION
The Ansible task to check the installed Consul version was failing with a `regex_search` error if the `consul version` command output did not contain the expected version string. This would happen if Consul was not yet installed or if the output format changed.

This commit makes the version detection more resilient by using a Jinja2 `or` filter to provide a default value ('0.0.0') when the regex does not find a match. This prevents the filter from failing on a `None` value and allows the playbook to proceed correctly.