### PR TITLE
Switch World Model Service health check to script

### DIFF
--- a/ansible/roles/world_model_service/world_model.nomad.j2
+++ b/ansible/roles/world_model_service/world_model.nomad.j2
@@ -52,14 +52,12 @@ job "world-model-service" {
         port = "http"
 
         check {
-          type     = "http"
+          type     = "script"
           name     = "alive"
-          path     = "/health"
+          command  = "python"
+          args     = ["-c", "import os, urllib.request; port = os.getenv('NOMAD_PORT_http'); urllib.request.urlopen(f'http://127.0.0.1:{port}/health')"]
           interval = "15s"
           timeout  = "10s"
-          method   = "GET"
-          port     = "http"
-          address_mode = "host"
         }
       }
     }


### PR DESCRIPTION
The standard HTTP health check with `address_mode = "host"` failed to reach the service in the `host` network mode environment, likely due to routing or firewall issues with the advertised IP.

This commit switches to a `script` check running inside the container (via the Docker driver). It uses a Python one-liner to check `http://127.0.0.1:<NOMAD_PORT_http>/health`, ensuring the application is reachable locally regardless of external network configuration.