### PR TITLE
Fix: Resolve Ansible collection path issue

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,7 +10,6 @@ inventory = inventory.yaml
 host_key_checking = false
 interpreter_python = /usr/bin/python3
 filter_plugins = ansible/filter_plugins
-collections_paths = ~/.ansible/collections
 
 
 [privilege_escalation]


### PR DESCRIPTION
Removes the restrictive `collections_paths` directive from `ansible.cfg`.

This was preventing Ansible from finding the `community.general` collection, which was installed in the default location by the `bootstrap.sh` script. The hardcoded path in `ansible.cfg` overrode Ansible's default search paths, leading to the `version_compare` filter not being found.

By removing this line, Ansible can now correctly locate the collection.