### PR TITLE
fix(ansible): Handle empty JSON output in Consul ACL bootstrap

### DIFF
--- a/ansible/roles/consul/tasks/acl.yaml
+++ b/ansible/roles/consul/tasks/acl.yaml
@@ -63,12 +63,18 @@
           register: acl_bootstrap_result_recovery
           become: yes
 
+        - name: "Debug: Display ACL bootstrap recovery output"
+          debug:
+            msg:
+              - "STDOUT: {{ acl_bootstrap_result_recovery.stdout }}"
+              - "STDERR: {{ acl_bootstrap_result_recovery.stderr }}"
+
         - name: Store recovered management token
           copy:
             content: "{{ (acl_bootstrap_result_recovery.stdout | from_json).SecretID }}"
             dest: "{{ consul_config_dir }}/management_token"
             mode: '0600'
-          when: acl_bootstrap_result_recovery.stdout != ""
+          when: acl_bootstrap_result_recovery.stdout | from_json is a success
           become: yes
       when: ansible_failed_result.stderr is defined and 'ACL bootstrap no longer allowed' in ansible_failed_result.stderr
       delegate_to: "{{ groups['controller_nodes'][0] }}"


### PR DESCRIPTION
Adds a more robust check to the `consul` Ansible role to ensure the output of the `consul acl bootstrap` command is valid JSON before attempting to parse it. This prevents the playbook from failing when the command returns an empty or malformed string.

- Replaced `when: acl_bootstrap_result_recovery.stdout != ""` with `when: acl_bootstrap_result_recovery.stdout | from_json is a success` for more reliable validation.
- Added a debug task to log the `stdout` and `stderr` of the bootstrap command for easier troubleshooting.