### PR TITLE
Fix connection refused error in Nomad job handlers

### DIFF
--- a/ansible/roles/forgejo/handlers/main.yaml
+++ b/ansible/roles/forgejo/handlers/main.yaml
@@ -2,4 +2,4 @@
   ansible.builtin.command: nomad job run /opt/nomad/jobs/forgejo.nomad
   become: yes
   environment:
-    NOMAD_ADDR: "http://{{ ansible_facts['default_ipv4']['address'] }}:4646"
+    NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"

--- a/ansible/roles/gemini_cli/handlers/main.yaml
+++ b/ansible/roles/gemini_cli/handlers/main.yaml
@@ -2,4 +2,4 @@
   ansible.builtin.command: nomad job run /opt/nomad/jobs/gemini.nomad
   become: yes
   environment:
-    NOMAD_ADDR: "http://{{ ansible_facts['default_ipv4']['address'] }}:4646"
+    NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"

--- a/ansible/roles/memory_service/handlers/main.yaml
+++ b/ansible/roles/memory_service/handlers/main.yaml
@@ -2,4 +2,4 @@
   ansible.builtin.command:
     cmd: nomad job run -detach /opt/nomad/jobs/memory_service.nomad
   environment:
-    NOMAD_ADDR: "http://{{ ansible_facts['default_ipv4']['address'] }}:4646"
+    NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"

--- a/ansible/roles/nanochat/handlers/main.yaml
+++ b/ansible/roles/nanochat/handlers/main.yaml
@@ -2,5 +2,5 @@
   ansible.builtin.command:
     cmd: "nomad job run {{ nomad_jobs_dir }}/nanochat.nomad"
   environment:
-    NOMAD_ADDR: "http://{{ advertise_ip }}:4646"
+    NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
   become: yes

--- a/ansible/roles/opencode/handlers/main.yaml
+++ b/ansible/roles/opencode/handlers/main.yaml
@@ -2,4 +2,4 @@
   ansible.builtin.command: nomad job run /opt/nomad/jobs/opencode.nomad
   become: yes
   environment:
-    NOMAD_ADDR: "http://{{ ansible_facts['default_ipv4']['address'] }}:4646"
+    NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"

--- a/ansible/roles/vision/handlers/main.yaml
+++ b/ansible/roles/vision/handlers/main.yaml
@@ -2,5 +2,5 @@
   ansible.builtin.command:
     cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/vision.nomad
   environment:
-    NOMAD_ADDR: "http://localhost:4646"
+    NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
   changed_when: true

--- a/ansible/roles/vision/tasks/main.yaml
+++ b/ansible/roles/vision/tasks/main.yaml
@@ -44,5 +44,5 @@
   ansible.builtin.command:
     cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/vision.nomad
   environment:
-    NOMAD_ADDR: "http://localhost:4646"
+    NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
   changed_when: true


### PR DESCRIPTION
Fixes connection refused error by pointing handlers to cluster_ip instead of local interfaces.

---
*PR created automatically by Jules for task [15809651338124750998](https://jules.google.com/task/15809651338124750998) started by @LokiMetaSmith*