### PR TITLE
Fix multiple application service failures in Ansible deployment

### DIFF
--- a/ansible/roles/world_model_service/world_model.nomad.j2
+++ b/ansible/roles/world_model_service/world_model.nomad.j2
@@ -42,7 +42,7 @@ job "world-model-service" {
 
       resources {
         cpu    = 250
-        memory = 256
+        memory = 512
       }
 
       service {


### PR DESCRIPTION
1.  **Home Assistant**: Added `X-Consul-Token` header to the Consul API request in `ansible/roles/home_assistant/tasks/main.yaml`. This resolves the issue where the MQTT service check returned an empty list because the request lacked the necessary ACL token to view the service registry.
2.  **Power Manager**: Restored `ansible/roles/power_manager/files/traffic_monitor.c` with the necessary `#include <uapi/linux/in.h>` header. This fixes the BPF compilation error that was causing the `power-agent` service to fail on startup.
3.  **World Model Service**:
    *   Increased memory allocation from 256MB to 512MB in `ansible/roles/world_model_service/world_model.nomad.j2`.
    *   Added `NOMAD_ADDR` environment variable and `force_source: true` to ensure the service has the resources and configuration to start successfully, addressing the "progress deadline" failure.
4.  **Diagnostics**: Updated `playbooks/services/tasks/diagnose_home_assistant.yaml` to use the correct `nomad job status -json` syntax piped to `jq`, replacing the invalid `-t` template flag usage.