### PR TITLE
Fix Authentik Nomad job progress deadline failure by extending secret key

### DIFF
--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -77,7 +77,7 @@ job "authentik" {
         AUTHENTIK_POSTGRESQL__USER = "{{ authentik_db_user | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__NAME = "{{ authentik_db_name | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__PASSWORD = "{{ authentik_db_password | default('authentik_password') }}"
-        AUTHENTIK_SECRET_KEY = "{{ authentik_secret_key | default('change_me_to_a_random_string_in_production') }}"
+        AUTHENTIK_SECRET_KEY = "{{ authentik_secret_key | default('change_me_to_a_random_string_in_production_so_it_has_50_chars_min') }}"
         AUTHENTIK_ERROR_REPORTING__ENABLED = "true"
       }
 
@@ -123,7 +123,7 @@ job "authentik" {
         AUTHENTIK_POSTGRESQL__USER = "{{ authentik_db_user | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__NAME = "{{ authentik_db_name | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__PASSWORD = "{{ authentik_db_password | default('authentik_password') }}"
-        AUTHENTIK_SECRET_KEY = "{{ authentik_secret_key | default('change_me_to_a_random_string_in_production') }}"
+        AUTHENTIK_SECRET_KEY = "{{ authentik_secret_key | default('change_me_to_a_random_string_in_production_so_it_has_50_chars_min') }}"
         AUTHENTIK_ERROR_REPORTING__ENABLED = "true"
       }
 


### PR DESCRIPTION
Fixes a deployment issue where Authentik containers crash on startup due to a secret key that is too short. The fallback string in the Nomad template has been extended from 42 to 62 characters to meet Authentik's 50-character minimum requirement.

---
*PR created automatically by Jules for task [16764954769429616292](https://jules.google.com/task/16764954769429616292) started by @LokiMetaSmith*