### PR TITLE
This commit provides a comprehensive set of fixes for the Consul Ansi…

### DIFF
--- a/ansible/roles/consul/tasks/acl.yaml
+++ b/ansible/roles/consul/tasks/acl.yaml
@@ -69,11 +69,11 @@
             dest: "{{ consul_config_dir }}/management_token"
             mode: '0600'
           become: yes
-      when: "'ACL bootstrap no longer allowed' in ansible_failed_result.results[0].stderr"
+      when: ansible_failed_result.stderr is defined and 'ACL bootstrap no longer allowed' in ansible_failed_result.stderr
       delegate_to: "{{ groups['controller_nodes'][0] }}"
       run_once: true
 
     - name: Fail on unrecoverable ACL bootstrap error
       fail:
         msg: "ACL bootstrap failed with an unrecoverable error: {{ ansible_failed_result }}"
-      when: "'ACL bootstrap no longer allowed' not in ansible_failed_result.results[0].stderr"
+      when: ansible_failed_result.stderr is not defined or 'ACL bootstrap no longer allowed' not in ansible_failed_result.stderr


### PR DESCRIPTION
…ble playbook, addressing multiple critical errors and improving its overall robustness and resilience.

The following changes have been implemented:

1.  **Resolved File Copy Errors:** Corrected file copy tasks in `tls.yaml` by adding `remote_src: yes` and refactoring the certificate copy/rename logic into a single, idempotent task. This fixes the "Could not find or access" and "mv: cannot stat" errors.

2.  **Corrected ACL Configuration:** Added the `primary_datacenter` setting to `consul.hcl.j2` and defined the `consul_datacenter` variable in `defaults/main.yaml`, which are prerequisites for enabling ACLs.

3.  **Fixed Playbook Logic:** Reordered tasks in `main.yaml` to ensure the Consul configuration is applied *before* ACLs are bootstrapped. Added a `flush_handlers` task to guarantee the service restarts at the correct time.

4.  **Resolved Race Condition:** Added a wait task to `main.yaml` to poll the Consul API, ensuring the service is fully initialized before subsequent tasks are run. This fixes the "connection refused" error.

5.  **Improved Idempotency:** The ACL bootstrapping task in `acl.yaml` was refactored to use the `creates` argument, preventing it from failing on subsequent playbook runs.

6.  **Implemented Self-Healing:** The ACL bootstrap process in `acl.yaml` is now wrapped in a `block`/`rescue` structure. If the bootstrap fails with a recoverable "ACL bootstrap no longer allowed" error, the playbook will automatically stop Consul, reset its data directory, and retry the bootstrap, making the playbook reliably repeatable.

7.  **Corrected Error Handling:** The `when` conditions in the `rescue` block were corrected to properly access the `stderr` of a failed task, resolving the "has no attribute 'results'" error.