### PR TITLE
fix(bootstrap): Ensure ansible-core is installed with correct python

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -232,7 +232,7 @@ ANSIBLE_GALAXY_EXEC="$PYTHON_BIN_DIR/ansible-galaxy"
 # Check if Ansible executables exist, if not, install ansible-core
 if [ ! -x "$ANSIBLE_PLAYBOOK_EXEC" ] || [ ! -x "$ANSIBLE_GALAXY_EXEC" ]; then
     echo "Ansible executables not found. Attempting to install ansible-core..."
-    pip install ansible-core
+    "$PYTHON_EXEC" -m pip install ansible-core
     # Verify after installation
     if [ ! -x "$ANSIBLE_PLAYBOOK_EXEC" ] || [ ! -x "$ANSIBLE_GALAXY_EXEC" ]; then
         echo "Error: Failed to locate Ansible executables even after pip install." >&2


### PR DESCRIPTION
The `bootstrap.sh` script was failing with the error `Syntax error in expression: No filter named 'community.general.version_compare'`. This was caused by the `ansible-galaxy` and `ansible-playbook` executables not being available in the environment where the script was running.

This change modifies the `bootstrap.sh` script to use the specific python interpreter found by the script to install `ansible-core`. This ensures that the Ansible executables are installed in the correct environment, and that the collections are available to the playbook.