### PR TITLE
Fix: Correct various linting errors across the codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Expert agents are specialized LLMs deployed as separate, independent services. T
 **Only the Router Agent has access to the library of tools.** This is a deliberate design choice for security and predictability. When the Router determines that a task requires interacting with the outside world, it will select and use the appropriate tool itself, rather than passing that capability down to a specialized expert. This concentrates the system's interactive capabilities in one place, making it easier to manage, monitor, and secure.
 
 The following tools are available:
+
 - **`ssh`**: Executes commands on remote machines.
 - **`mcp`**: Provides agent introspection and self-control (e.g., status checks, memory management).
 - **`vision`**: Gets a real-time description of what is visible via the webcam.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For development, testing, or bootstrapping the very first node of a new cluster,
      - `all` (default): Full setup for a standalone control node.
      - `controller`: Sets up only the core infrastructure services (Consul, Nomad, etc.).
      - `worker`: Configures the node as a worker and requires `--controller-ip`.
-   - `--controller-ip <ip>`: The IP address of the main controller node. **Required** when ` --role` is `worker`.
+   - `--controller-ip <ip>`: The IP address of the main controller node. **Required** when `--role` is `worker`.
    - `--tags <tag1,tag2>`: Run only specific parts of the Ansible playbook (e.g., `--tags nomad` would only run the Nomad configuration tasks).
    - `--external-model-server`: Skips the download and build steps for large language models. This is ideal for development or if you are using a remote model server.
    - `--purge-jobs`: Stops and purges all running Nomad jobs before starting the bootstrap process, ensuring a clean deployment.

--- a/ansible/roles/claude_clone/tasks/main.yaml
+++ b/ansible/roles/claude_clone/tasks/main.yaml
@@ -1,4 +1,3 @@
----
 - name: Clone Claude_Clone repository
   ansible.builtin.git:
     repo: 'https://github.com/LokiMetaSmith/Claude_Clone.git'

--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -1,4 +1,3 @@
-
 # Task 1: Install unzip (from user snippet)
 - name: Install unzip
   become: true

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -105,5 +105,3 @@
     state: started
     enabled: yes
   become: yes
-
-

--- a/ansible/roles/llxprt_code/tasks/main.yaml
+++ b/ansible/roles/llxprt_code/tasks/main.yaml
@@ -1,4 +1,3 @@
----
 - name: Clone llxprt-code repository
   ansible.builtin.git:
     repo: 'https://github.com/vybestack/llxprt-code.git'

--- a/ansible/roles/moe_gateway/tasks/main.yaml
+++ b/ansible/roles/moe_gateway/tasks/main.yaml
@@ -1,4 +1,3 @@
----
 - name: Ensure gateway application directory exists
   ansible.builtin.file:
     path: /opt/pipecatapp/moe_gateway

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -1,6 +1,3 @@
----
-
-
 - name: Copy app.py into the build context
   ansible.builtin.copy:
     src: app.py  # Looks for files/app.py inside the role

--- a/diagnose_home_assistant.yaml
+++ b/diagnose_home_assistant.yaml
@@ -1,4 +1,3 @@
----
 - hosts: localhost
   become: yes
   gather_facts: no

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,6 +350,7 @@
       "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.41.0.tgz",
       "integrity": "sha512-kp29tKrMKdn+xonfefjp3a/MsNzAd9c5ke0ydMEI9PR98bOjzglYN4nfMSaIs69msUf1DNkgevAIAPtK2SeX0Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commander": "~12.1.0",
         "get-stdin": "~9.0.0",

--- a/playbooks/cluster_status.yaml
+++ b/playbooks/cluster_status.yaml
@@ -1,4 +1,3 @@
----
 - hosts: localhost
   gather_facts: no
   become: no

--- a/playbooks/promote_to_controller.yaml
+++ b/playbooks/promote_to_controller.yaml
@@ -1,4 +1,3 @@
----
 - hosts: all
   become: yes
   gather_facts: yes

--- a/playbooks/services/nomad_client.yaml
+++ b/playbooks/services/nomad_client.yaml
@@ -1,4 +1,3 @@
----
 - name: Configure Nomad as a client
   ansible.builtin.include_role:
     name: nomad

--- a/playbooks/worker.yaml
+++ b/playbooks/worker.yaml
@@ -1,4 +1,3 @@
----
 - hosts: all
   become: yes
   gather_facts: yes

--- a/prompt_engineering/agents/ADAPTATION_AGENT.md
+++ b/prompt_engineering/agents/ADAPTATION_AGENT.md
@@ -22,5 +22,5 @@ The agent is activated by the `supervisor.py` script and receives a single input
 
 The agent produces two primary outputs:
 
-1.  **A YAML Test Case File**: A new file containing a structured test case that reproduces the failure.
-2.  **A Subprocess Call**: An invocation of `prompt_engineering/evolve.py` with the path to the new test case file as an argument.
+1. **A YAML Test Case File**: A new file containing a structured test case that reproduces the failure.
+2. **A Subprocess Call**: An invocation of `prompt_engineering/evolve.py` with the path to the new test case file as an argument.

--- a/pxe_setup.yaml
+++ b/pxe_setup.yaml
@@ -1,4 +1,3 @@
----
 - hosts: pxe_server
   become: yes
   tasks:


### PR DESCRIPTION
This commit addresses multiple linting issues identified by `yamllint` and `markdownlint-cli` to bring the codebase into compliance with the project's style guides.

The following changes were made:
- Removed forbidden `---` document start markers from various Ansible task files and playbooks.
- Fixed `blanks-around-lists` and `list-marker-space` errors in `AGENTS.md` and other Markdown files.
- Corrected a `no-space-in-code` error in `README.md`.
- Resolved an `empty-lines` and `new-line-at-end-of-file` error in an Ansible task file.