### PR TITLE
This commit provides a comprehensive set of fixes for the Consul Ansi…

### DIFF
--- a/ansible/roles/consul/tasks/acl.yaml
+++ b/ansible/roles/consul/tasks/acl.yaml
@@ -1,15 +1,11 @@
 - name: Bootstrap ACLs
   block:
-    - name: Check if ACLs are already bootstrapped
-      stat:
-        path: "{{ consul_config_dir }}/acl_bootstrapped"
-      register: acl_bootstrapped
-      become: yes
-
     - name: Bootstrap ACLs
       command: "consul acl bootstrap"
+      args:
+        creates: "{{ consul_config_dir }}/management_token"
       register: acl_bootstrap_result
-      when: not acl_bootstrapped.stat.exists
+      changed_when: acl_bootstrap_result.rc == 0 and acl_bootstrap_result.stdout != ""
       become: yes
 
     - name: Store management token
@@ -17,14 +13,7 @@
         content: "{{ (acl_bootstrap_result.stdout | from_json).SecretID }}"
         dest: "{{ consul_config_dir }}/management_token"
         mode: '0600'
-      when: not acl_bootstrapped.stat.exists
-      become: yes
-
-    - name: Mark ACLs as bootstrapped
-      file:
-        path: "{{ consul_config_dir }}/acl_bootstrapped"
-        state: touch
-      when: not acl_bootstrapped.stat.exists
+      when: acl_bootstrap_result.changed
       become: yes
   when: "'controller_nodes' in groups and groups['controller_nodes'] | length > 0"
   run_once: true


### PR DESCRIPTION
…ble playbook, addressing multiple critical errors.

The following changes have been implemented:

1.  **Resolved File Copy Errors:** Corrected file copy tasks in `tls.yaml` by adding `remote_src: yes` and refactoring the certificate copy/rename logic into a single, idempotent task. This fixes the "Could not find or access" and "mv: cannot stat" errors.

2.  **Corrected ACL Configuration:** Added the `primary_datacenter` setting to `consul.hcl.j2` and defined the `consul_datacenter` variable in `defaults/main.yaml`, which are prerequisites for enabling ACLs.

3.  **Fixed Playbook Logic:** Reordered tasks in `main.yaml` to ensure the Consul configuration is applied *before* ACLs are bootstrapped. Added a `flush_handlers` task to guarantee the service restarts at the correct time.

4.  **Resolved Race Condition:** Added a wait task to `main.yaml` to poll the Consul API, ensuring the service is fully initialized before subsequent tasks are run. This fixes the "connection refused" error.

5.  **Improved Idempotency:** The ACL bootstrapping task in `acl.yaml` was refactored to use the `creates` argument, preventing it from failing on subsequent playbook runs.

**Outstanding Issue:**
Despite these extensive fixes, the playbook continues to fail with the error: "Failed ACL bootstrapping: Unexpected response code: 401 (ACL support disabled)". The `acl = { enabled = true }` block is confirmed to be present in the configuration template, and the service is restarted before the bootstrap is attempted. The root cause of this final error remains unidentified.