### PR TITLE
Fix world model service health check by using native HTTP check

### DIFF
--- a/ansible/roles/world_model_service/files/debug_world_model.sh
+++ b/ansible/roles/world_model_service/files/debug_world_model.sh
@@ -34,23 +34,11 @@ if ! docker ps | grep -q $CONTAINER_NAME; then
     exit 1
 fi
 
-echo "Checking application health via HTTP (HOST)..."
+echo "Checking application health at http://localhost:$DEBUG_PORT/state..."
 if curl -v --max-time 5 http://localhost:$DEBUG_PORT/state; then
-    echo "Success: Application is reachable via curl!"
+    echo "Success: Application is healthy!"
 else
-    echo "Failure: Application is not responding to curl."
-fi
-
-echo "Checking application health via Python script (INTERNAL)..."
-# Simulate Nomad script check: Execute python inside container
-# We must pass the env var explicitly because docker exec doesn't inherit container env vars by default in the same way Nomad might expects?
-# Actually, docker exec DOES NOT use container env vars for the command unless they are exported in the entrypoint or passed.
-# But Nomad documentation says it runs in the task environment.
-# Let's test WITH explicit env var first to verify the script logic.
-if docker exec -e NOMAD_PORT_http=$DEBUG_PORT $CONTAINER_NAME /usr/local/bin/python -c "import httpx, os; httpx.get('http://127.0.0.1:' + os.environ['NOMAD_PORT_http'] + '/state').raise_for_status()"; then
-    echo "Success: Internal python script check passed!"
-else
-    echo "Failure: Internal python script check failed."
+    echo "Failure: Application is not responding."
 fi
 
 echo "=== Container Logs ==="

--- a/ansible/roles/world_model_service/world_model.nomad.j2
+++ b/ansible/roles/world_model_service/world_model.nomad.j2
@@ -21,7 +21,6 @@ job "world-model-service" {
 
       config {
         image   = "world-model-service:latest"
-        ports   = ["http"]
         force_pull = false
       }
 
@@ -50,11 +49,13 @@ job "world-model-service" {
         port = "http"
 
         check {
-          type     = "script"
+          type     = "http"
           name     = "alive"
-          command  = "python -c 'import urllib.request, os, sys; sys.exit(0) if urllib.request.urlopen(\"http://127.0.0.1:\" + os.environ[\"NOMAD_PORT_http\"] + \"/state\").getcode() == 200 else sys.exit(1)'"
+          path     = "/state"
           interval = "15s"
           timeout  = "10s"
+          method   = "GET"
+          port     = "http"
         }
       }
     }


### PR DESCRIPTION
- Replaced the script-based health check with a native Nomad `http` check in `world_model.nomad.j2` as script checks run on the host and lack the necessary environment/dependencies.
- Removed redundant `ports` configuration in the Docker driver config.
- Added `world_model_service` tag to the "Run nomad job" task in `ansible/roles/world_model_service/tasks/main.yaml` to ensure it executes when the role is tagged.