### PR TITLE
feat: Install Ansible collections system-wide

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -253,8 +253,8 @@ if [ ! -x "$ANSIBLE_GALAXY_EXEC" ]; then
     exit 1
 fi
 
-# Install collections without a specific path to use Ansible's default search path
-if ! "$ANSIBLE_GALAXY_EXEC" collection install community.general ansible.posix community.docker; then
+# Install collections to a system-wide path to ensure they are available to the root user (via become)
+if ! sudo "$ANSIBLE_GALAXY_EXEC" collection install community.general ansible.posix community.docker --collections-path /usr/share/ansible/collections; then
     echo "Error: Failed to install Ansible collections." >&2
     exit 1
 fi


### PR DESCRIPTION
Resolves a persistent issue where Ansible playbooks running with `become: yes` could not find collections installed in the user's home directory.

The `bootstrap.sh` script is modified to install Ansible collections to the system-wide path `/usr/share/ansible/collections` using `sudo`. This ensures that the collections are available to the `root` user, fixing the `community.general.version_compare` filter not found error in the Consul role.