### PR TITLE
fix(ansible): Correctly parse Consul ACL bootstrap output

### DIFF
--- a/ansible/roles/consul/tasks/acl.yaml
+++ b/ansible/roles/consul/tasks/acl.yaml
@@ -12,7 +12,7 @@
 
         - name: Store management token
           copy:
-            content: "{{ (acl_bootstrap_result.stdout | from_json).SecretID }}"
+            content: "{{ acl_bootstrap_result.stdout | regex_search('SecretID:\\s+([^\\n]+)', '\\1') | first }}"
             dest: "{{ consul_config_dir }}/management_token"
             mode: '0600'
           when: acl_bootstrap_result.changed
@@ -71,10 +71,10 @@
 
         - name: Store recovered management token
           copy:
-            content: "{{ (acl_bootstrap_result_recovery.stdout | from_json).SecretID }}"
+            content: "{{ acl_bootstrap_result_recovery.stdout | regex_search('SecretID:\\s+([^\\n]+)', '\\1') | first }}"
             dest: "{{ consul_config_dir }}/management_token"
             mode: '0600'
-          when: acl_bootstrap_result_recovery.stdout | from_json is a success
+          when: "'SecretID:' in acl_bootstrap_result_recovery.stdout"
           become: yes
       when: ansible_failed_result.stderr is defined and 'ACL bootstrap no longer allowed' in ansible_failed_result.stderr
       delegate_to: "{{ groups['controller_nodes'][0] }}"


### PR DESCRIPTION
The `consul acl bootstrap` command returns plain text, not JSON. The previous code used the `from_json` filter, which caused the task to fail or be skipped silently.

This change replaces the incorrect `from_json` filter with a `regex_search` to reliably extract the `SecretID` from the command's plain text output. The `when` condition is also updated to check for the presence of the 'SecretID:' string, ensuring the task only runs when the command succeeds. This fix is applied to both the initial bootstrap and the recovery block for consistency.