### PR TITLE
Fix Home Assistant diagnostic playbook crash and MQTT config

### DIFF
--- a/playbooks/services/tasks/diagnose_home_assistant.yaml
+++ b/playbooks/services/tasks/diagnose_home_assistant.yaml
@@ -26,7 +26,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      nomad job status -t "{{ '{{' }} (index .Allocations 0).ID {{ '}}' }}" mqtt | head -n 1
+      nomad job status -json mqtt | jq -r '.Allocations[0].ID'
     executable: /bin/bash
   register: mqtt_alloc_id
   changed_when: false


### PR DESCRIPTION
- Fix `AttributeError` in `diagnose_home_assistant.yaml` by handling missing `stat` attributes.
- Enable `allow_anonymous` in `mqtt` role for Mosquitto 2.0+ compatibility.
- Add robust MQTT diagnostics using `jq` for allocation ID retrieval.