### PR TITLE
Fix `rustc` version for llmfit build

### DIFF
--- a/ansible/roles/system_deps/tasks/main.yaml
+++ b/ansible/roles/system_deps/tasks/main.yaml
@@ -14,7 +14,6 @@
       - acl
       - avahi-daemon
       - build-essential
-      - cargo
       - chrony
       - cmake
       - cmatrix
@@ -67,7 +66,6 @@
       - python3-venv
       - python3-virtualenv
       - rsync
-      - rustc
       - sl
       - sshpass
       - sysbench
@@ -87,4 +85,33 @@
     name: avahi-daemon
     state: started
     enabled: yes
+  become: yes
+
+- name: Check if Cargo is installed
+  ansible.builtin.stat:
+    path: /root/.cargo/bin/cargo
+  register: cargo_stat
+
+- name: Install Rust and Cargo via rustup
+  ansible.builtin.shell: |
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  when: not cargo_stat.stat.exists
+  become: yes
+
+- name: Add cargo to PATH for all users
+  ansible.builtin.copy:
+    dest: /etc/profile.d/rust.sh
+    content: |
+      export PATH="/root/.cargo/bin:$PATH"
+    mode: '0644'
+  become: yes
+
+- name: Create symlinks for cargo and rustc
+  ansible.builtin.file:
+    src: "/root/.cargo/bin/{{ item }}"
+    dest: "/usr/local/bin/{{ item }}"
+    state: link
+  loop:
+    - cargo
+    - rustc
   become: yes

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -35,14 +35,14 @@ sudo rm -rf /etc/systemd/system/nomad.service.d
 # Purge packages
 echo "Purging installed packages..."
 sudo apt-get purge -y \
-    acl build-essential cmake cargo chrony cmatrix curl figlet fio \
+    acl build-essential cmake chrony cmatrix curl figlet fio \
     fortune-mod fuse-overlayfs gstreamer1.0-libav git hollywood htop iperf3 jq \
     libavif16 libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev \
     libavfilter-dev libswscale-dev libswresample-dev libcurl4-openssl-dev \
     libevent-2.1-7t64 libflite1 libgstreamer-plugins-bad1.0-0 libmecab-dev \
     lolcat make mecab mecab-ipadic-utf8 mosh ncdu nfs-common openssh-server \
     pkg-config portaudio19-dev python3 python3-dev python3-full python3-pip \
-    python3-venv python3-virtualenv rsync rustc sl sshpass sysbench toilet \
+    python3-venv python3-virtualenv rsync sl sshpass sysbench toilet \
     tmux ufw unzip yq docker.io docker-doc docker-compose podman-docker \
     containerd runc
 sudo apt-get autoremove -y
@@ -81,3 +81,10 @@ sudo sed -i '/# ANSIBLE MANAGED BLOCK/d' /etc/hosts
 
 echo "Uninstall complete."
 echo "Please reboot the system to ensure all changes are applied."
+
+# Remove Rust installed via rustup
+echo "Removing Rust and Cargo..."
+sudo rm -rf /root/.rustup /root/.cargo
+sudo rm -f /etc/profile.d/rust.sh
+sudo rm -f /usr/local/bin/cargo
+sudo rm -f /usr/local/bin/rustc


### PR DESCRIPTION
Resolves the issue where `llmfit` fails to build because the `rustc` version supplied by the system APT repository is too old (1.75.0, where 1.86.0 is required). Uses `rustup` to download and install the latest stable version of Rust and Cargo. Creates symlinks in `/usr/local/bin` to ensure they are available system-wide for Ansible tasks and users. Updates `uninstall.sh` to purge `~/.rustup`, `~/.cargo`, `/etc/profile.d/rust.sh`, and the symlinks instead of running `apt-get purge`.

---
*PR created automatically by Jules for task [13422299070648866753](https://jules.google.com/task/13422299070648866753) started by @LokiMetaSmith*