### PR TITLE
Fix connection refused error in Nomad job submissions and Forgejo dep…

### DIFF
--- a/ansible/roles/forgejo/templates/forgejo.nomad.j2
+++ b/ansible/roles/forgejo/templates/forgejo.nomad.j2
@@ -32,6 +32,7 @@ job "forgejo" {
         USER_GID = "1000"
         FORGEJO__server__HTTP_PORT = "${NOMAD_PORT_http}"
         FORGEJO__server__SSH_PORT  = "${NOMAD_PORT_ssh}"
+        FORGEJO__server__START_SSH_SERVER = "true"
         FORGEJO__server__ROOT_URL  = "http://${attr.unique.network.ip-address}:${NOMAD_PORT_http}/"
       }
 


### PR DESCRIPTION
…loyment timeout

1. Updated application Ansible role handlers (Forgejo, Opencode, Gemini CLI, Memory Service, Vision, Nanochat) to bind the NOMAD_ADDR environment variable to the cluster IP instead of localhost or the default IPv4 address. This resolves 'connection refused' errors that occurred during playbook execution because Nomad binds to `cluster_ip` (Tailscale or evaluated IPv4).

2. Resolved a deployment timeout for the Forgejo service where the task failed its health checks due to the internal OpenSSH daemon continuously crashing. This crash occurred due to rootless volume permission issues with host keys. Enabled Forgejo's built-in Go SSH server (`FORGEJO__server__START_SSH_SERVER="true"`) to bypass the system `sshd` limitation and restore SSH functionality correctly.