### PR TITLE
The Ansible playbook failed during the Consul TLS setup because the `…

### DIFF
--- a/ansible/roles/consul/tasks/tls.yaml
+++ b/ansible/roles/consul/tasks/tls.yaml
@@ -3,6 +3,7 @@
     src: "{{ consul_temp_cert_dir }}/ca.pem"
     dest: "{{ consul_config_dir }}/ca.pem"
     mode: '0644'
+    remote_src: yes
   become: yes
 
 - name: Copy node certificate and key to each node
@@ -10,6 +11,7 @@
     src: "{{ consul_temp_cert_dir }}/{{ inventory_hostname }}.{{ item }}"
     dest: "{{ consul_config_dir }}/{{ item }}"
     mode: '0600'
+    remote_src: yes
   loop:
     - key
     - pem


### PR DESCRIPTION
…copy` module was looking for the generated certificate files on the Ansible controller instead of the target machine where they were created.

This was resolved by adding the `remote_src: yes` parameter to the `copy` tasks in `ansible/roles/consul/tasks/tls.yaml`. This instructs Ansible to source the files from the remote (target) machine, allowing the playbook to find the certificates and complete the setup successfully.