### PR TITLE
Fix(ansible): Ensure bootstrap.sh reliably installs collections

### DIFF
--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -1,11 +1,4 @@
 
-# Task 0: Install community.general collection
-- name: Install community.general Ansible collection
-  ansible.builtin.command: ansible-galaxy collection install community.general
-  tags:
-    - consul_install_deps
-
-
 # Task 1: Install unzip (from user snippet)
 - name: Install unzip
   become: true

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -214,62 +214,38 @@ else
 fi
 
 # --- Find Ansible Playbook executable ---
-find_executable() {
-    local executable_name=$1
-    # 1. Check local virtual environment
-    if [ -f ".venv/bin/$executable_name" ]; then
-        # Use realpath to resolve the absolute path
-        echo "$(realpath ".venv/bin/$executable_name")"
-        return 0
-    fi
+# JULES: The original find_executable function was unreliable. This new approach
+# dynamically finds the active python interpreter's bin directory, making it
+# portable across different environments (system, venv, pyenv).
 
-    # 2. Check PATH
-    if command -v "$executable_name" &> /dev/null; then
-        command -v "$executable_name"
-        return 0
-    fi
-
-    # 3. Check pyenv shims and versions
-    if [ -d "$HOME/.pyenv" ]; then
-        local pyenv_path
-        pyenv_path=$(find "$HOME/.pyenv/versions" -type f -name "$executable_name" | head -n 1)
-        if [ -n "$pyenv_path" ] && [ -x "$pyenv_path" ]; then
-            echo "$pyenv_path"
-            return 0
-        fi
-    fi
-
-    return 1
-}
-
-# Find the ansible-playbook executable
-ANSIBLE_PLAYBOOK_EXEC=$(find_executable "ansible-playbook")
-
-if [ -n "$ANSIBLE_PLAYBOOK_EXEC" ] && [ -x "$ANSIBLE_PLAYBOOK_EXEC" ]; then
-    echo "Found ansible-playbook: $ANSIBLE_PLAYBOOK_EXEC"
-else
-    echo "Error: ansible-playbook not found."
-    echo "Please ensure you have created a virtual environment, run 'pip install -r requirements-dev.txt',"
-    echo "and that 'ansible-core' is listed in the requirements file."
+# Find the directory containing the active python executable
+PYTHON_EXEC=$(command -v python || command -v python3)
+if [ -z "$PYTHON_EXEC" ]; then
+    echo "Error: Could not find 'python' or 'python3' in the PATH." >&2
     exit 1
 fi
+PYTHON_BIN_DIR=$(dirname "$PYTHON_EXEC")
 
-# Find the ansible-galaxy executable
-ANSIBLE_GALAXY_EXEC=$(find_executable "ansible-galaxy")
-if [ -n "$ANSIBLE_GALAXY_EXEC" ] && [ -x "$ANSIBLE_GALAXY_EXEC" ]; then
-    echo "Found ansible-galaxy: $ANSIBLE_GALAXY_EXEC"
-else
-    echo "Error: ansible-galaxy not found."
-    exit 1
+ANSIBLE_PLAYBOOK_EXEC="$PYTHON_BIN_DIR/ansible-playbook"
+ANSIBLE_GALAXY_EXEC="$PYTHON_BIN_DIR/ansible-galaxy"
+
+# Check if Ansible executables exist, if not, install ansible-core
+if [ ! -x "$ANSIBLE_PLAYBOOK_EXEC" ] || [ ! -x "$ANSIBLE_GALAXY_EXEC" ]; then
+    echo "Ansible executables not found. Attempting to install ansible-core..."
+    pip install ansible-core
+    # Verify after installation
+    if [ ! -x "$ANSIBLE_PLAYBOOK_EXEC" ] || [ ! -x "$ANSIBLE_GALAXY_EXEC" ]; then
+        echo "Error: Failed to locate Ansible executables even after pip install." >&2
+        echo "Looked for: $ANSIBLE_PLAYBOOK_EXEC"
+        exit 1
+    fi
 fi
 
-# Install Ansible and collections
+echo "Found ansible-playbook: $ANSIBLE_PLAYBOOK_EXEC"
+echo "Found ansible-galaxy: $ANSIBLE_GALAXY_EXEC"
+
+# Install Ansible collections
 echo "Installing Ansible and collections..."
-if ! "$ANSIBLE_PLAYBOOK_EXEC" --version > /dev/null 2>&1 || ! "$ANSIBLE_GALAXY_EXEC" --version > /dev/null 2>&1; then
-    echo "Ansible or ansible-galaxy not found, installing..."
-    pip install ansible
-fi
-
 # Define the collections path
 COLLECTIONS_PATH="$HOME/.ansible/collections"
 mkdir -p "$COLLECTIONS_PATH"


### PR DESCRIPTION
This commit resolves a persistent Ansible error, "No filter named 'community.general.version_compare'", that occurred during the execution of the `bootstrap.sh` script.

**Root Cause Analysis:**

The failure was caused by a combination of two issues:

1.  **Race Condition:** A task within the `ansible/roles/consul/tasks/main.yaml` file attempted to install the `community.general` collection using `ansible-galaxy`. This approach is fundamentally flawed because Ansible parses the entire playbook and loads all required collections *before* executing any tasks. The `version_compare` filter was needed at parse time, but the task to install it hadn't run yet, causing the playbook to fail.

2.  **Unreliable Executable Discovery:** The `bootstrap.sh` script, which is the correct place for this installation to happen, used a fragile function to find the `ansible-galaxy` executable. This function often failed in the development environment, causing the collection installation step to be skipped entirely.

**Solution:**

This commit implements a robust, multi-part solution:

1.  The incorrect `ansible-galaxy` installation task has been removed from the `consul` role to eliminate the race condition.
2.  The `bootstrap.sh` script has been significantly hardened. It now uses a portable method to dynamically find the active Python interpreter's `bin` directory and constructs the absolute paths to `ansible-playbook` and `ansible-galaxy` from there.
3.  The script now ensures that `ansible-galaxy collection install` is successfully run *before* any playbooks are executed, guaranteeing the `community.general` collection and its filters are available when needed.

This approach ensures the bootstrapping process is reliable and portable across different development environments.