### PR TITLE
feat: integrate Traefik, Authentik, Beszel, and SOPS

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - path_regex: \.sops\.yaml$
+    age: "age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" # Replace with your generated age public key

--- a/README.md
+++ b/README.md
@@ -403,7 +403,24 @@ This project includes a web-based dashboard for real-time display and debugging.
 
 ## 10. Security & Authentication
 
-### 10.1. TPM-Backed SSH Identity
+### 10.1. Secret Management with SOPS
+
+The cluster supports managing encrypted secrets (like API keys, database passwords) directly within the Git repository using [SOPS](https://github.com/getsops/sops) and `age` encryption.
+Ansible automatically decrypts variables from `*.sops.yaml` files during playbook runs, ensuring that sensitive data is secure at rest while enabling GitOps workflows.
+
+1. **Setup Age Key:**
+   ```bash
+   age-keygen -o ~/.config/sops/age/keys.txt
+   ```
+2. **Update SOPS Config:**
+   Update `.sops.yaml` at the root of the project to include the public key generated above.
+3. **Manage Secrets:**
+   Create encrypted variable files in `group_vars/` or `host_vars/` (e.g. `group_vars/secrets.sops.yaml`).
+   ```bash
+   sops group_vars/secrets.sops.yaml
+   ```
+
+### 10.2. TPM-Backed SSH Identity
 
 The Pipecat cluster utilizes a Trusted Platform Module (TPM) to provide a unique, immutable identity for each node.
 Instead of storing traditional SSH private keys (`id_rsa`) in plaintext on the filesystem, the `tpm_ssh` Ansible role generates an SSH key and securely seals it inside the physical TPM chip.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,6 +10,7 @@ inventory = inventory.yaml
 host_key_checking = false
 interpreter_python = auto_silent
 filter_plugins = ansible/filter_plugins
+vars_plugins_enabled = host_group_vars,community.sops.sops
 
 
 [privilege_escalation]

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.sops

--- a/ansible/roles/authentik/defaults/main.yml
+++ b/ansible/roles/authentik/defaults/main.yml
@@ -1,0 +1,2 @@
+nomad_volumes_dir: /opt/nomad/volumes
+nomad_jobs_dir: /opt/nomad/jobs

--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -1,0 +1,25 @@
+- name: Create Authentik directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+    recurse: yes
+  become: yes
+  loop:
+    - "{{ nomad_volumes_dir }}/authentik/media"
+    - "{{ nomad_volumes_dir }}/authentik/templates"
+    - "{{ nomad_volumes_dir }}/authentik/certs"
+    - "{{ nomad_volumes_dir }}/authentik/postgres"
+
+- name: Template Authentik Nomad job
+  ansible.builtin.template:
+    src: authentik.nomad.j2
+    dest: "{{ nomad_jobs_dir }}/authentik.nomad"
+  become: yes
+
+- name: Run Authentik Nomad job
+  ansible.builtin.command: nomad job run {{ nomad_jobs_dir }}/authentik.nomad
+  environment:
+    NOMAD_ADDR: "http://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+  register: authentik_deploy
+  changed_when: "'modified' in authentik_deploy.stdout or 'created' in authentik_deploy.stdout"

--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -1,0 +1,136 @@
+job "authentik" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "authentik" {
+    network {
+      mode = "bridge"
+      port "http" {
+        static = {{ authentik_http_port | default(9000) }}
+        to     = 9000
+      }
+      port "https" {
+        static = {{ authentik_https_port | default(9443) }}
+        to     = 9443
+      }
+      port "redis" {
+        to = 6379
+      }
+      port "postgres" {
+        to = 5432
+      }
+    }
+
+    task "redis" {
+      driver = "docker"
+
+      config {
+        image = "redis:7.2-alpine"
+        ports = ["redis"]
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+
+    task "postgresql" {
+      driver = "docker"
+
+      config {
+        image = "postgres:15-alpine"
+        ports = ["postgres"]
+        volumes = [
+          "{{ nomad_volumes_dir }}/authentik/postgres:/var/lib/postgresql/data"
+        ]
+      }
+
+      env {
+        POSTGRES_USER     = "{{ authentik_db_user | default('authentik') }}"
+        POSTGRES_PASSWORD = "{{ authentik_db_password | default('authentik_password') }}"
+        POSTGRES_DB       = "{{ authentik_db_name | default('authentik') }}"
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image        = "ghcr.io/goauthentik/server:2024.2.2"
+        args         = ["server"]
+        ports        = ["http", "https"]
+        volumes = [
+          "{{ nomad_volumes_dir }}/authentik/media:/media",
+          "{{ nomad_volumes_dir }}/authentik/templates:/templates"
+        ]
+      }
+
+      env {
+        AUTHENTIK_REDIS__HOST = "127.0.0.1"
+        AUTHENTIK_POSTGRESQL__HOST = "127.0.0.1"
+        AUTHENTIK_POSTGRESQL__USER = "{{ authentik_db_user | default('authentik') }}"
+        AUTHENTIK_POSTGRESQL__NAME = "{{ authentik_db_name | default('authentik') }}"
+        AUTHENTIK_POSTGRESQL__PASSWORD = "{{ authentik_db_password | default('authentik_password') }}"
+        AUTHENTIK_SECRET_KEY = "{{ authentik_secret_key | default('change_me_to_a_random_string_in_production') }}"
+        AUTHENTIK_ERROR_REPORTING__ENABLED = "true"
+      }
+
+      service {
+        name = "authentik"
+        port = "http"
+        tags = [
+          "traefik.enable=true",
+          "traefik.http.routers.authentik.rule=Host(`authentik.service.consul`)",
+          "traefik.http.services.authentik.loadbalancer.server.port=9000"
+        ]
+        check {
+          name     = "alive"
+          type     = "http"
+          path     = "/-/health/live/"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+    }
+
+    task "worker" {
+      driver = "docker"
+
+      config {
+        image        = "ghcr.io/goauthentik/server:2024.2.2"
+        args         = ["worker"]
+        volumes = [
+          "{{ nomad_volumes_dir }}/authentik/media:/media",
+          "{{ nomad_volumes_dir }}/authentik/certs:/certs",
+          "{{ nomad_volumes_dir }}/authentik/templates:/templates"
+        ]
+      }
+
+      env {
+        AUTHENTIK_REDIS__HOST = "127.0.0.1"
+        AUTHENTIK_POSTGRESQL__HOST = "127.0.0.1"
+        AUTHENTIK_POSTGRESQL__USER = "{{ authentik_db_user | default('authentik') }}"
+        AUTHENTIK_POSTGRESQL__NAME = "{{ authentik_db_name | default('authentik') }}"
+        AUTHENTIK_POSTGRESQL__PASSWORD = "{{ authentik_db_password | default('authentik_password') }}"
+        AUTHENTIK_SECRET_KEY = "{{ authentik_secret_key | default('change_me_to_a_random_string_in_production') }}"
+        AUTHENTIK_ERROR_REPORTING__ENABLED = "true"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+    }
+  }
+}

--- a/ansible/roles/common-tools/tasks/main.yaml
+++ b/ansible/roles/common-tools/tasks/main.yaml
@@ -11,7 +11,15 @@
       - ufw
       - figlet
       - lolcat
+      - age
     state: present
+  become: yes
+
+- name: Download SOPS binary
+  ansible.builtin.get_url:
+    url: https://github.com/getsops/sops/releases/download/v3.8.1/sops-v3.8.1.linux.amd64
+    dest: /usr/local/bin/sops
+    mode: '0755'
   become: yes
 
 - name: Ensure Mosh is allowed through the firewall

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -65,6 +65,50 @@
         NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port }}"
       changed_when: true
 
+- name: Deploy Beszel
+  block:
+    - name: Create Beszel volume directory
+      ansible.builtin.file:
+        path: "{{ nomad_volumes_dir }}/beszel"
+        state: directory
+        mode: '0755'
+      become: yes
+
+    - name: Template beszel job
+      ansible.builtin.template:
+        src: beszel.nomad.j2
+        dest: "{{ nomad_jobs_dir }}/beszel.nomad"
+      become: yes
+
+    - name: Run beszel job
+      ansible.builtin.command:
+        cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/beszel.nomad
+      environment:
+        NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port }}"
+      changed_when: true
+
+- name: Deploy Statsping
+  block:
+    - name: Create Statsping volume directory
+      ansible.builtin.file:
+        path: "{{ nomad_volumes_dir }}/statsping"
+        state: directory
+        mode: '0755'
+      become: yes
+
+    - name: Template statsping job
+      ansible.builtin.template:
+        src: statsping.nomad.j2
+        dest: "{{ nomad_jobs_dir }}/statsping.nomad"
+      become: yes
+
+    - name: Run statsping job
+      ansible.builtin.command:
+        cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/statsping.nomad
+      environment:
+        NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port }}"
+      changed_when: true
+
 - name: Deploy Memory Audit
   block:
     - name: Template memory-audit job

