### PR TITLE
Implement virtual subnet for cluster traffic using IP aliasing

### DIFF
--- a/ansible/roles/consul/templates/consul.hcl.j2
+++ b/ansible/roles/consul/templates/consul.hcl.j2
@@ -1,5 +1,5 @@
 data_dir = "{{ consul_data_dir }}"
-bind_addr = "{{ ansible_default_ipv4.address }}"
+bind_addr = "{{ cluster_ip }}"
 client_addr = "0.0.0.0"
 leave_on_terminate = true
 primary_datacenter = "{{ consul_datacenter }}"

--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -1,10 +1,11 @@
 data_dir  = "{{ nomad_data_dir }}"
-bind_addr = "0.0.0.0" # Listen on all interfaces
+bind_addr = "{{ cluster_ip }}" # Bind explicitly to the Private Alias IP
 
 advertise {
-  http = "{{ ansible_default_ipv4.address }}"
-  rpc  = "{{ ansible_default_ipv4.address }}"
-  serf = "{{ ansible_default_ipv4.address }}"
+  # Advertise the private IP so other nodes talk over the private lane
+  http = "{{ cluster_ip }}"
+  rpc  = "{{ cluster_ip }}"
+  serf = "{{ cluster_ip }}"
 }
 
 consul {

--- a/ansible/roles/nomad/templates/server.hcl.j2
+++ b/ansible/roles/nomad/templates/server.hcl.j2
@@ -1,10 +1,11 @@
 data_dir  = "{{ nomad_data_dir }}"
-bind_addr = "0.0.0.0" # Listen on all interfaces
+bind_addr = "{{ cluster_ip }}" # Bind explicitly to the Private Alias IP
 
 advertise {
-  http = "{{ ansible_default_ipv4.address }}"
-  rpc  = "{{ ansible_default_ipv4.address }}"
-  serf = "{{ ansible_default_ipv4.address }}"
+  # Advertise the private IP so other nodes talk over the private lane
+  http = "{{ cluster_ip }}"
+  rpc  = "{{ cluster_ip }}"
+  serf = "{{ cluster_ip }}"
 }
 
 {% if is_controller is defined and is_controller %}
@@ -40,7 +41,7 @@ plugin "exec" {
 
 client {
   enabled = true
-  servers = ["127.0.0.1"]
+  servers = ["{{ cluster_ip }}"]
 
   host_volume "pipecatapp" {
     path      = "/opt/pipecatapp"

--- a/ansible/roles/pxe_server/templates/dhcpd.conf.j2
+++ b/ansible/roles/pxe_server/templates/dhcpd.conf.j2
@@ -14,13 +14,13 @@ option client-arch code 93 = unsigned integer 16;
 
 log-facility local7;
 
-subnet 192.168.1.0 netmask 255.255.255.0 {
-  range 192.168.1.200 192.168.1.250;
-  option routers 192.168.1.1;
+subnet {{ pxe_subnet }} netmask {{ pxe_netmask }} {
+  range {{ pxe_range_start }} {{ pxe_range_end }};
+  option routers {{ pxe_router }};
 
   if exists user-class and option user-class = "iPXE" {
     # Client is already running iPXE
-    filename "http://{{ ansible_default_ipv4.address }}/boot.ipxe";
+    filename "http://{{ cluster_ip }}/boot.ipxe";
   } else if option client-arch = 00:07 {
     # UEFI client
     filename "ipxe.efi";

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -5,6 +5,14 @@
 nomad_zip_url: "https://releases.hashicorp.com/nomad/1.7.5/nomad_1.7.5_linux_amd64.zip"
 expected_cluster_size: "{{ groups['workers'] | length if 'workers' in groups else 1 }}"
 
+# This variable dynamically determines the node ID based on the hostname.
+# If the hostname is 'devbox', the ID is 10.
+# Otherwise, it extracts the number from the hostname (e.g., 'worker1' -> 1) and adds 10 (result: 11).
+node_id: "{{ '10' if inventory_hostname == 'devbox' else (inventory_hostname | regex_replace('^.*?([0-9]+)$', '\\\\1') | int + 10) }}"
+
+cluster_subnet_prefix: "10.0.0"
+cluster_ip: "{{ cluster_subnet_prefix }}.{{ node_id }}"
+
 ansible_python_interpreter: /usr/bin/python3
 
 # This variable dynamically determines the IP address for Nomad to advertise.
@@ -96,9 +104,9 @@ pxe_interface: "enp0s8"
 # Replace this with your actual public key.
 pxe_client_ssh_key: "ssh-rsa AAAA..."
 
-# DHCP network configuration for NixOS clients.
-pxe_subnet: "192.168.1.0"
+# DHCP network configuration for NixOS clients and the pxe_server role.
+pxe_subnet: "10.0.0.0"
 pxe_netmask: "255.255.255.0"
-pxe_range_start: "192.168.1.200"
-pxe_range_end: "192.168.1.250"
-pxe_router: "192.168.1.1"
+pxe_range_start: "10.0.0.200"
+pxe_range_end: "10.0.0.250"
+pxe_router: "10.0.0.1"

--- a/initial-setup/setup.conf
+++ b/initial-setup/setup.conf
@@ -15,6 +15,13 @@ NETMASK="255.255.255.0"
 GATEWAY="192.168.1.254"
 
 # -----------------
+# Cluster Network Configuration
+# -----------------
+# The private subnet for cluster traffic (Nomad/Consul)
+CLUSTER_SUBNET_PREFIX="10.0.0"
+CLUSTER_NETMASK="255.255.255.0"
+
+# -----------------
 # Hostname Configuration
 # -----------------
 HOSTNAME="devbox"


### PR DESCRIPTION
-   Configures `eth0` (WAN) for DHCP and `eth0:0` (LAN) with a static IP (`10.0.0.x`) to isolate cluster traffic.
-   Updates PXE DHCP server to listen only on the private `10.0.0.x` subnet, resolving conflicts with the home router.
-   Re-binds Nomad and Consul to the private cluster IP.
-   Parameterizes all IP addresses in Ansible and shell scripts to avoid hardcoding.