### PR TITLE
Fix tool_server crash and term_everything build issues

### DIFF
--- a/ansible/roles/term_everything/tasks/main.yml
+++ b/ansible/roles/term_everything/tasks/main.yml
@@ -94,7 +94,7 @@
     - name: Find the AppImage file
       ansible.builtin.find:
         paths: /tmp/term.everything/dist
-        patterns: "*.AppImage"
+        patterns: "term.everything*"
         recurse: yes
       register: find_result
 


### PR DESCRIPTION
- term_everything: Update role to recursively search for build artifacts (`term.everything*`) and force build if the final AppImage is missing.
- tool_server: Set `force_pull = false` to use local image and add detailed allocation status debugging.