### PR TITLE
Improve Consul and Nomad role idempotency

### DIFF
--- a/ansible/roles/consul/handlers/main.yaml
+++ b/ansible/roles/consul/handlers/main.yaml
@@ -1,10 +1,18 @@
-- name: restart consul
+- name: Restart Consul
+  listen: "Restart Consul"
   become: yes
   ansible.builtin.service:
     name: consul
     state: restarted
 
 - name: Wait for Consul to start up
-  wait_for:
+  listen: "Restart Consul"
+  ansible.builtin.wait_for:
     port: 8500
     delay: 10
+    timeout: 300
+
+- name: Reload systemd
+  become: yes
+  ansible.builtin.systemd:
+    daemon_reload: yes

--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -193,7 +193,7 @@
     owner: consul
     group: consul
     mode: '0640'
-  notify: restart consul
+  notify: Restart Consul
   tags:
     - consul_configure
 
@@ -204,15 +204,9 @@
     src: consul.service.j2
     dest: /etc/systemd/system/consul.service
     mode: '0644'
-  notify: restart consul
-  tags:
-    - consul_configure
-
-# Task 14: Reload systemd to recognize new service (from original file)
-- name: Reload systemd to recognize new service
-  become: true
-  ansible.builtin.systemd:
-    daemon_reload: yes
+  notify:
+    - Reload systemd
+    - Restart Consul
   tags:
     - consul_configure
 

--- a/ansible/roles/consul/templates/consul.hcl.j2
+++ b/ansible/roles/consul/templates/consul.hcl.j2
@@ -1,5 +1,5 @@
 data_dir = "{{ consul_data_dir }}"
-bind_addr = "{{ advertise_ip }}"
+bind_addr = "{{ cluster_ip }}"
 client_addr = "0.0.0.0"
 leave_on_terminate = true
 primary_datacenter = "{{ consul_datacenter }}"
@@ -39,10 +39,10 @@ bootstrap_expect = 1
 {% else %}
 # For multi-node setups, we expect a quorum of controller nodes.
 bootstrap_expect = {{ groups['controller_nodes'] | length }}
-retry_join = ["{{ hostvars[groups['controller_nodes'][0]]['ansible_host'] }}"]
+retry_join = ["{{ hostvars[groups['controller_nodes'][0]]['cluster_ip'] }}"]
 {% endif %}
 {% else %}
 # This is a client node, so it should try to join the controller.
 server = false
-retry_join = ["{{ hostvars[groups['controller_nodes'][0]]['ansible_host'] }}"]
+retry_join = ["{{ hostvars[groups['controller_nodes'][0]]['cluster_ip'] }}"]
 {% endif %}

--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -263,7 +263,6 @@
     name: nomad
     state: started
     enabled: yes
-    daemon_reload: yes
   become: yes
   async: 45
   poll: 5

--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -1,17 +1,17 @@
 data_dir  = "{{ nomad_data_dir }}"
