### PR TITLE
fix(deps): add podman dependency for llm-sandbox

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,6 +27,6 @@ uvicorn
 langchain
 python-nomad
 quibbler
-llm-sandbox[docker]
+llm-sandbox[docker,podman]
 kubernetes
 paho-mqtt


### PR DESCRIPTION
The unit tests were failing in the CI pipeline due to a `ModuleNotFoundError: No module named 'podman'`. This error originated from the `llm-sandbox` library, which requires the `podman` package when configured to use a podman backend.

This change updates `requirements-dev.txt` to install `llm-sandbox` with both `docker` and `podman` extras, ensuring that all necessary dependencies are present for the tests to run successfully.