### PR TITLE
Add Gemma 4 31B to Council Tool OpenRouter Models

### DIFF
--- a/pipecatapp/tools/council_tool.py
+++ b/pipecatapp/tools/council_tool.py
@@ -19,7 +19,8 @@ class CouncilTool:
         self.openrouter_models = [
             "openai/gpt-4-turbo",
             "anthropic/claude-3-opus",
-            "google/gemini-pro-1.5"
+            "google/gemini-pro-1.5",
+            "google/gemma-4-31b-it"
         ] if self.openrouter_api_key else []
 
     async def _discover_local_experts(self) -> Dict[str, str]:


### PR DESCRIPTION
Adds 'google/gemma-4-31b-it' to the hardcoded `openrouter_models` list in `pipecatapp/tools/council_tool.py`.

---
*PR created automatically by Jules for task [13094405521589651873](https://jules.google.com/task/13094405521589651873) started by @LokiMetaSmith*