### PR TITLE
Fix moe-gateway hanging deployment

### DIFF
--- a/ansible/roles/moe_gateway/files/gateway.py
+++ b/ansible/roles/moe_gateway/files/gateway.py
@@ -183,7 +183,10 @@ async def discover_pipecat_service():
 @app.on_event("startup")
 async def startup_event():
     """On startup, discover the pipecat service."""
-    await discover_pipecat_service()
+    try:
+        await discover_pipecat_service()
+    except Exception as e:
+        logger.warning(f"Startup service discovery failed: {e}. Continuing to allow health checks.")
 
 # --- Health Check Endpoint ---
 @app.get("/health", status_code=200)


### PR DESCRIPTION
- Update `gateway.py` to listen on `NOMAD_PORT_http` instead of hardcoded 8001.
- Wrap startup service discovery in try/except to prevent application crash on startup if dependencies are not ready, allowing health checks to pass.
- Add `httpx` and `pydantic` to `requirements.txt` to prevent import errors.
- Remove outdated comment about port configuration.