### PR TITLE
feat: add async fallback and warning for ssh key fetch

### DIFF
--- a/os-image/config/includes.chroot/etc/profile.d/99-pipecat-welcome.sh
+++ b/os-image/config/includes.chroot/etc/profile.d/99-pipecat-welcome.sh
@@ -35,10 +35,23 @@ if [ ! -f /etc/pipecat_github_user ] && [ ! -f /home/pipecatapp/.ssh/.skip_githu
     fi
 elif [ -f /etc/pipecat_github_user ] && [ ! -f /home/pipecatapp/.ssh/.keys_fetched ]; then
     # Automatically fetch keys on first boot if pre-configured
+    github_user=$(cat /etc/pipecat_github_user)
     if [ "$IP" != "No IP found (check network)" ]; then
-        github_user=$(cat /etc/pipecat_github_user)
         sudo /usr/local/bin/setup-ssh-keys.sh "$github_user" >/dev/null 2>&1
         touch /home/pipecatapp/.ssh/.keys_fetched
+    else
+        echo "Warning: No IP found. Delaying SSH key fetch for $github_user."
+        (
+            # Wait up to 60 more seconds in the background
+            for i in {1..60}; do
+                if [ -n "$(hostname -I | awk '{print $1}')" ]; then
+                    sudo /usr/local/bin/setup-ssh-keys.sh "$github_user" >/dev/null 2>&1
+                    touch /home/pipecatapp/.ssh/.keys_fetched
+                    break
+                fi
+                sleep 1
+            done
+        ) &
     fi
 fi
 echo ""


### PR DESCRIPTION
When booting the custom Debian live ISO, the `99-pipecat-welcome.sh` script runs a wait loop for the DHCP-assigned IP address. If DHCP takes longer than the 10-second wait, the `setup-ssh-keys.sh` script previously ran synchronously, failed, and incorrectly touched `.keys_fetched`.

This commit adds a warning message when no IP is found and spawns an asynchronous background subshell that polls for an IP address for an additional 60 seconds before executing the fetch. This ensures the user is alerted and the operation reliably succeeds without blocking login.