### PR TITLE
feat: Add Paperless-ngx deployment capability

### DIFF
--- a/ansible/roles/paperless/handlers/main.yaml
+++ b/ansible/roles/paperless/handlers/main.yaml
@@ -1,0 +1,5 @@
+- name: Run Paperless Job
+  command: nomad job run /opt/nomad/jobs/paperless.nomad
+  environment:
+    NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
+  become: yes

--- a/ansible/roles/paperless/tasks/main.yaml
+++ b/ansible/roles/paperless/tasks/main.yaml
@@ -1,0 +1,25 @@
+- name: Create Paperless directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+  loop:
+    - /opt/paperless/data
+    - /opt/paperless/media
+    - /opt/paperless/export
+    - /opt/paperless/consume
+    - /opt/paperless/postgres
+    - /opt/paperless/redis
+  become: yes
+
+- name: Create Paperless Nomad job file
+  ansible.builtin.template:
+    src: paperless.nomad.j2
+    dest: /opt/nomad/jobs/paperless.nomad
+    owner: root
+    group: root
+    mode: '0644'
+  become: yes
+  notify: Run Paperless Job

--- a/ansible/roles/paperless/templates/paperless.nomad.j2
+++ b/ansible/roles/paperless/templates/paperless.nomad.j2
@@ -1,0 +1,107 @@
+job "paperless" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "paperless-stack" {
+    count = 1
+
+    network {
+      mode = "bridge"
+      port "http" {
+        static = {{ paperless_port | default(8010) }}
+        to     = 8000
+      }
+    }
+
+    service {
+      name     = "paperless"
+      port     = "http"
+      provider = "consul"
+
+      check {
+        name     = "Paperless Web UI"
+        type     = "tcp"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "postgres" {
+      driver = "docker"
+
+      config {
+        image = "postgres:16.0-alpine"
+        volumes = [
+          "/opt/paperless/postgres:/var/lib/postgresql/data"
+        ]
+      }
+
+      env {
+        POSTGRES_USER     = "paperless"
+        POSTGRES_PASSWORD = "paperless_password"
+        POSTGRES_DB       = "paperless"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+    }
+
+    task "redis" {
+      driver = "docker"
+
+      config {
+        image = "redis:7.2-alpine"
+        volumes = [
+          "/opt/paperless/redis:/data"
+        ]
+      }
+
+      env {
+        REDIS_ARGS = "--save 60 10"
+      }
+
+      resources {
+        cpu    = 250
+        memory = 256
+      }
+    }
+
+    task "paperless-ngx" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/paperless-ngx/paperless-ngx:latest"
+        ports = ["http"]
+        volumes = [
+          "/opt/paperless/data:/usr/src/paperless/data",
+          "/opt/paperless/media:/usr/src/paperless/media",
+          "/opt/paperless/export:/usr/src/paperless/export",
+          "/opt/paperless/consume:/usr/src/paperless/consume"
+        ]
+      }
+
+      env {
+        USERMAP_UID              = "1000"
+        USERMAP_GID              = "1000"
+        PAPERLESS_TIME_ZONE      = "UTC"
+        PAPERLESS_OCR_LANGUAGE   = "eng"
+        PAPERLESS_REDIS          = "redis://127.0.0.1:6379"
+        PAPERLESS_DBHOST         = "127.0.0.1"
+        PAPERLESS_DBNAME         = "paperless"
+        PAPERLESS_DBUSER         = "paperless"
+        PAPERLESS_DBPASS         = "paperless_password"
+        PAPERLESS_SECRET_KEY     = "change_me_in_prod"
+        PAPERLESS_URL            = "http://{{ cluster_ip }}:{{ paperless_port | default(8010) }}"
+        PAPERLESS_ADMIN_USER     = "admin"
+        PAPERLESS_ADMIN_PASSWORD = "admin"
+      }
+
+      resources {
+        cpu    = 1000
+        memory = 1024
+      }
+    }
+  }
+}

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -149,6 +149,10 @@ nanochat_platform: "gpu"
 enable_provisioning_api: true
 enable_home_assistant: true
 enable_frigate: false
+enable_paperless: true
+
+# Service Ports
+paperless_port: 8010
 
 # The default user for remote connections and service execution.
 target_user: ubuntu

--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -106,6 +106,7 @@
         - llmfit
         - openclaw
         - forgejo
+        - paperless
       loop_control:
         loop_var: role_name
       tags:
@@ -115,6 +116,7 @@
         - world_model_service
         - tool_server
         - forgejo
+        - paperless
 
     - name: Run Paddler Stack
       when: enable_paddler | default(false)


### PR DESCRIPTION
Adds support for deploying Paperless-ngx as an app service to the cluster for robust document management. Deploying a self-contained Nomad job, which orchestrates Postgres, Redis, and Paperless-ngx together over a bridge network for secure inter-process communication. Storage volumes are securely managed using host bind mounts directly in the Nomad task configuration to prevent timing and circular dependency issues.

---
*PR created automatically by Jules for task [17318677875558598099](https://jules.google.com/task/17318677875558598099) started by @LokiMetaSmith*