### PR TITLE
fix(deps): add missing dependencies to fix ci failures

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,3 +28,5 @@ langchain
 python-nomad
 quibbler
 llm-sandbox[docker]
+kubernetes
+paho-mqtt

--- a/testing/unit_tests/test_world_model_service.py
+++ b/testing/unit_tests/test_world_model_service.py
@@ -3,6 +3,9 @@ import os
 import sys
 from unittest.mock import MagicMock, patch, AsyncMock
 
+# Add the ansible/roles directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../ansible/roles')))
+
 from world_model_service.files.app import app, on_connect, on_message, run_mqtt_client
 from fastapi.testclient import TestClient
 


### PR DESCRIPTION
Adds the `kubernetes` and `paho-mqtt` packages to the development requirements to resolve `ModuleNotFoundError` exceptions that were causing the unit tests to fail in the CI environment. This also corrects a faulty import path in the `world_model_service` test that prevented it from locating the module under test.