### PR TITLE
Fix Consul certificate permissions

### DIFF
--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -150,6 +150,17 @@
   tags:
     - consul_configure
 
+- name: Set readable permissions on generated certs
+  ansible.builtin.file:
+    path: "{{ consul_temp_cert_dir }}"
+    state: directory
+    recurse: yes
+    mode: '0644'
+  delegate_to: localhost
+  run_once: true
+  tags:
+    - consul_configure
+
 # Task 10: Include TLS tasks (from original file)
 - name: Include TLS tasks
   ansible.builtin.include_tasks: tls.yaml


### PR DESCRIPTION
The Ansible playbook was failing with a "Permission denied" error when trying to copy the Consul TLS certificates. This was because the `openssl` commands were creating files with restrictive permissions that prevented the playbook user from reading them.

This commit resolves the issue by adding a new task to `ansible/roles/consul/tasks/main.yaml` that recursively sets the mode of the generated certificate files to `0644`. This ensures that the playbook user has the necessary read permissions before the files are copied, allowing the playbook to complete successfully.