### PR TITLE
Add debug infrastructure for world-model-service

### DIFF
--- a/ansible/roles/world_model_service/files/app.py
+++ b/ansible/roles/world_model_service/files/app.py
@@ -24,6 +24,7 @@ NOMAD_ADDR = os.getenv("NOMAD_ADDR", "http://localhost:4646")
 # Robustly determine the port
 nomad_port = os.getenv("NOMAD_PORT_http")
 if nomad_port:
+    logger.info(f"Found NOMAD_PORT_http: {nomad_port}")
     PORT = int(nomad_port)
 else:
     # Fallback for local development or if NOMAD_PORT_http is missing
@@ -31,9 +32,10 @@ else:
     # which causes int() to fail.
     port_env = os.getenv("PORT", "5678")
     if port_env and port_env.isdigit():
+        logger.info(f"Using PORT env var: {port_env}")
         PORT = int(port_env)
     else:
-        print(f"Warning: Invalid PORT environment variable '{port_env}'. Defaulting to 5678.")
+        logger.warning(f"Invalid PORT environment variable '{port_env}'. Defaulting to 5678.")
         PORT = 5678
 
 # --- In-Memory State ---

--- a/ansible/roles/world_model_service/files/debug_world_model.sh
+++ b/ansible/roles/world_model_service/files/debug_world_model.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+
+echo "Starting World Model Service Debug..."
+
+CONTAINER_NAME="world-model-debug"
+IMAGE_NAME="world-model-service:latest"
+DEBUG_PORT=12345
+
+# Clean up previous run
+echo "Cleaning up previous container..."
+docker stop $CONTAINER_NAME 2>/dev/null || true
+docker rm $CONTAINER_NAME 2>/dev/null || true
+
+# Run container
+echo "Running container..."
+# We use host networking to mimic Nomad environment, but set NOMAD_PORT_http manually.
+# We also set PYTHONUNBUFFERED=1 to see logs.
+docker run -d --name $CONTAINER_NAME \
+  --net=host \
+  -e NOMAD_PORT_http=$DEBUG_PORT \
+  -e PYTHONUNBUFFERED=1 \
+  -e MQTT_HOST="localhost" \
+  -e NOMAD_ADDR="http://localhost:4646" \
+  $IMAGE_NAME
+
+echo "Waiting for container to start..."
+sleep 5
+
+echo "Checking container status..."
+if ! docker ps | grep -q $CONTAINER_NAME; then
+    echo "Container failed to start!"
+    docker logs $CONTAINER_NAME
+    exit 1
+fi
+
+echo "Checking application health at http://localhost:$DEBUG_PORT/state..."
+if curl -v --max-time 5 http://localhost:$DEBUG_PORT/state; then
+    echo "Success: Application is healthy!"
+else
+    echo "Failure: Application is not responding."
+fi
+
+echo "=== Container Logs ==="
+docker logs $CONTAINER_NAME
+echo "======================"
+
+echo "Stopping debug container..."
+docker stop $CONTAINER_NAME

--- a/ansible/roles/world_model_service/tasks/main.yaml
+++ b/ansible/roles/world_model_service/tasks/main.yaml
@@ -40,6 +40,33 @@
     state: present
   become: true
 
+- name: "World Model Service : Copy debug script"
+  tags:
+    - world_model_service
+  ansible.builtin.copy:
+    src: "debug_world_model.sh"
+    dest: "/opt/world_model_service/debug_world_model.sh"
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: "0755"
+  become: true
+
+- name: "World Model Service : Run debug script (verify container)"
+  tags:
+    - world_model_service
+  ansible.builtin.command:
+    cmd: "/opt/world_model_service/debug_world_model.sh"
+  become: true
+  register: debug_output
+  changed_when: false
+  failed_when: false
+
+- name: "World Model Service : Display debug output"
+  tags:
+    - world_model_service
+  ansible.builtin.debug:
+    var: debug_output.stdout_lines
+
 - name: "World Model Service : Deploy world_model.nomad job"
   tags:
     - world_model_service


### PR DESCRIPTION
- Create `debug_world_model.sh` to test the container in isolation using `docker run`.
- Update `ansible/roles/world_model_service/tasks/main.yaml` to execute the debug script and display logs.
- Enhance `app.py` logging to verify environment variables (NOMAD_PORT_http).
- Keep previous fixes for Nomad timeouts and logging configuration.