### PR TITLE
Fix tool_server crash and term_everything build issues

### DIFF
--- a/ansible/roles/term_everything/tasks/main.yml
+++ b/ansible/roles/term_everything/tasks/main.yml
@@ -95,7 +95,13 @@
       ansible.builtin.find:
         paths: /tmp/term.everything/dist
         patterns: "*.AppImage"
+        recurse: yes
       register: find_result
+
+    - name: Fail if AppImage not found
+      ansible.builtin.fail:
+        msg: "Build succeeded but no AppImage found in /tmp/term.everything/dist"
+      when: find_result.files | length == 0
 
     - name: Move AppImage to tools directory
       ansible.builtin.copy:

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -100,6 +100,19 @@
         var: ts_logs_stderr.stdout
       when: ts_logs_stderr is defined
 
+    - name: "Tool Server : Get Allocation Status (Detailed)"
+      ansible.builtin.command:
+        cmd: "/usr/local/bin/nomad alloc status -verbose {{ ts_alloc_id.stdout }}"
+      register: ts_alloc_status
+      ignore_errors: yes
+      become: no
+      when: ts_alloc_id.stdout | length > 0
+
+    - name: "Tool Server : Display Allocation Status"
+      ansible.builtin.debug:
+        var: ts_alloc_status.stdout
+      when: ts_alloc_status is defined
+
     - name: "Tool Server : Clean up temp file"
       ansible.builtin.file:
         path: "/tmp/ts_allocs.json"


### PR DESCRIPTION
- term_everything: Update role to recursively search for AppImage and force build if artifact is missing.
- tool_server: Set `force_pull = false` to use local image and add detailed allocation status debugging.