### PR TITLE
Fix Forgejo rootless OpenSSH permission issues

### DIFF
--- a/ansible/roles/forgejo/templates/forgejo.nomad.j2
+++ b/ansible/roles/forgejo/templates/forgejo.nomad.j2
@@ -28,8 +28,6 @@ job "forgejo" {
       }
 
       env {
-        USER_UID = "1000"
-        USER_GID = "1000"
         FORGEJO__server__HTTP_PORT = "${NOMAD_PORT_http}"
         FORGEJO__server__SSH_PORT  = "${NOMAD_PORT_ssh}"
         FORGEJO__server__START_SSH_SERVER = "true"

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. Add `system_deps` as a dependency to `python_deps` role. The `python_deps` task fails because it tries to compile `pyaudio` via `uv pip install`, which requires `portaudio19-dev` (and other compilation dependencies like gcc). The `python_deps` task is called directly from `playbooks/developer_tools.yaml` (via `heretic_tool` -> `python_deps`). But it is missing the C headers required to compile the Python packages. By adding `system_deps` to the `dependencies` array in `ansible/roles/python_deps/meta/main.yaml`, we ensure that `build-essential` and `portaudio19-dev` are installed prior to `uv pip install` compiling python modules.
-2. The `system_deps` is explicitly called in `app_services.yaml` *before* `python_deps`, but it is skipped when running `playbooks/developer_tools.yaml` directly or in isolation unless it's chained via dependencies.
-3. Pre-commit instructions.
-4. Submit the changes.


### PR DESCRIPTION
Remove `USER_UID` and `USER_GID` environment variables from the Forgejo Nomad job template since the rootless image relies on its own user setup and overriding them breaks the OpenSSH daemon's ability to read host keys from the mounted data volume.

---
*PR created automatically by Jules for task [2801386457943969567](https://jules.google.com/task/2801386457943969567) started by @LokiMetaSmith*