### PR TITLE
fix(ansible): fix forgejo rootless deployment crash loop

### DIFF
--- a/ansible/roles/forgejo/tasks/main.yaml
+++ b/ansible/roles/forgejo/tasks/main.yaml
@@ -7,6 +7,15 @@
     group: "{{ target_user }}"
   become: yes
 
+- name: Create Forgejo config directory
+  ansible.builtin.file:
+    path: /opt/forgejo/config
+    state: directory
+    mode: '0755'
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+  become: yes
+
 - name: Create Forgejo Nomad job file
   ansible.builtin.template:
     src: forgejo.nomad.j2

--- a/ansible/roles/forgejo/templates/forgejo.nomad.j2
+++ b/ansible/roles/forgejo/templates/forgejo.nomad.j2
@@ -23,7 +23,8 @@ job "forgejo" {
         ports = ["http", "ssh"]
 
         volumes = [
-          "/opt/forgejo/data:/data"
+          "/opt/forgejo/data:/var/lib/gitea",
+          "/opt/forgejo/config:/etc/gitea"
         ]
       }
 


### PR DESCRIPTION
Fixes an issue where the Forgejo rootless Nomad deployment would fail with a deadline progress error and crashloop because it could not find or access the `/etc/gitea` and `/var/lib/gitea` directory paths inside the container, due to incorrect volume mapping for the rootless image variant.

---
*PR created automatically by Jules for task [7915470665557501521](https://jules.google.com/task/7915470665557501521) started by @LokiMetaSmith*