-bind_addr = "{{ advertise_ip }}" # Bind explicitly to the Private Alias IP
+bind_addr = "{{ cluster_ip }}" # Bind explicitly to the Private Alias IP
 
 addresses {
   http = "0.0.0.0" # Listen on all interfaces for UI/API access
-  rpc  = "{{ advertise_ip }}"
-  serf = "{{ advertise_ip }}"
+  rpc  = "{{ cluster_ip }}"
+  serf = "{{ cluster_ip }}"
 }
 
 advertise {
   # Advertise the private IP so other nodes talk over the private lane
   http = "{{ advertise_ip }}"
-  rpc  = "{{ advertise_ip }}"
-  serf = "{{ advertise_ip }}"
+  rpc  = "{{ cluster_ip }}"
+  serf = "{{ cluster_ip }}"
 }
 
 consul {

--- a/ansible/roles/nomad/templates/server.hcl.j2
+++ b/ansible/roles/nomad/templates/server.hcl.j2
@@ -1,5 +1,5 @@
 data_dir  = "{{ nomad_data_dir }}"
-bind_addr = "{{ advertise_ip }}" # Bind explicitly to the Private Alias IP
+bind_addr = "{{ cluster_ip }}" # Bind explicitly to the Private Alias IP
 
 addresses {
   http = "0.0.0.0" # Listen on all interfaces for UI/API access
@@ -8,8 +8,8 @@ addresses {
 advertise {
   # Advertise the private IP so other nodes talk over the private lane
   http = "{{ advertise_ip }}"
-  rpc  = "{{ advertise_ip }}"
-  serf = "{{ advertise_ip }}"
+  rpc  = "{{ cluster_ip }}"
+  serf = "{{ cluster_ip }}"
 }
 
 {% if is_controller is defined and is_controller %}

--- a/docs/NETWORK.md
+++ b/docs/NETWORK.md
@@ -1,0 +1,61 @@
+# Network Architecture
+
+The cluster utilizes a "Dual Network" architecture to ensure stability, isolation, and accessibility. This design separates internal cluster communication from external management and user access.
+
+## Mental Model: Front of House vs. Backstage
+
+To understand this structure, it helps to visualize the cluster node as a venue:
+
+### 1. `advertise_ip` = Front of House (Public / User Access)
+*   **What it is:** The IP assigned by your home router (e.g., `192.168.1.55`).
+*   **Behavior:** It acts like a **Billboard**. It changes whenever your router feels like it (DHCP), but it's the only way *you* (the audience) can enter the building.
+*   **Use Case:** SSH, Web Browsers (Consul UI, Nomad UI), Home Assistant Dashboards.
+*   **Why it's unstable:** If this IP changes, the "Billboard" moves, and you have to find it again. But the show inside shouldn't stop.
+
+### 2. `cluster_ip` = Backstage (Private / Internal Sync)
+*   **What it is:** The static IP created on the alias interface (e.g., `10.0.0.10`).
+*   **Behavior:** It acts like a **Walkie-Talkie channel**. It is hard-coded and never changes.
+*   **Use Case:** Nomad Client talking to Nomad Server, Consul syncing data, Raft Consensus.
+*   **Why it's stable:** Even if the "Billboard" (`advertise_ip`) changes or the front door moves, the band members (nodes) can still keep playing because they are on a dedicated, static channel.
+
+---
+
+## Technical Implementation
+
+### 1. Network Segmentation
+
+#### A. Public / Management Network (DHCP)
+- **Interface:** The primary physical or bridged interface.
+- **Variable:** `advertise_ip` (Ansible fact `default_ipv4.address`).
+- **Role:** External accessibility.
+
+#### B. Cluster / Private Network (Static Virtual Subnet)
+- **Interface:** IP alias on the primary interface.
+- **Variable:** `cluster_ip` (Derived from Hostname).
+- **Role:** Internal stability.
+
+### 2. Addressing Scheme
+
+Nodes are assigned a deterministic `node_id` based on their hostname, which sets the last octet of their Cluster IP.
+
+| Hostname | Node ID | Cluster IP | Role |
+| :--- | :--- | :--- | :--- |
+| `devbox` | 10 | `10.0.0.10` | Single-node Dev Cluster |
+| `worker1` | 11 | `10.0.0.11` | Worker Node |
+| `worker2` | 12 | `10.0.0.12` | Worker Node |
+| `pxe-server`| 1 | `10.0.0.1` | PXE / Gateway |
+
+**Formula:** `cluster_ip = "10.0.0." + node_id`
+
+### 3. Service Configuration
+
+#### Consul
+- **Bind Address:** `cluster_ip` (Listens for internal gossip/RPC).
+- **Client Address:** `0.0.0.0` (Listens for API/UI requests on all interfaces).
+- **Retry Join:** Uses `cluster_ip` of controller nodes.
+
+#### Nomad
+- **Bind Address:** `cluster_ip`.
+- **RPC/Serf Address:** `cluster_ip`.
+- **HTTP API:** Listens on `0.0.0.0` (Publicly accessible).
+- **Advertise HTTP:** `advertise_ip` (So the UI links point to the reachable public IP).

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -20,9 +20,7 @@ node_id: >-
   }}
 
 cluster_subnet_prefix: "10.0.0"
-# In single-node or dev environments without a dedicated overlay network,
-# we bind to the primary interface IP to ensure services start.
-# Otherwise, we use the overlay network IP derived from the node ID.
+# Always force the private/static IP alias for cluster binding
 cluster_ip: "{{ cluster_subnet_prefix + '.' + node_id }}"
 
 


### PR DESCRIPTION
- Consul: Update handlers to include wait logic and reload systemd only on change. Rename handler to `Restart Consul` for consistency.
- Consul: Update tasks to notify correct handlers and remove redundant `daemon_reload`.
- Nomad: Remove redundant `daemon_reload` from start task.
- Ensure strict idempotency for service restarts and reloads.