### PR TITLE
Implement virtual cluster subnet and fix DHCP conflict

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -7,8 +7,17 @@ expected_cluster_size: "{{ groups['workers'] | length if 'workers' in groups els
 
 # This variable dynamically determines the node ID based on the hostname.
 # If the hostname is 'devbox', the ID is 10.
-# Otherwise, it extracts the number from the hostname (e.g., 'worker1' -> 1) and adds 10 (result: 11).
-node_id: "{{ '10' if inventory_hostname == 'devbox' else (inventory_hostname | regex_replace('^.*?([0-9]+)$', '\\\\1') | int + 10) }}"
+# If the hostname contains numbers (e.g. 'worker1'), it extracts them and adds 10 (worker1 -> 11).
+# If the hostname has no numbers (e.g. 'loki'), it defaults to 11 to match the shell script fallback.
+node_id: >-
+  {{
+    '10' if inventory_hostname == 'devbox'
+    else (
+      ((inventory_hostname | regex_search('[0-9]+')) | int + 10)
+      if (inventory_hostname | regex_search('[0-9]+'))
+      else '11'
+    )
+  }}
 
 cluster_subnet_prefix: "10.0.0"
 cluster_ip: "{{ cluster_subnet_prefix }}.{{ node_id }}"


### PR DESCRIPTION
-   Enable `initial-setup/setup.sh` in `bootstrap.sh` to ensure network aliases are created.
-   Configure IP aliasing: `dhcp` for WAN (Internet), static `10.0.0.x` alias for LAN (Cluster).
-   Fix PXE DHCP server to only serve the private `10.0.0.x` subnet.
-   Re-bind Nomad/Consul internal traffic to private cluster IP (`{{ cluster_ip }}`).
-   Expose Nomad/Consul HTTP API/UI on `0.0.0.0` for home network access.
-   Parameterize network variables in `group_vars/all.yaml` and `setup.conf`.
-   Align `node_id` calculation logic between shell and Ansible to default to 11 for non-numeric hostnames.