### PR TITLE
Fix Nomad Consul token config and diagnostic script path

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -47,7 +47,7 @@
 
 - name: Run home-assistant job asynchronously
   ansible.builtin.command:
-    cmd: nomad job run /opt/nomad/jobs/home-assistant.nomad
+    cmd: /usr/local/bin/nomad job run /opt/nomad/jobs/home-assistant.nomad
   environment:
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
   changed_when: true

--- a/ansible/roles/llama_cpp/handlers/main.yaml
+++ b/ansible/roles/llama_cpp/handlers/main.yaml
@@ -1,6 +1,6 @@
 - name: run nomad llamacpp-rpc job
   ansible.builtin.command:
-    cmd: nomad job run "/opt/nomad/jobs/llamacpp-rpc-{{ item.filename | regex_replace('\\.gguf$', '') }}.nomad"
+    cmd: /usr/local/bin/nomad job run "/opt/nomad/jobs/llamacpp-rpc-{{ item.filename | regex_replace('\\.gguf$', '') }}.nomad"
   loop: "{{ all_models_for_rpc }}"
   environment:
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -128,7 +128,7 @@
 
 - name: Stop and purge any existing llamacpp-rpc jobs if llama.cpp was rebuilt
   ansible.builtin.command:
-    cmd: nomad job stop -purge "llamacpp-rpc-{{ item.filename | regex_replace('\\.gguf$', '') }}"
+    cmd: /usr/local/bin/nomad job stop -purge "llamacpp-rpc-{{ item.filename | regex_replace('\\.gguf$', '') }}"
   loop: "{{ all_models_for_rpc }}"
   register: rpc_job_stop_status
   changed_when: "'Running' in rpc_job_stop_status.stdout"
@@ -139,7 +139,7 @@
 
 - name: Stop and purge any existing expert jobs if llama.cpp was rebuilt
   ansible.builtin.command:
-    cmd: nomad job stop -purge "expert-{{ item }}"
+    cmd: /usr/local/bin/nomad job stop -purge "expert-{{ item }}"
   loop: "{{ experts }}"
   register: expert_job_stop_status
   changed_when: "'Running' in expert_job_stop_status.stdout"

--- a/ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml
+++ b/ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml
@@ -20,7 +20,7 @@
 
 - name: Run llamacpp-rpc job for {{ model_item.filename }}
   ansible.builtin.command:
-    cmd: "nomad job run /tmp/llamacpp-rpc-{{ model_item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
+    cmd: "/usr/local/bin/nomad job run /tmp/llamacpp-rpc-{{ model_item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
   register: rpc_job_run
   changed_when: "'Eval ID' in rpc_job_run.stdout"
   environment:

--- a/ansible/roles/moe_gateway/tasks/main.yaml
+++ b/ansible/roles/moe_gateway/tasks/main.yaml
@@ -26,5 +26,5 @@
 
 - name: Ensure moe-gateway job is running
   ansible.builtin.command:
-    cmd: nomad job run /opt/nomad/jobs/moe-gateway.nomad
+    cmd: /usr/local/bin/nomad job run /opt/nomad/jobs/moe-gateway.nomad
   changed_when: true

--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -46,7 +46,7 @@
 
 - name: Purge mqtt job
   ansible.builtin.command:
-    cmd: nomad job stop -purge mqtt
+    cmd: /usr/local/bin/nomad job stop -purge mqtt
   environment:
     NOMAD_ADDR: "http://{{ ansible_facts['default_ipv4']['address'] }}:4646"
   changed_when: true
@@ -66,7 +66,7 @@
 
 - name: Run mqtt job
   ansible.builtin.command:
-    cmd: nomad job run /opt/nomad/jobs/mqtt.nomad
+    cmd: /usr/local/bin/nomad job run /opt/nomad/jobs/mqtt.nomad
   environment:
     NOMAD_ADDR: "http://{{ ansible_facts['default_ipv4']['address'] }}:4646"
   changed_when: true

--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -143,7 +143,6 @@
     mode: "0644"
   vars:
     is_controller: true
