### PR TITLE
Fix tool-server dependencies and model auth

### DIFF
--- a/ansible/roles/pipecatapp/files/tools/summarizer_tool.py
+++ b/ansible/roles/pipecatapp/files/tools/summarizer_tool.py
@@ -24,7 +24,8 @@ class SummarizerTool:
         self.name = "summarizer"
         self.description = "A tool to provide summaries of the conversation."
         # Using a smaller, efficient model as requested.
-        self.model = SentenceTransformer("google/embeddinggemma-300m")
+        # Switched to all-MiniLM-L6-v2 to avoid Hugging Face gating/token requirements
+        self.model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
 
     def get_summary(self, query: str, conversation_history: list = None) -> str:
         """Returns the most relevant parts of the conversation related to a query.

--- a/ansible/roles/tool_server/Dockerfile
+++ b/ansible/roles/tool_server/Dockerfile
@@ -64,6 +64,7 @@ RUN pip install --no-cache-dir \
     ansible
 
 COPY app.py .
+COPY pmm_memory.py .
 COPY tools ./tools
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Fixes `tool-server` startup crashes caused by missing files and gated model requirements.

- Updates `tool_server/Dockerfile` to copy `pmm_memory.py` into the image.
- Switches `SummarizerTool` to use `sentence-transformers/all-MiniLM-L6-v2` (public) instead of `google/embeddinggemma-300m` (gated) to avoid HF token errors.
- Includes previous refactors for tool compatibility in standalone mode.