### PR TITLE
Fix Nomad startup by binding to 0.0.0.0 and safely handling sound device

### DIFF
--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -1,5 +1,5 @@
 data_dir  = "{{ nomad_data_dir }}"
-bind_addr = "{{ cluster_ip }}" # Bind explicitly to the Private Alias IP
+bind_addr = "0.0.0.0" # Bind to all interfaces to ensure startup even if alias is missing
 
 addresses {
   http = "0.0.0.0" # Listen on all interfaces for UI/API access

--- a/ansible/roles/nomad/templates/server.hcl.j2
+++ b/ansible/roles/nomad/templates/server.hcl.j2
@@ -1,5 +1,5 @@
 data_dir  = "{{ nomad_data_dir }}"
-bind_addr = "{{ cluster_ip }}" # Bind explicitly to the Private Alias IP
+bind_addr = "0.0.0.0" # Bind to all interfaces to ensure startup even if alias is missing
 
 addresses {
   http = "0.0.0.0" # Listen on all interfaces for UI/API access


### PR DESCRIPTION
This commit addresses Nomad startup failures caused by binding to a specific interface alias that may be missing, and by configuring a host volume for a non-existent sound device.

Changes:
- **Bind Address:** Updated `bind_addr` in `server.hcl.j2` and `client.hcl.j2` to `0.0.0.0`. This ensures the Nomad agent can start successfully on all available interfaces, resolving "Connection refused" errors if the `cluster_ip` alias is not configured.
- **Sound Device Check:** Added an Ansible `stat` check for `/dev/snd` and a `sound_enabled` fact.
- **Conditional Configuration:** The `host_volume "snd"` block in Nomad config and the corresponding `volume` and `devices` blocks in the `pipecatapp` job are now conditional on `sound_enabled`. This prevents crashes on headless nodes while preserving functionality on hardware-equipped nodes.
- **Cleanup:** Removed the incorrect task that attempted to force-create `/dev/snd` as a directory.