### PR TITLE
Implement TPM-backed SSH identities and offline Consul Key distribution

### DIFF
--- a/ansible/roles/common/templates/update-ssh-authorized-keys.sh.j2
+++ b/ansible/roles/common/templates/update-ssh-authorized-keys.sh.j2
@@ -8,7 +8,7 @@ log_sync() {
 
 # The USERNAME is set in /etc/environment by a previous script, but we can default to 'user'
 if [ -z "$USERNAME" ]; then
-    USERNAME="user"
+    USERNAME="{{ target_user | default('pipecatapp') }}"
 fi
 
 USER_HOME="/home/$USERNAME"

--- a/ansible/roles/system_deps/tasks/main.yaml
+++ b/ansible/roles/system_deps/tasks/main.yaml
@@ -14,38 +14,41 @@
       - acl
       - avahi-daemon
       - build-essential
-      - cmake
       - cargo
       - chrony
+      - cmake
       - cmatrix
       - curl
+      - expect
+      - ffmpeg
       - figlet
       - fio
-      - ffmpeg
       - fortune-mod
       - fuse-overlayfs
-      - gstreamer1.0-libav
       - git
+      - gstreamer1.0-libav
       - hollywood
       - htop
       - iperf3
       - jq
-      - libavif16
-      - libavformat-dev
       - libavcodec-dev
       - libavdevice-dev
-      - libavutil-dev
       - libavfilter-dev
-      - libswscale-dev
-      - libswresample-dev
+      - libavformat-dev
+      - libavif16
+      - libavutil-dev
       - libcurl4-openssl-dev
       - libevent-2.1-7t64
       - libflite1
-      - libgstreamer-plugins-bad1.0-0
       - libgl1
       - libglib2.0-0t64
+      - libgstreamer-plugins-bad1.0-0
       - libmecab-dev
       - libnss-mdns
+      - libswresample-dev
+      - libswscale-dev
+      - libtpm2-pkcs11-1
+      - libtpm2-pkcs11-tools
       - lolcat
       - make
       - mecab
@@ -53,6 +56,7 @@
       - mosh
       - ncdu
       - nfs-common
+      - opensc
       - openssh-server
       - pkg-config
       - portaudio19-dev
@@ -67,8 +71,10 @@
       - sl
       - sshpass
       - sysbench
-      - toilet
       - tmux
+      - toilet
+      - tpm2-abrmd
+      - tpm2-tools
       - ufw
       - unzip
       - yq

--- a/ansible/roles/tpm_ssh/handlers/main.yaml
+++ b/ansible/roles/tpm_ssh/handlers/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: restart tpm-ssh-agent
+  ansible.builtin.systemd:
+    name: tpm-ssh-agent
+    state: restarted
+    daemon_reload: yes

--- a/ansible/roles/tpm_ssh/tasks/main.yaml
+++ b/ansible/roles/tpm_ssh/tasks/main.yaml
@@ -1,0 +1,176 @@
+---
+- name: "TPM : Check if TPM device exists"
+  stat:
+    path: /dev/tpmrm0
+  register: tpm_device
+
+- name: "TPM : Fallback check for raw TPM device"
+  stat:
+    path: /dev/tpm0
+  register: tpm0_device
+  when: not tpm_device.stat.exists
+
+- name: "TPM : Set TPM presence fact"
+  set_fact:
+    has_tpm: "{{ tpm_device.stat.exists or (tpm0_device.stat.exists | default(false)) }}"
+
+- block:
+    - name: "TPM : Ensure tss group exists"
+      ansible.builtin.group:
+        name: tss
+        state: present
+
+    - name: "TPM : Add pipecatapp user to tss group"
+      ansible.builtin.user:
+        name: "{{ target_user | default('pipecatapp') }}"
+        groups: tss
+        append: yes
+
+    - name: "TPM : Ensure SSH config directory exists"
+      ansible.builtin.file:
+        path: "/home/{{ target_user | default('pipecatapp') }}/.ssh"
+        state: directory
+        owner: "{{ target_user | default('pipecatapp') }}"
+        group: "{{ target_user | default('pipecatapp') }}"
+        mode: '0700'
+
+    - name: "TPM : Check if TPM token already initialized"
+      ansible.builtin.stat:
+        path: "/home/{{ target_user | default('pipecatapp') }}/.tpm2_pkcs11/tpm2_pkcs11.sqlite3"
+      register: tpm_db
+
+    - block:
+        - name: "TPM : Generate random SO PIN"
+          ansible.builtin.command: openssl rand -hex 16
+          register: sopin_gen
+
+        - name: "TPM : Generate random User PIN"
+          ansible.builtin.command: openssl rand -hex 16
+          register: userpin_gen
+
+        - name: "TPM : Save PINs securely"
+          ansible.builtin.template:
+            src: tpm_pins.j2
+            dest: /etc/tpm_ssh_pins
+            owner: root
+            group: root
+            mode: '0600'
+
+        - name: "TPM : Initialize PKCS#11 store"
+          ansible.builtin.command:
+            cmd: tpm2_ptool init
+          environment:
+            HOME: "/home/{{ target_user | default('pipecatapp') }}"
+          become: yes
+          become_user: "{{ target_user | default('pipecatapp') }}"
+
+        - name: "TPM : Add token"
+          ansible.builtin.command:
+            cmd: "tpm2_ptool addtoken --pid 1 --label sshtoken --sopin {{ sopin_gen.stdout }} --userpin {{ userpin_gen.stdout }}"
+          environment:
+            HOME: "/home/{{ target_user | default('pipecatapp') }}"
+          become: yes
+          become_user: "{{ target_user | default('pipecatapp') }}"
+
+        - name: "TPM : Generate temporary SSH key for import"
+          ansible.builtin.command:
+            cmd: "ssh-keygen -t rsa -b 4096 -f /tmp/tpm_temp_key -N '' -m PEM -q"
+          become: yes
+          become_user: "{{ target_user | default('pipecatapp') }}"
+
+        - name: "TPM : Convert to PEM format (already done by -m PEM but ensuring no password)"
+          ansible.builtin.command:
+            cmd: "ssh-keygen -p -f /tmp/tpm_temp_key -m PEM -P '' -N ''"
+          become: yes
+          become_user: "{{ target_user | default('pipecatapp') }}"
+
+        - name: "TPM : Import SSH key into TPM token"
+          ansible.builtin.command:
+            cmd: "tpm2_ptool import --label sshtoken --key-label sshkey1 --userpin {{ userpin_gen.stdout }} --privkey /tmp/tpm_temp_key --algorithm rsa"
+          environment:
+            HOME: "/home/{{ target_user | default('pipecatapp') }}"
+          become: yes
+          become_user: "{{ target_user | default('pipecatapp') }}"
+
+        - name: "TPM : Cleanup temporary SSH key"
+          ansible.builtin.file:
+            path: "{{ item }}"
+            state: absent
+          loop:
+            - /tmp/tpm_temp_key
+            - /tmp/tpm_temp_key.pub
+
+      when: not tpm_db.stat.exists
+
+    - name: "TPM : Ensure PKCS11Provider is in SSH config"
+      ansible.builtin.lineinfile:
+        path: "/home/{{ target_user | default('pipecatapp') }}/.ssh/config"
+        line: "PKCS11Provider /usr/lib/x86_64-linux-gnu/pkcs11/libtpm2_pkcs11.so"
+        create: yes
+        owner: "{{ target_user | default('pipecatapp') }}"
+        group: "{{ target_user | default('pipecatapp') }}"
+        mode: '0600'
+        insertbefore: BOF
+
+    - name: "TPM : Extract Public Key from TPM"
+      ansible.builtin.shell:
+        cmd: "ssh-keygen -D /usr/lib/x86_64-linux-gnu/pkcs11/libtpm2_pkcs11.so"
+      environment:
+        HOME: "/home/{{ target_user | default('pipecatapp') }}"
+      become: yes
+      become_user: "{{ target_user | default('pipecatapp') }}"
+      register: tpm_pub_key
+      changed_when: false
+      ignore_errors: yes
+
+    - name: "TPM : Save TPM public key locally"
+      ansible.builtin.copy:
+        content: "{{ tpm_pub_key.stdout }}\n"
+        dest: "/home/{{ target_user | default('pipecatapp') }}/.ssh/id_tpm.pub"
+        owner: "{{ target_user | default('pipecatapp') }}"
+        group: "{{ target_user | default('pipecatapp') }}"
+        mode: '0644'
+      when: tpm_pub_key is not failed
+
+
+
+
+    - name: "TPM : Wait for Consul to be available before publishing key"
+      ansible.builtin.wait_for:
+        port: 8500
+        host: 127.0.0.1
+        timeout: 120
+      ignore_errors: yes
+
+    - name: "TPM : Publish public key to Consul"
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:8500/v1/kv/ssh-keys/{{ inventory_hostname }}"
+        method: PUT
+        body: "{{ tpm_pub_key.stdout }}"
+        status_code: [200, 201]
+      when: tpm_pub_key is not failed and tpm_pub_key.stdout != ''
+      ignore_errors: yes
+
+    - name: "TPM : Create headless SSH Agent wrapper script"
+      ansible.builtin.template:
+        src: tpm-ssh-agent.sh.j2
+        dest: /usr/local/bin/tpm-ssh-agent.sh
+        mode: '0755'
+        owner: root
+
+    - name: "TPM : Create systemd service for headless SSH Agent"
+      ansible.builtin.template:
+        src: tpm-ssh-agent.service.j2
+        dest: /etc/systemd/system/tpm-ssh-agent.service
+        mode: '0644'
+        owner: root
+      notify: restart tpm-ssh-agent
+
+    - name: "TPM : Enable and start headless SSH Agent"
+      ansible.builtin.systemd:
+        name: tpm-ssh-agent
+        state: started
+        enabled: yes
+        daemon_reload: yes
+
+  when: has_tpm | bool

--- a/ansible/roles/tpm_ssh/templates/tpm-ssh-agent.service.j2
+++ b/ansible/roles/tpm_ssh/templates/tpm-ssh-agent.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Headless TPM SSH Agent
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/tpm-ssh-agent.sh
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/tpm_ssh/templates/tpm-ssh-agent.sh.j2
+++ b/ansible/roles/tpm_ssh/templates/tpm-ssh-agent.sh.j2
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Starts an ssh-agent and adds the TPM key using the stored PIN via expect
+
+USER="{{ target_user | default('pipecatapp') }}"
+USER_HOME="/home/$USER"
+AUTH_SOCK="$USER_HOME/.ssh/tpm_auth_sock"
+
+# Source the PIN
+if [ -f /etc/tpm_ssh_pins ]; then
+    source /etc/tpm_ssh_pins
+else
+    echo "Error: /etc/tpm_ssh_pins not found."
+fi
+
+# Clean up old socket
+rm -f "$AUTH_SOCK"
+
+# Start ssh-agent binding to our custom socket path
+eval $(ssh-agent -a "$AUTH_SOCK")
+
+# Use expect to script the ssh-add prompt
+export SSH_AUTH_SOCK="$AUTH_SOCK"
+export HOME="$USER_HOME"
+
+expect << EOD
+spawn su -c "ssh-add -s /usr/lib/x86_64-linux-gnu/pkcs11/libtpm2_pkcs11.so" $USER
+expect "Enter PIN for 'sshkey1':"
+send "$USERPIN\r"
+expect eof
+EOD
+
+# Ensure the user has permissions on the socket
+chown $USER:$USER "$AUTH_SOCK"
+chmod 600 "$AUTH_SOCK"
+
+echo "TPM SSH Agent is running. Set SSH_AUTH_SOCK=$AUTH_SOCK to use."
+
+# Wait forever using sleep infinity to avoid blocking scripts
+exec sleep infinity

--- a/ansible/roles/tpm_ssh/templates/tpm_pins.j2
+++ b/ansible/roles/tpm_ssh/templates/tpm_pins.j2
@@ -1,0 +1,4 @@
+# This file contains the PINs required to unlock the TPM PKCS#11 token.
+# It is heavily guarded with 0600 permissions and only accessible by root.
+SOPIN="{{ sopin_gen.stdout }}"
+USERPIN="{{ userpin_gen.stdout }}"

--- a/initial-setup/modules/04-ssh.sh
+++ b/initial-setup/modules/04-ssh.sh
@@ -38,7 +38,15 @@ fi
 # --- Consul Integration ---
 # Publish public key to Consul KV store
 HOSTNAME=$(hostname)
-PUB_KEY_CONTENT=$(cat "$PUBLIC_KEY")
+
+if [ -f "$SSH_DIR/id_tpm.pub" ]; then
+    log "Found TPM public key. Using it instead of standard RSA key."
+    PUBLIC_KEY="$SSH_DIR/id_tpm.pub"
+    PUB_KEY_CONTENT=$(cat "$PUBLIC_KEY")
+else
+    PUB_KEY_CONTENT=$(cat "$PUBLIC_KEY")
+fi
+
 
 log "Checking for active Consul agent before attempting to publish SSH key..."
 if systemctl is-active --quiet consul; then

--- a/playbooks/common_setup.yaml
+++ b/playbooks/common_setup.yaml
@@ -1,6 +1,12 @@
 - name: Common Setup
   hosts: all
   become: yes
+  roles:
+    - role: tpm_ssh
+      tags:
+        - tpm_ssh
+        - common
+
   tasks:
     - name: Ensure Debian repositories are configured (needed for minimal/live ISOs)
       raw: |

--- a/playbooks/services/core_infra.yaml
+++ b/playbooks/services/core_infra.yaml
@@ -45,3 +45,7 @@
     - role: common
       tags:
         - common
+    - role: tpm_ssh
+      tags:
+        - tpm_ssh
+        - common


### PR DESCRIPTION
This change implements secure, immutable machine identities by storing SSH private keys inside a Trusted Platform Module (TPM). It introduces a new `tpm_ssh` Ansible role that generates and imports an RSA key into the TPM, using `expect` to automatically load it into a headless `ssh-agent` service for agentic operations. 

Furthermore, to remove internet dependency (e.g., GitHub), the cluster now uses Consul KV as the primary mechanism for offline key distribution, allowing seamless lateral access for automated jobs across the air-gapped cluster.

---
*PR created automatically by Jules for task [4428453659128347482](https://jules.google.com/task/4428453659128347482) started by @LokiMetaSmith*