### PR TITLE
Enable auto-promotion of perfect agents in evolution loop

### DIFF
--- a/prompt_engineering/evaluator.py
+++ b/prompt_engineering/evaluator.py
@@ -143,7 +143,8 @@ async def evaluate_code(candidate_code: str) -> dict:
             "fitness": fitness,
             "passed": results.get("passed"),
             "details": results.get("details"),
-            "log": results.get("log", "")
+            "log": results.get("log", ""),
+            "agent_id": eval_id
         }
         return evaluation_results
 


### PR DESCRIPTION
- Update `prompt_engineering/evaluator.py` to return `agent_id` in evaluation results.
- Update `prompt_engineering/evolve.py` to accept `--auto-promote` flag.
- Implement logic in `evolve.py` to trigger `promote_agent` when fitness is 1.0.
- Fix metric logging to handle non-numeric values.