### PR TITLE
Fix moe-gateway hanging by aligning with pipecatapp robust deployment…

### DIFF
--- a/ansible/roles/moe_gateway/tasks/main.yaml
+++ b/ansible/roles/moe_gateway/tasks/main.yaml
@@ -32,6 +32,29 @@
   notify:
     - Run moe-gateway job
 
+- name: Debug Nomad Address
+  ansible.builtin.debug:
+    msg: "NOMAD_ADDR is http://{{ cluster_ip }}:{{ nomad_http_port }}"
+
+- name: Wait for Nomad API to be ready
+  ansible.builtin.uri:
+    url: "http://{{ cluster_ip }}:{{ nomad_http_port }}/v1/status/leader"
+    method: GET
+    status_code: 200
+  register: nomad_api_status
+  until: nomad_api_status.status == 200
+  retries: 12 # Total wait time = retries * delay = 60 seconds
+  delay: 5   # Wait 5 seconds between retries
+
+- name: Stop and purge any existing moe-gateway job to ensure idempotency
+  ansible.builtin.command:
+    cmd: /usr/local/bin/nomad job stop -purge moe-gateway
+  register: moe_gateway_job_stop_status
+  changed_when: "moe_gateway_job_stop_status.rc == 0"
+  failed_when: false
+  environment:
+    NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port }}"
+
 - name: Deploy moe-gateway Job
   block:
     - name: Ensure moe-gateway job is running


### PR DESCRIPTION
… pattern

The `moe_gateway` role was hanging during Nomad job deployment, likely due to connectivity issues or environment mismatches. This commit brings the role implementation in line with the proven `pipecatapp` role by:

1. Adding a `Wait for Nomad API` task using `ansible.builtin.uri` to fail fast if the cluster leader is unreachable, preventing indefinite CLI hangs.
2. Adding a `Stop and purge` task to ensure a clean deployment state.
3. Explicitly setting `NOMAD_ADDR` and `become: no` for all Nomad CLI commands.
4. Wrapping the deployment in a `block`/`rescue` structure to capture and display allocation logs on failure.
5. Adding debug output for `NOMAD_ADDR`.
6. Updating the role handler to match these environment settings.