-    consul_token: "{{ consul_token_slurp['content'] | b64decode }}"
   become: yes
   when: "'controller_nodes' in groups and inventory_hostname in groups['controller_nodes']"
   notify:
@@ -154,8 +153,6 @@
   ansible.builtin.template:
     src: nomad.hcl.server.j2
     dest: "{{ nomad_config_dir }}/nomad.hcl"
-  vars:
-    consul_token: "{{ consul_token_slurp['content'] | b64decode }}"
   when: "inventory_hostname == 'localhost' and 'controller' not in group_names and 'workers' not in group_names"
   notify:
     - Restart nomad
@@ -167,8 +164,6 @@
     owner: root
     group: root
     mode: "0644"
-  vars:
-    consul_token: "{{ consul_token_slurp['content'] | b64decode }}"
   become: yes
   when: "'workers' in groups and inventory_hostname in groups['workers']"
   notify:

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -202,7 +202,7 @@
 
 - name: Stop and purge any existing expert jobs to ensure idempotency
   ansible.builtin.command:
-    cmd: nomad job stop -purge "expert-{{ item }}"
+    cmd: /usr/local/bin/nomad job stop -purge "expert-{{ item }}"
   loop: "{{ experts }}"
   register: expert_job_stop_status
   changed_when: "'Running' in expert_job_stop_status.stdout"
@@ -294,7 +294,7 @@
 
 - name: Stop and purge any existing pipecat-app job to ensure idempotency
   ansible.builtin.command:
-    cmd: nomad job stop -purge pipecat-app
+    cmd: /usr/local/bin/nomad job stop -purge pipecat-app
   register: pipecat_job_stop_status
   changed_when: "pipecat_job_stop_status.rc == 0"
   failed_when: false
@@ -306,7 +306,7 @@
 
 - name: Run router job
   ansible.builtin.command:
-    cmd: nomad job run /opt/nomad/jobs/router.nomad
+    cmd: /usr/local/bin/nomad job run /opt/nomad/jobs/router.nomad
   environment:
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
   register: router_job_run
@@ -327,7 +327,7 @@
 
 - name: Run pipecat-app job
   ansible.builtin.command:
-    cmd: nomad job run /opt/nomad/jobs/pipecatapp.nomad
+    cmd: /usr/local/bin/nomad job run /opt/nomad/jobs/pipecatapp.nomad
   environment:
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
   register: router_job_run

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -21,5 +21,5 @@
     dest: /opt/nomad/jobs/tool_server.nomad
 
 - name: Run tool-server nomad job
-  ansible.builtin.command: nomad job run /opt/nomad/jobs/tool_server.nomad
+  ansible.builtin.command: /usr/local/bin/nomad job run /opt/nomad/jobs/tool_server.nomad
   changed_when: true

--- a/ansible/roles/world_model_service/tasks/main.yaml
+++ b/ansible/roles/world_model_service/tasks/main.yaml
@@ -53,7 +53,7 @@
 
 - name: "World Model Service : Run nomad job"
   ansible.builtin.command:
-    cmd: "nomad job run /opt/nomad/jobs/world_model.nomad"
+    cmd: "/usr/local/bin/nomad job run /opt/nomad/jobs/world_model.nomad"
   environment:
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
   changed_when: true
@@ -73,7 +73,7 @@
 
 - name: "World Model Service : Register batch nomad job"
   ansible.builtin.command:
-    cmd: "nomad job run /opt/nomad/jobs/llamacpp-batch.nomad"
+    cmd: "/usr/local/bin/nomad job run /opt/nomad/jobs/llamacpp-batch.nomad"
   environment:
     NOMAD_ADDR: "http://{{ ansible_default_ipv4.address }}:4646"
   changed_when: true

--- a/playbooks/services/tasks/diagnose_home_assistant.yaml
+++ b/playbooks/services/tasks/diagnose_home_assistant.yaml
@@ -6,7 +6,7 @@
     mode: '0644'
 
 - name: Check Nomad job status for MQTT
