### PR TITLE
Fix MQTT health check and Home Assistant connection config

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -24,7 +24,7 @@
 
 - name: Wait for Nomad API to be ready before submitting job
   ansible.builtin.uri:
-    url: "http://{{ ansible_default_ipv4.address }}:4646/v1/status/leader"
+    url: "http://{{ ansible_facts['default_ipv4']['address'] }}:4646/v1/status/leader"
     method: GET
     status_code: 200
   register: home_assistant_nomad_api_status
@@ -36,7 +36,7 @@
 
 - name: Wait for MQTT service to be available in Consul before starting HA
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/health/service/mqtt?passing"
+    url: "http://{{ ansible_facts['default_ipv4']['address'] }}:8500/v1/health/service/mqtt?passing"
     return_content: yes
   register: home_assistant_mqtt_health
   until: home_assistant_mqtt_health.json is defined and home_assistant_mqtt_health.json | length > 0

--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -88,7 +88,7 @@ job "home-assistant" {
         {% if home_assistant_token is defined and home_assistant_token | length > 0 %}
         HA_TOKEN = "{{ home_assistant_token }}"
         {% endif %}
-        MQTT_SERVER = "mqtt://{{ hostvars['controller_node_1']['ansible_host'] | default('127.0.0.1') }}:1883"
+        MQTT_SERVER = "mqtt://{{ hostvars['controller_node_1']['ansible_host'] | default(advertise_ip) }}:1883"
       }
 
       volume_mount {

--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -73,6 +73,13 @@
   register: mqtt_job_run
 #  notify: Restart Home Assistant
 
+- name: Wait for MQTT port to be open
+  ansible.builtin.wait_for:
+    host: "{{ ansible_facts['default_ipv4']['address'] }}"
+    port: 1883
+    timeout: 60
+  become: no
+
 - name: Debug mqtt job run
   ansible.builtin.debug:
     var: mqtt_job_run

--- a/playbooks/services/tasks/diagnose_home_assistant.yaml
+++ b/playbooks/services/tasks/diagnose_home_assistant.yaml
@@ -26,7 +26,8 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      nomad job status -json mqtt | jq -r '.Allocations[0].ID'
+      nomad job status -t "{{ '{{' }} range .Allocations {{ '}}' }}{{ '{{' }} .ID {{ '}}' }}
+      {{ '{{' }} end {{ '}}' }}" mqtt | head -n 1
     executable: /bin/bash
   register: mqtt_alloc_id
   changed_when: false
@@ -67,7 +68,8 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      nomad job status -t "{{ '{{' }} .ID {{ '}}' }}" home-assistant | head -n 1
+      nomad job status -t "{{ '{{' }} range .Allocations {{ '}}' }}{{ '{{' }} .ID {{ '}}' }}
+      {{ '{{' }} end {{ '}}' }}" home-assistant | head -n 1
     executable: /bin/bash
   register: alloc_id
   changed_when: false


### PR DESCRIPTION
- Replaced deprecated `-json` flag in `diagnose_home_assistant.yaml` with robust Go template formatting to fix diagnostic script failure.
- Updated `home_assistant.nomad.j2` to use `advertise_ip` (defaulting to `ansible_default_ipv4.address`) for MQTT server address, ensuring containers can connect to the host service.
- Added an explicit `wait_for` task for port 1883 in the `mqtt` role to ensure the service is listening before proceeding.
- Updated Ansible tasks to use `ansible_facts['default_ipv4']['address']` instead of `ansible_default_ipv4.address` to resolve deprecation warnings.
- Changed Consul health check URL to use the interface IP instead of localhost for better consistency.