### PR TITLE
Fix llxprt_code role to include Consul token in service check

### DIFF
--- a/ansible/roles/llxprt_code/tasks/main.yaml
+++ b/ansible/roles/llxprt_code/tasks/main.yaml
@@ -18,6 +18,8 @@
 - name: Discover tool-server-api address
   ansible.builtin.uri:
     url: "http://localhost:{{ consul_http_port }}/v1/health/service/tool-server-api?passing"
+    headers:
+      X-Consul-Token: "{{ consul_bootstrap_token }}"
     return_content: yes
   register: tool_server_service
   until: tool_server_service.json | length > 0


### PR DESCRIPTION
This commit adds the `X-Consul-Token` header to the `ansible.builtin.uri` task in the `llxprt_code` role. This is necessary because Consul is running with ACLs enabled (default deny), so unauthenticated requests to the health API return an empty list instead of the actual service status, causing the task to timeout and fail. Using `consul_bootstrap_token` ensures the request is authorized to discover the `tool-server-api` service.