### PR TITLE
Isolate cluster traffic on virtual subnet while keeping UI accessible

### DIFF
--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -1,6 +1,10 @@
 data_dir  = "{{ nomad_data_dir }}"
 bind_addr = "{{ cluster_ip }}" # Bind explicitly to the Private Alias IP
 
+addresses {
+  http = "0.0.0.0" # Listen on all interfaces for UI/API access
+}
+
 advertise {
   # Advertise the private IP so other nodes talk over the private lane
   http = "{{ cluster_ip }}"

--- a/ansible/roles/nomad/templates/server.hcl.j2
+++ b/ansible/roles/nomad/templates/server.hcl.j2
@@ -1,6 +1,10 @@
 data_dir  = "{{ nomad_data_dir }}"
 bind_addr = "{{ cluster_ip }}" # Bind explicitly to the Private Alias IP
 
+addresses {
+  http = "0.0.0.0" # Listen on all interfaces for UI/API access
+}
+
 advertise {
   # Advertise the private IP so other nodes talk over the private lane
   http = "{{ cluster_ip }}"


### PR DESCRIPTION
-   Implement IP aliasing: `dhcp` for WAN (Internet), static `10.0.0.x` alias for LAN (Cluster).
-   Update PXE DHCP server to serve only the private `10.0.0.x` subnet.
-   Re-bind Nomad/Consul internal traffic (RPC/Serf) to the private cluster IP.
-   Expose Nomad HTTP UI/API on `0.0.0.0` to allow access from the home network.
-   Parameterize all network configs in `group_vars/all.yaml` and `setup.conf`.