### PR TITLE
Fix docker volume mount permissions for authentik and forgejo

### DIFF
--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -1,15 +1,26 @@
-- name: Create Authentik directories
+- name: Create Authentik non-database directories
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: '0755'
+    owner: "1000"
+    group: "1000"
     recurse: yes
   become: yes
   loop:
     - "{{ nomad_volumes_dir }}/authentik/media"
     - "{{ nomad_volumes_dir }}/authentik/templates"
     - "{{ nomad_volumes_dir }}/authentik/certs"
-    - "{{ nomad_volumes_dir }}/authentik/postgres"
+
+- name: Create Authentik postgres directory
+  ansible.builtin.file:
+    path: "{{ nomad_volumes_dir }}/authentik/postgres"
+    state: directory
+    mode: '0700'
+    owner: "70"
+    group: "70"
+    recurse: yes
+  become: yes
 
 - name: Template Authentik Nomad job
   ansible.builtin.template:

--- a/ansible/roles/forgejo/tasks/main.yaml
+++ b/ansible/roles/forgejo/tasks/main.yaml
@@ -3,8 +3,8 @@
     path: /opt/forgejo/data
     state: directory
     mode: '0755'
-    owner: "{{ target_user }}"
-    group: "{{ target_user }}"
+    owner: "1000"
+    group: "1000"
   become: yes
 
 - name: Create Forgejo config directory
@@ -12,8 +12,8 @@
     path: /opt/forgejo/config
     state: directory
     mode: '0755'
-    owner: "{{ target_user }}"
-    group: "{{ target_user }}"
+    owner: "1000"
+    group: "1000"
   become: yes
 
 - name: Create Forgejo Nomad job file


### PR DESCRIPTION
Fix failing Nomad deployments for authentik and forgejo due to host volume mount permissions.

---
*PR created automatically by Jules for task [9986478601674913140](https://jules.google.com/task/9986478601674913140) started by @LokiMetaSmith*