### PR TITLE
Fix Ansible registry reachability checks

### DIFF
--- a/ansible/roles/exo/tasks/main.yaml
+++ b/ansible/roles/exo/tasks/main.yaml
@@ -47,6 +47,7 @@
     state: started
     timeout: 1
   register: registry_check
+  failed_when: false
   ignore_errors: true
   when: exo_enable
 
@@ -57,7 +58,7 @@
     push: true
     source: local
   become: yes
-  when: exo_enable and registry_check is success
+  when: exo_enable and registry_check.state | default('stopped') == 'started'
 
 - name: Cleanup build directory
   ansible.builtin.file:

--- a/ansible/roles/memory_graph/tasks/main.yaml
+++ b/ansible/roles/memory_graph/tasks/main.yaml
@@ -22,6 +22,7 @@
     state: started
     timeout: 1
   register: registry_check
+  failed_when: false
   ignore_errors: true
 
 - name: Tag and push memory-graph service image to local registry
@@ -30,17 +31,17 @@
     repository: "{{ docker_registry_host }}:{{ docker_registry_port }}/memory-graph-service:latest"
     push: true
     source: local
-  when: registry_check is success
+  when: registry_check.state | default('stopped') == 'started'
 
 - name: Set memory_graph_image (Registry)
   ansible.builtin.set_fact:
     memory_graph_image: "{{ docker_registry_host }}:{{ docker_registry_port }}/memory-graph-service:latest"
-  when: registry_check is success
+  when: registry_check.state | default('stopped') == 'started'
 
 - name: Set memory_graph_image (Local Fallback)
   ansible.builtin.set_fact:
     memory_graph_image: "memory-graph-service:local"
-  when: registry_check is failed
+  when: registry_check.state | default('stopped') != 'started'
 
 - name: Deploy memory-graph Nomad job
   community.general.nomad_job:

--- a/ansible/roles/memory_service/tasks/main.yaml
+++ b/ansible/roles/memory_service/tasks/main.yaml
@@ -36,6 +36,7 @@
     state: started
     timeout: 1
   register: registry_check
+  failed_when: false
   ignore_errors: true
 
 - name: Tag and push memory_service image to local registry
@@ -45,7 +46,7 @@
     repository: "{{ docker_registry_host }}:{{ docker_registry_port }}/memory_service"
     push: true
     source: local
-  when: registry_check is success
+  when: registry_check.state | default('stopped') == 'started'
 
 - name: Template memory service Nomad job
   ansible.builtin.template:

--- a/ansible/roles/openclaw/tasks/main.yaml
+++ b/ansible/roles/openclaw/tasks/main.yaml
@@ -37,6 +37,7 @@
     state: started
     timeout: 1
   register: registry_check
+  failed_when: false
   ignore_errors: true
 
 - name: Tag and push openclaw image to local registry
@@ -46,7 +47,7 @@
     repository: "{{ docker_registry_host }}:{{ docker_registry_port }}/openclaw"
     push: true
     source: local
-  when: registry_check is success
+  when: registry_check.state | default('stopped') == 'started'
 
 - name: Copy Pipecat Skill
   ansible.builtin.copy:

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -412,17 +412,18 @@
     state: started
     timeout: 1
   register: pipecatapp_registry_check
+  failed_when: false
   ignore_errors: true
 
 - name: Set pipecatapp_image_ref (Registry)
   ansible.builtin.set_fact:
     pipecatapp_image_ref: "{{ docker_registry_host }}:{{ docker_registry_port }}/pipecatapp:local"
-  when: pipecatapp_registry_check is success
+  when: pipecatapp_registry_check.state | default('stopped') == 'started'
 
 - name: Set pipecatapp_image_ref (Local Fallback)
   ansible.builtin.set_fact:
     pipecatapp_image_ref: "pipecatapp:local"
-  when: pipecatapp_registry_check is failed
+  when: pipecatapp_registry_check.state | default('stopped') != 'started'
 
 - name: Ensure Nomad jobs directory exists
   ansible.builtin.file:

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -104,7 +104,7 @@
     push: true
     source: local
   become: yes
-  when: registry_check is success
+  when: registry_check.state | default('stopped') == 'started'
 
 - name: "Tool Server : Verify Docker image exists"
   ansible.builtin.command:

--- a/ansible/tasks/build_pipecatapp_image.yaml
+++ b/ansible/tasks/build_pipecatapp_image.yaml
@@ -83,6 +83,7 @@
     state: started
     timeout: 1
   register: registry_check
+  failed_when: false
   ignore_errors: true
   when: pipecat_deployment_style == 'docker'
 
@@ -94,7 +95,7 @@
     push: true
     source: local
   become: yes
-  when: pipecat_deployment_style == 'docker' and registry_check is success
+  when: pipecat_deployment_style == 'docker' and registry_check.state | default('stopped') == 'started'
 
 - name: Tag and push pipecatapp image (versioned) to local registry
   community.docker.docker_image:
@@ -104,4 +105,4 @@
     push: true
     source: local
   become: yes
-  when: pipecat_deployment_style == 'docker' and registry_check is success
+  when: pipecat_deployment_style == 'docker' and registry_check.state | default('stopped') == 'started'

--- a/ansible/tasks/deploy_expert_wrapper.yaml
+++ b/ansible/tasks/deploy_expert_wrapper.yaml
@@ -46,6 +46,7 @@
         state: started
         timeout: 5
       register: registry_check
+      failed_when: false
       ignore_errors: true
       when: registry_is_reachable | default(true)
 
@@ -58,7 +59,7 @@
         source: local
       when:
         - registry_is_reachable | default(true)
-        - registry_check is success
+        - registry_check.state | default('stopped') == 'started'
 
     - name: "Expert {{ expert_name }} : Ensure startup script exists (Dev Mode fallback)"
       ansible.builtin.template:

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -141,6 +141,7 @@
         state: started
         timeout: 5
       register: global_registry_check
+      failed_when: false
       ignore_errors: true
       tags:
         - deploy-expert
@@ -148,14 +149,14 @@
     - name: Set pipecat_image_id fact (Registry)
       ansible.builtin.set_fact:
         pipecat_image_id: "{{ docker_registry_host }}:{{ docker_registry_port }}/{{ pipecat_image_name }}:{{ pipecat_image_tag }}"
-      when: global_registry_check is success
+      when: global_registry_check.state | default('stopped') == 'started'
       tags:
         - deploy-expert
 
     - name: Set pipecat_image_id fact (Local Fallback)
       ansible.builtin.set_fact:
         pipecat_image_id: "{{ (pipecat_image_info.stdout | from_json)[0].Id }}"
-      when: global_registry_check is failed
+      when: global_registry_check.state | default('stopped') != 'started'
       tags:
         - deploy-expert
 
@@ -282,7 +283,7 @@
       include_tasks:
         file: "{{ playbook_dir }}/../../ansible/tasks/deploy_expert_wrapper.yaml"
       vars:
-        registry_is_reachable: "{{ global_registry_check is success }}"
+        registry_is_reachable: "{{ global_registry_check.state | default('stopped') == 'started' }}"
       loop: "{{ experts }}"
       loop_control:
         loop_var: expert_name


### PR DESCRIPTION
Fixed an issue where Ansible playbooks were trying to push Docker images to unreachable registries because `wait_for` timeouts were being incorrectly evaluated as successes due to the combination of `ignore_errors: true` and missing/incorrect condition evaluations.

---
*PR created automatically by Jules for task [7351306879840540420](https://jules.google.com/task/7351306879840540420) started by @LokiMetaSmith*