### PR TITLE
Add retries to CNI plugin download in Nomad role

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -211,6 +211,10 @@
     dest: /tmp/cni-plugins.tgz
     mode: '0644'
     timeout: 30
+  register: download_cni
+  until: download_cni is success
+  retries: 5
+  delay: 10
   check_mode: no
 
 - name: Extract CNI plugins into /opt/cni/bin


### PR DESCRIPTION
- Add 5 retries with 10s delay to "Download CNI plugins tarball" task to handle transient HTTP 504 errors.