### PR TITLE
Fix moe-gateway hang and enable log capture on failure

### DIFF
--- a/ansible/roles/moe_gateway/tasks/main.yaml
+++ b/ansible/roles/moe_gateway/tasks/main.yaml
@@ -76,6 +76,19 @@
       changed_when: true
       become: no
       register: moe_gateway_job_run
+
+    - name: Wait for the moe-gateway service to be healthy in Consul
+      ansible.builtin.uri:
+        url: "http://{{ cluster_ip }}:{{ consul_http_port }}/v1/health/service/moe-gateway"
+        return_content: yes
+      register: moe_gateway_health
+      until: >
+        moe_gateway_health.json is defined and
+        moe_gateway_health.json | map(attribute='Checks') | flatten | selectattr('Status', 'equalto', 'passing') | list | length > 0
+      retries: 60
+      delay: 2
+      changed_when: false
+
   rescue:
     - name: Get moe-gateway job status
       ansible.builtin.command:
@@ -147,15 +160,3 @@
     - name: Fail after debugging
       ansible.builtin.fail:
         msg: "moe-gateway job failed to start. See logs above."
-
-- name: Wait for the moe-gateway service to be healthy in Consul
-  ansible.builtin.uri:
-    url: "http://{{ cluster_ip }}:{{ consul_http_port }}/v1/health/service/moe-gateway"
-    return_content: yes
-  register: moe_gateway_health
-  until: >
-    moe_gateway_health.json is defined and
-    moe_gateway_health.json | map(attribute='Checks') | flatten | selectattr('Status', 'equalto', 'passing') | list | length > 0
-  retries: 60
-  delay: 2
-  changed_when: false


### PR DESCRIPTION
The `moe_gateway` role was hanging during `nomad job run`. Previous fixes added `-detach` to prevent the hang, but the subsequent health check failed silently without logs because it was outside the rescue block.

This commit:
1. Moves the `Wait for moe-gateway service` task INSIDE the `block`. This ensures that if the service fails to become healthy, the `rescue` block is triggered.
2. The `rescue` block fetches and displays `nomad alloc logs`, providing visibility into startup crashes (e.g., missing dependencies, port conflicts).
3. Retains `-detach` on `nomad job run` to prevent CLI hangs.
4. Retains `network { mode = "host" }` and venv checks for correctness.