-  ansible.builtin.command: "nomad job status mqtt"
+  ansible.builtin.command: "/usr/local/bin/nomad job status mqtt"
   register: mqtt_job_status
   changed_when: false
   ignore_errors: yes
@@ -26,7 +26,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      nomad job status -t "{{ '{{' }} range .Allocations {{ '}}' }}{{ '{{' }} .ID {{ '}}' }}
+      /usr/local/bin/nomad job status -t "{{ '{{' }} range .Allocations {{ '}}' }}{{ '{{' }} .ID {{ '}}' }}
       {{ '{{' }} end {{ '}}' }}" mqtt | head -n 1
     executable: /bin/bash
   register: mqtt_alloc_id
@@ -34,7 +34,7 @@
   when: mqtt_job_status.rc == 0
 
 - name: Get MQTT allocation logs
-  ansible.builtin.command: "nomad alloc logs {{ mqtt_alloc_id.stdout }}"
+  ansible.builtin.command: "/usr/local/bin/nomad alloc logs {{ mqtt_alloc_id.stdout }}"
   register: mqtt_alloc_logs
   changed_when: false
   when: mqtt_alloc_id.stdout is defined and mqtt_alloc_id.stdout != ""
@@ -48,7 +48,7 @@
   when: mqtt_alloc_logs.stdout is defined
 
 - name: Check Nomad job status
-  ansible.builtin.command: "nomad job status home-assistant"
+  ansible.builtin.command: "/usr/local/bin/nomad job status home-assistant"
   register: job_status
   changed_when: false
   ignore_errors: yes
@@ -68,7 +68,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      nomad job status -t "{{ '{{' }} range .Allocations {{ '}}' }}{{ '{{' }} .ID {{ '}}' }}
+      /usr/local/bin/nomad job status -t "{{ '{{' }} range .Allocations {{ '}}' }}{{ '{{' }} .ID {{ '}}' }}
       {{ '{{' }} end {{ '}}' }}" home-assistant | head -n 1
     executable: /bin/bash
   register: alloc_id
@@ -76,7 +76,7 @@
   when: job_status.rc == 0
 
 - name: Get allocation details
-  ansible.builtin.command: "nomad alloc status {{ alloc_id.stdout }}"
+  ansible.builtin.command: "/usr/local/bin/nomad alloc status {{ alloc_id.stdout }}"
   register: alloc_status
   changed_when: false
   when: alloc_id.stdout is defined and alloc_id.stdout != ""
@@ -90,7 +90,7 @@
   when: alloc_status.stdout is defined
 
 - name: Get allocation logs
-  ansible.builtin.command: "nomad alloc logs {{ alloc_id.stdout }}"
+  ansible.builtin.command: "/usr/local/bin/nomad alloc logs {{ alloc_id.stdout }}"
   register: alloc_logs
   changed_when: false
   when: alloc_id.stdout is defined and alloc_id.stdout != ""


### PR DESCRIPTION
- Fix bug in `ansible/roles/nomad/tasks/main.yaml` where `consul_token` variable referenced undefined `consul_token_slurp` and was unused in templates (which correctly use `consul_bootstrap_token`).
- Update `playbooks/services/tasks/diagnose_home_assistant.yaml` to use `/usr/local/bin/nomad` instead of `nomad` to avoid using the outdated snap version of Nomad on the user's machine.
- Update `ansible/roles/home_assistant/tasks/main.yaml`, `ansible/roles/mqtt/tasks/main.yaml`, `ansible/roles/pipecatapp/tasks/main.yaml`, `ansible/roles/llama_cpp/tasks/main.yaml`, `ansible/roles/llama_cpp/handlers/main.yaml`, `ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml`, `ansible/roles/tool_server/tasks/main.yaml`, `ansible/roles/world_model_service/tasks/main.yaml`, and `ansible/roles/moe_gateway/tasks/main.yaml` to use `/usr/local/bin/nomad` explicitly.
- This ensures the correct Nomad binary (v1.x) is used for job operations and service registration, fixing Consul service registration issues and diagnostic script failures.