### PR TITLE
feat: Add support for reasoning tokens in MoE Gateway and Pipecat

### DIFF
--- a/ansible/roles/pipecatapp/files/workflows/default_agent_loop.yaml
+++ b/ansible/roles/pipecatapp/files/workflows/default_agent_loop.yaml
@@ -1,0 +1,33 @@
+name: "Tiered Agent Loop"
+nodes:
+  - id: "Input"
+    type: "InputNode"
+    inputs: []
+
+  - id: "Summarizer"
+    type: "SimpleLLMNode"
+    model_tier: "fast"
+    system_prompt: "You are a concise summarizer. Summarize the user's input in one sentence."
+    inputs:
+      - name: "user_text"
+        connection:
+          from_node: "Input"
+          from_output: "user_text"
+
+  - id: "Reasoning"
+    type: "SimpleLLMNode"
+    model_tier: "balanced"
+    system_prompt: "You are a thoughtful assistant. Answer the user based on the summary provided."
+    inputs:
+      - name: "user_text"
+        connection:
+          from_node: "Summarizer"
+          from_output: "response"
+
+  - id: "Output"
+    type: "OutputNode"
+    inputs:
+      - name: "final_output"
+        connection:
+          from_node: "Reasoning"
+          from_output: "response"


### PR DESCRIPTION
- Update `SimpleLLMNode` and `ExpertRouterNode` to accept and inject `reasoning` config (e.g., `effort`, `max_tokens`) into LLM requests.
- Update `SimpleLLMNode` and `ExpertRouterNode` to extract `reasoning_details` from responses and store them in the context.
- Update `reflect.py` to support `reasoning_config` when calling OpenAI-compatible endpoints for self-healing.
- Update `gateway.py` to:
    - Log and forward `reasoning` and `reasoning_details` fields from internal Pipecat responses to the external API response.
    - Ensure compliance with OpenAI-compatible schemas while preserving reasoning data.
- Restore `default_agent_loop.yaml` from `tiered_agent_loop.yaml` to ensure application startup and test passing.
- Verified with unit tests mocking the API interactions.