### PR TITLE
fix: Enable GPU support in requirements to utilize Moondream optimiza…

### DIFF
--- a/ansible/roles/python_deps/files/requirements.txt
+++ b/ansible/roles/python_deps/files/requirements.txt
@@ -1,4 +1,3 @@
---index-url https://download.pytorch.org/whl/cpu
 torch
 torchvision
 torchaudio


### PR DESCRIPTION
…tions

- Removed forced CPU index for PyTorch in `ansible/roles/python_deps/files/requirements.txt` to allow installing GPU-enabled wheels.
- This unlocks the recently added optimizations (TF32, BF16, torch.compile) in `moondream_detector.py` when running on GPU nodes.