### PR TITLE
Fix: Replace deprecated version_compare filter in Consul role

### DIFF
--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -40,11 +40,9 @@
     group: root
     mode: 0755
   vars:
-    # Define local var for use in 'when' condition
-    current_version: "{{ consul_version_output.stdout | default('') | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') }}"
-  when: >
-    current_version is none or
-    current_version | community.general.version_compare(consul_version, '<')
+    # Define local var for use in 'when' condition. Use 'or' to default the version.
+    current_version: "{{ (consul_version_output.stdout | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+')) or '0.0.0' }}"
+  when: current_version is version(consul_version, '<')
   tags:
     - consul_configure
 


### PR DESCRIPTION
Replaced the deprecated and non-existent 'community.general.version_compare' filter with the modern, built-in 'version' test.

This resolves the playbook failure 'No filter named community.general.version_compare'.

The logic was also improved to handle cases where Consul is not yet installed by defaulting the current version to '0.0.0', making the installation condition more robust.