### PR TITLE
The Ansible playbook failed during the Consul TLS setup because the c…

### DIFF
--- a/ansible/roles/consul/tasks/tls.yaml
+++ b/ansible/roles/consul/tasks/tls.yaml
@@ -8,23 +8,11 @@
 
 - name: Copy node certificate and key to each node
   copy:
-    src: "{{ consul_temp_cert_dir }}/{{ inventory_hostname }}.{{ item }}"
-    dest: "{{ consul_config_dir }}/{{ item }}"
+    src: "{{ consul_temp_cert_dir }}/{{ inventory_hostname }}.{{ item.src }}"
+    dest: "{{ consul_config_dir }}/{{ item.dest }}"
     mode: '0600'
     remote_src: yes
   loop:
-    - key
-    - pem
-  become: yes
-
-- name: Rename node certificate to cert.pem
-  command: "mv {{ consul_config_dir }}/{{ inventory_hostname }}.pem {{ consul_config_dir }}/cert.pem"
-  args:
-    creates: "{{ consul_config_dir }}/cert.pem"
-  become: yes
-
-- name: Rename node key to key.pem
-  command: "mv {{ consul_config_dir }}/{{ inventory_hostname }}.key {{ consul_config_dir }}/key.pem"
-  args:
-    creates: "{{ consul_config_dir }}/key.pem"
+    - { src: 'pem', dest: 'cert.pem' }
+    - { src: 'key', dest: 'key.pem' }
   become: yes


### PR DESCRIPTION
…opy module was looking for the generated certificate files on the Ansible controller instead of the target machine where they were created. Additionally, the subsequent mv command was failing because the copy operation never succeeded.

This was resolved by adding the remote_src: yes parameter to the copy tasks in ansible/roles/consul/tasks/tls.yaml. This instructs Ansible to source the files from the remote (target) machine.

Furthermore, the playbook was refactored to copy the certificates directly to their final destination filenames (cert.pem and key.pem), eliminating the need for separate and fragile rename tasks. This makes the playbook more robust and idempotent.