### PR TITLE
Fix world model service health check by using a script check

### DIFF
--- a/ansible/roles/world_model_service/world_model.nomad.j2
+++ b/ansible/roles/world_model_service/world_model.nomad.j2
@@ -50,11 +50,11 @@ job "world-model-service" {
         port = "http"
 
         check {
-          type     = "http"
-          path     = "/state"
+          type     = "script"
+          name     = "alive"
+          command  = "python -c 'import urllib.request, os; urllib.request.urlopen(\"http://127.0.0.1:\" + os.environ[\"NOMAD_PORT_http\"] + \"/state\")'"
           interval = "15s"
           timeout  = "10s"
-          address_mode = "host"
         }
       }
     }


### PR DESCRIPTION
Replaced the HTTP health check, which was failing due to network reachability issues on the host interface, with a Python-based script check that runs inside the container and queries the service on localhost. This ensures reliability regardless of the host's network configuration or advertise_ip reachability.