### PR TITLE
Implement virtual cluster subnet and fix DHCP conflict

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -127,14 +127,14 @@ cd "$SCRIPT_DIR"
 # --- Run Initial Machine Setup based on Role ---
 # This script handles pre-Ansible configuration like network and hostname.
 # It's run for all roles, and the script itself determines what to do based on the config.
-# echo "--- Running Initial Machine Setup ---"
-# if [ -f "initial-setup/setup.sh" ]; then
-#     echo "You may be prompted for your sudo password to run the initial setup script."
-#     sudo bash "initial-setup/setup.sh"
-#     echo "✅ Initial machine setup complete."
-# else
-#     echo "⚠️  Warning: initial-setup/setup.sh not found. Skipping pre-configuration."
-# fi
+echo "--- Running Initial Machine Setup ---"
+if [ -f "initial-setup/setup.sh" ]; then
+    echo "You may be prompted for your sudo password to run the initial setup script."
+    sudo bash "initial-setup/setup.sh"
+    echo "✅ Initial machine setup complete."
+else
+    echo "⚠️  Warning: initial-setup/setup.sh not found. Skipping pre-configuration."
+fi
 
 
 # --- Handle the --clean option ---


### PR DESCRIPTION
-   Enable `initial-setup/setup.sh` in `bootstrap.sh` to ensure network aliases are created.
-   Configure IP aliasing: `dhcp` for WAN, static `10.0.0.x` alias for LAN.
-   Fix PXE DHCP server to only serve the private `10.0.0.x` subnet.
-   Re-bind Nomad/Consul internal traffic to private cluster IP (`{{ cluster_ip }}`).
-   Expose Nomad/Consul HTTP API/UI on `0.0.0.0` for home network access.
-   Parameterize network variables in `group_vars/all.yaml` and `setup.conf`.