### PR TITLE
fix: use IPv4 for Nomad advertise_ip to prevent invalid argument errors

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -8,10 +8,9 @@ expected_cluster_size: "{{ groups['workers'] | length if 'workers' in groups els
 ansible_python_interpreter: /usr/bin/python3
 
 # This variable dynamically determines the IP address for Nomad to advertise.
-# It prefers the first non-loopback IPv6 address if available,
-# otherwise it falls back to the default IPv4 address.
-advertise_ip: "{{ (ansible_all_ipv6_addresses | reject('equalto', '::1') | list | first) |
-default(ansible_default_ipv4.address) }}"
+# It is set to the default IPv4 address to align with the Nomad configuration
+# which explicitly binds to IPv4.
+advertise_ip: "{{ ansible_default_ipv4.address }}"
 
 nomad_namespace: "default"
 nomad_models_dir: "/opt/nomad/models"


### PR DESCRIPTION
Update `group_vars/all.yaml` to set `advertise_ip` to `ansible_default_ipv4.address`. This ensures that `NOMAD_ADDR` uses a valid IPv4 address instead of an ambiguous IPv6 link-local address (missing zone index), resolving connection failures during `nomad job run`. This also aligns the variable with the Nomad configuration which explicitly binds to IPv4.