### PR TITLE
Fix Home Assistant Consul check and diagnostic script

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -34,9 +34,17 @@
   changed_when: false
   become: no # Should be accessible locally
 
+- name: Fetch Consul management token
+  ansible.builtin.slurp:
+    src: /etc/consul.d/management_token
+  register: home_assistant_consul_token
+  become: yes
+
 - name: Wait for MQTT service to be available in Consul before starting HA
   ansible.builtin.uri:
     url: "http://{{ ansible_facts['default_ipv4']['address'] }}:8500/v1/health/service/mqtt?passing"
+    headers:
+      X-Consul-Token: "{{ home_assistant_consul_token.content | b64decode | trim }}"
     return_content: yes
   register: home_assistant_mqtt_health
   until: home_assistant_mqtt_health.json is defined and home_assistant_mqtt_health.json | length > 0

--- a/playbooks/services/tasks/diagnose_home_assistant.yaml
+++ b/playbooks/services/tasks/diagnose_home_assistant.yaml
@@ -26,8 +26,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      /usr/local/bin/nomad job status -t "{{ '{{' }} range .Allocations {{ '}}' }}{{ '{{' }} .ID {{ '}}' }}
-      {{ '{{' }} end {{ '}}' }}" mqtt | head -n 1
+      /usr/local/bin/nomad job status -json mqtt | jq -r '.Allocations[0].ID'
     executable: /bin/bash
   register: mqtt_alloc_id
   changed_when: false
@@ -68,8 +67,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      /usr/local/bin/nomad job status -t "{{ '{{' }} range .Allocations {{ '}}' }}{{ '{{' }} .ID {{ '}}' }}
-      {{ '{{' }} end {{ '}}' }}" home-assistant | head -n 1
+      /usr/local/bin/nomad job status -json home-assistant | jq -r '.Allocations[0].ID'
     executable: /bin/bash
   register: alloc_id
   changed_when: false


### PR DESCRIPTION
- Updated `ansible/roles/home_assistant/tasks/main.yaml` to read the Consul management token and use it in the `uri` health check for MQTT. This resolves failures caused by Consul's default deny ACL policy.
- Fixed `playbooks/services/tasks/diagnose_home_assistant.yaml` to use `jq` for parsing Nomad job status instead of the unsupported `-t` flag, preventing the diagnostic script from crashing.