### PR TITLE
fix(ansible): Refactor common_setup.yaml to be a task list

### DIFF
--- a/playbooks/common_setup.yaml
+++ b/playbooks/common_setup.yaml
@@ -1,60 +1,47 @@
-- name: Play 1 - Bootstrap New Nodes as 'root'
-  hosts: all
-  become: yes # We are already root
-
+- name: Ensure the sudo package is installed
   tags:
-    - common-setup
+    - sudo
+  ansible.builtin.apt:
+    name: sudo
+    state: present
 
-  vars_files:
-    - "{{ playbook_dir }}/../group_vars/all.yaml"
-    - "{{ playbook_dir }}/../group_vars/models.yaml"
-    - "{{ playbook_dir }}/../group_vars/external_experts.yaml"
+- name: Ensure the rsync package is installed
+  tags:
+    - rsync
+  ansible.builtin.apt:
+    name: rsync
+    state: present
 
-  tasks:
-    - name: Ensure the sudo package is installed
-      tags:
-        - sudo
-      ansible.builtin.apt:
-        name: sudo
-        state: present
+- name: Ensure the sudo group exists
+  tags:
+    - sudo
+  ansible.builtin.group:
+    name: sudo
+    state: present
 
-    - name: Ensure the rsync package is installed
-      tags:
-        - rsync
-      ansible.builtin.apt:
-        name: rsync
-        state: present
+- name: Create the '{{ target_user }}' account with sudo access
+  tags:
+    - user
+  ansible.builtin.user:
+    name: "{{ target_user }}"
+    shell: /bin/bash
+    groups: sudo
+    append: yes
 
-    - name: Ensure the sudo group exists
-      tags:
-        - sudo
-      ansible.builtin.group:
-        name: sudo
-        state: present
+- name: Set correct permissions for the user's home directory
+  tags:
+    - user
+  ansible.builtin.file:
+    path: "/home/{{ target_user }}"
+    state: directory
+    mode: '0755'
 
-    - name: Create the '{{ target_user }}' account with sudo access
-      tags:
-        - user
-      ansible.builtin.user:
-        name: "{{ target_user }}"
-        shell: /bin/bash
-        groups: sudo
-        append: yes
-
-    - name: Set correct permissions for the user's home directory
-      tags:
-        - user
-      ansible.builtin.file:
-        path: "/home/{{ target_user }}"
-        state: directory
-        mode: '0755'
-
-    - name: Allow '{{ target_user }}' to have passwordless sudo access
-      tags:
-        - sudo
-      ansible.builtin.lineinfile:
-        path: "/etc/sudoers.d/ansible-{{ target_user }}-nopasswd"
-        line: "{{ target_user }} ALL=(ALL) NOPASSWD: ALL"
-        create: yes
-        validate: 'visudo -cf %s'
-        mode: '0440'
+- name: Allow '{{ target_user }}' to have passwordless sudo access
+  tags:
+    - sudo
+  ansible.builtin.lineinfile:
+    path: "/etc/sudoers.d/ansible-{{ target_user }}-nopasswd"
+    line: "{{ target_user }} ALL=(ALL) NOPASSWD: ALL"
+    create: yes
+    validate: 'visudo -cf %s'
+    mode: '0440'


### PR DESCRIPTION
The `worker.yaml` playbook was failing with a "conflicting action statements" error because it was trying to include `common_setup.yaml`, which was incorrectly structured as a full playbook with its own `hosts` and `vars_files` directives.

Ansible's `include_tasks` module can only include files that contain a simple list of tasks.

This change refactors `common_setup.yaml` by removing the playbook-level directives, converting it into a valid task list that can be correctly included by other playbooks. This resolves the Ansible error and allows the worker provisioning process to proceed.