--- a/ansible/roles/monitoring/templates/beszel.nomad.j2
+++ b/ansible/roles/monitoring/templates/beszel.nomad.j2
@@ -1,0 +1,97 @@
+job "beszel-agent" {
+  datacenters = ["dc1"]
+  type        = "system"
+
+  group "beszel" {
+    network {
+      port "agent" {
+        static = {{ beszel_agent_port | default(45876) }}
+      }
+    }
+
+    task "agent" {
+      driver = "docker"
+
+      config {
+        image        = "henrygd/beszel-agent"
+        network_mode = "host"
+        pid_mode     = "host"
+        privileged   = true
+        volumes = [
+          "/var/run/docker.sock:/var/run/docker.sock:ro",
+          "/:/host:ro",
+          "/dev/disk:/dev/disk:ro",
+        ]
+      }
+
+      env {
+        PORT       = "{{ beszel_agent_port | default(45876) }}"
+        KEY        = "{{ beszel_agent_key | default('change_me') }}"
+        FILESYSTEM = "/host"
+      }
+
+      resources {
+        cpu    = 50
+        memory = 50
+      }
+
+      service {
+        name = "beszel-agent"
+        port = "agent"
+        check {
+          name     = "alive"
+          type     = "tcp"
+          port     = "agent"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}
+
+job "beszel-hub" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "beszel-hub" {
+    network {
+      port "http" {
+        static = {{ beszel_hub_port | default(8090) }}
+      }
+    }
+
+    task "hub" {
+      driver = "docker"
+
+      config {
+        image        = "henrygd/beszel"
+        network_mode = "host"
+        volumes = [
+          "{{ nomad_volumes_dir }}/beszel:/beszel_data",
+        ]
+      }
+
+      service {
+        name = "beszel-hub"
+        port = "http"
+        tags = [
+          "traefik.enable=true",
+          "traefik.http.routers.beszel.rule=Host(`beszel.service.consul`)"
+        ]
+        check {
+          name     = "alive"
+          type     = "tcp"
+          port     = "http"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      resources {
+        cpu    = 200
+        memory = 200
+      }
+    }
+  }
+}

--- a/ansible/roles/monitoring/templates/statsping.nomad.j2
+++ b/ansible/roles/monitoring/templates/statsping.nomad.j2
@@ -1,0 +1,51 @@
+job "statsping" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "statsping" {
+    network {
+      port "http" {
+        to = 8080
+        static = {{ statsping_http_port | default(8088) }}
+      }
+    }
+
+    task "statsping" {
+      driver = "docker"
+
+      config {
+        image = "statping/statping:latest"
+        ports = ["http"]
+        volumes = [
+          "{{ nomad_volumes_dir }}/statsping:/app"
+        ]
+      }
+
+      env {
+        DB_CONN = "sqlite"
+        IS_DOCKER = "true"
+      }
+
+      service {
+        name = "statsping"
+        port = "http"
+        tags = [
+          "traefik.enable=true",
+          "traefik.http.routers.statsping.rule=Host(`statsping.service.consul`)"
+        ]
+        check {
+          name     = "alive"
+          type     = "http"
+          path     = "/health"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      resources {
+        cpu    = 200
+        memory = 200
+      }
+    }
+  }
+}

--- a/ansible/roles/traefik/defaults/main.yml
+++ b/ansible/roles/traefik/defaults/main.yml
@@ -1,0 +1,2 @@
+nomad_volumes_dir: /opt/nomad/volumes
+nomad_jobs_dir: /opt/nomad/jobs

--- a/ansible/roles/traefik/tasks/main.yml
+++ b/ansible/roles/traefik/tasks/main.yml
@@ -1,0 +1,22 @@
+- name: Create Traefik directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+  become: yes
+  loop:
+    - "{{ nomad_jobs_dir }}"
+
+- name: Template Traefik Nomad job
+  ansible.builtin.template:
+    src: traefik.nomad.j2
+    dest: "{{ nomad_jobs_dir }}/traefik.nomad"
+  become: yes
+
+- name: Run Traefik Nomad job
+  ansible.builtin.command: nomad job run {{ nomad_jobs_dir }}/traefik.nomad
+  environment:
+    NOMAD_ADDR: "http://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+  register: traefik_deploy
+  changed_when: "'modified' in traefik_deploy.stdout or 'created' in traefik_deploy.stdout"
+  become: yes

--- a/ansible/roles/traefik/templates/traefik.nomad.j2
+++ b/ansible/roles/traefik/templates/traefik.nomad.j2
@@ -1,0 +1,72 @@
+job "traefik" {
+  datacenters = ["dc1"]
+  type        = "system"
+
+  group "traefik" {
+    network {
+      port "http" {
+        static = {{ traefik_http_port | default(80) }}
+      }
+      port "https" {
+        static = {{ traefik_https_port | default(443) }}
+      }
+      port "api" {
+        static = {{ traefik_api_port | default(8080) }}
+      }
+    }
+
+    service {
+      name = "traefik"
+      port = "http"
+
+      check {
+        name     = "alive"
+        type     = "tcp"
+        port     = "http"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "traefik" {
+      driver = "docker"
+
+      config {
+        image        = "traefik:v3.0"
+        network_mode = "host"
+        volumes = [
+          "local/traefik.yml:/etc/traefik/traefik.yml",
+        ]
+      }
+
+      template {
+        data = <<EOF
+entryPoints:
+  web:
+    address: ":{{ traefik_http_port | default(80) }}"
+  websecure:
+    address: ":{{ traefik_https_port | default(443) }}"
+  traefik:
+    address: ":{{ traefik_api_port | default(8080) }}"
+
+api:
+  dashboard: true
+  insecure: true
+
+providers:
+  consulCatalog:
+    prefix: "traefik"
+    exposedByDefault: false
+    endpoint:
+      address: "127.0.0.1:8500"
+EOF
+        destination = "local/traefik.yml"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+  }
+}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -529,7 +529,7 @@ ensure_python_environment() {
 
     # Install Ansible collections
     if [ -x "$ANSIBLE_GALAXY_EXEC" ]; then
-        run_step "Installing Ansible collections" "$ANSIBLE_GALAXY_EXEC collection install community.general ansible.posix community.docker"
+        run_step "Installing Ansible collections" "$ANSIBLE_GALAXY_EXEC collection install community.general ansible.posix community.docker community.sops"
     else
         echo "Error: ansible-galaxy not found in venv." >&2
         exit 1

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -45,6 +45,14 @@ nomad_models_dir: "/opt/nomad/models"
 # Standard Ports
 consul_http_port: 8500
 consul_dns_port: 8600
+traefik_http_port: 80
+traefik_https_port: 443
+traefik_api_port: 8080
+authentik_http_port: 9000
+authentik_https_port: 9443
+beszel_agent_port: 45876
+beszel_hub_port: 8090
+statsping_http_port: 8088
 consul_rpc_port: 8300
 consul_serf_lan_port: 8301
 consul_serf_wan_port: 8302

--- a/playbooks/services/core_infra.yaml
+++ b/playbooks/services/core_infra.yaml
@@ -49,3 +49,11 @@
       tags:
         - tpm_ssh
         - common
+    - role: traefik
+      tags:
+        - traefik
+        - proxy
+    - role: authentik
+      tags:
+        - authentik
+        - auth


### PR DESCRIPTION
This PR integrates the architectural recommendations from the "State of Homelab 2026" blog post into our Nomad/Consul cluster. 

Key additions:
- **Traefik:** Added an Ansible role to deploy Traefik via Nomad as the cluster ingress/reverse proxy, integrated with Consul Catalog.
- **Authentik:** Added an Ansible role to deploy Authentik for SSO and Identity Management. The deployment is a self-contained Nomad job group running Server, Worker, Redis, and Postgres using bridge networking.
- **Monitoring:** Added Beszel (agent and hub) and Statsping to the existing monitoring role.
- **SOPS:** Integrated SOPS into the cluster bootstrapping process by installing the binary via GitHub releases, adding a `.sops.yaml` configuration, enabling the `community.sops.sops` vars plugin in `ansible.cfg`, and documenting usage.
- **Centralized Ports:** All new service ports have been parameterized and added to `group_vars/all.yaml` to prevent hardcoded ports.

---
*PR created automatically by Jules for task [12113682491407304687](https://jules.google.com/task/12113682491407304687) started by @LokiMetaSmith*