### PR TITLE
fix(bootstrap): Ensure Ansible collections are installed correctly

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -263,9 +263,19 @@ else
     exit 1
 fi
 
-# Install Ansible collections
-echo "Installing Ansible collections..."
-if ! "$ANSIBLE_GALAXY_EXEC" collection install community.general ansible.posix community.docker; then
+# Install Ansible and collections
+echo "Installing Ansible and collections..."
+if ! "$ANSIBLE_PLAYBOOK_EXEC" --version > /dev/null 2>&1 || ! "$ANSIBLE_GALAXY_EXEC" --version > /dev/null 2>&1; then
+    echo "Ansible or ansible-galaxy not found, installing..."
+    pip install ansible
+fi
+
+# Define the collections path
+COLLECTIONS_PATH="$HOME/.ansible/collections"
+mkdir -p "$COLLECTIONS_PATH"
+
+# Install collections to the specified path
+if ! "$ANSIBLE_GALAXY_EXEC" collection install community.general ansible.posix community.docker -p "$COLLECTIONS_PATH"; then
     echo "Error: Failed to install Ansible collections." >&2
     exit 1
 fi


### PR DESCRIPTION
The bootstrap.sh script was failing with an Ansible error: "No filter named 'community.general.version_compare'". This was caused by the community.general Ansible collection not being available to the playbook.

The root cause was twofold:
1. The 'ansible' package, which provides 'ansible-galaxy', was not explicitly installed.
2. The collection installation path was not guaranteed to be in a location searched by ansible-playbook.

This commit fixes the issue by:
- Explicitly installing the 'ansible' package if it's not found.
- Forcing the installation of Ansible collections to the standard ~/.ansible/collections path using the '-p' flag with 'ansible-galaxy'.

This ensures the required collections are always present and discoverable, resolving the playbook execution error.