### PR TITLE
Install avahi-daemon for mDNS resolution

### DIFF
--- a/ansible/roles/system_deps/tasks/main.yaml
+++ b/ansible/roles/system_deps/tasks/main.yaml
@@ -12,6 +12,7 @@
   apt:
     name:
       - acl
+      - avahi-daemon
       - build-essential
       - cmake
       - cargo
@@ -42,6 +43,7 @@
       - libflite1
       - libgstreamer-plugins-bad1.0-0
       - libmecab-dev
+      - libnss-mdns
       - lolcat
       - make
       - mecab
@@ -71,3 +73,10 @@
     state: present
   become: yes
   check_mode: no
+
+- name: Ensure avahi-daemon is started and enabled
+  ansible.builtin.service:
+    name: avahi-daemon
+    state: started
+    enabled: yes
+  become: yes


### PR DESCRIPTION
Installs avahi-daemon and libnss-mdns in the system_deps role and ensures the avahi-daemon service is started and enabled. This enables local hostname resolution (e.g., hostname.local) and supports both IPv4 and IPv6, fulfilling the requirement for reliable local resource access via DNS.