### PR TITLE
fix: generate and inject Authentik secrets and hosts via Consul

### DIFF
--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -22,6 +22,27 @@
     recurse: yes
   become: yes
 
+- name: Check if Authentik secret key exists in Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ consul_http_port | default(8500) }}/v1/kv/authentik/secret-key"
+    method: GET
+    status_code: [200, 404]
+  register: authentik_consul_key
+  ignore_errors: yes
+
+- name: Generate Authentik secret key
+  ansible.builtin.command: openssl rand -hex 32
+  register: authentik_generated_key
+  when: authentik_consul_key is not failed and authentik_consul_key.status == 404
+
+- name: Publish Authentik secret key to Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ consul_http_port | default(8500) }}/v1/kv/authentik/secret-key"
+    method: PUT
+    body: "{{ authentik_generated_key.stdout }}"
+    status_code: [200, 201]
+  when: authentik_consul_key is not failed and authentik_consul_key.status == 404
+
 - name: Template Authentik Nomad job
   ansible.builtin.template:
     src: authentik.nomad.j2

--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -71,13 +71,20 @@ job "authentik" {
         ]
       }
 
+      template {
+        data = <<EOH
+AUTHENTIK_SECRET_KEY="{{ '{{' }} key "authentik/secret-key" {{ '}}' }}"
+AUTHENTIK_REDIS__HOST="{{ '{{' }} range service "redis" {{ '}}' }}{{ '{{' }} .Address {{ '}}' }}{{ '{{' }} end {{ '}}' }}"
+AUTHENTIK_POSTGRESQL__HOST="{{ '{{' }} range service "postgres" {{ '}}' }}{{ '{{' }} .Address {{ '}}' }}{{ '{{' }} end {{ '}}' }}"
+EOH
+        destination = "secrets/authentik.env"
+        env         = true
+      }
+
       env {
-        AUTHENTIK_REDIS__HOST = "127.0.0.1"
-        AUTHENTIK_POSTGRESQL__HOST = "127.0.0.1"
         AUTHENTIK_POSTGRESQL__USER = "{{ authentik_db_user | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__NAME = "{{ authentik_db_name | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__PASSWORD = "{{ authentik_db_password | default('authentik_password') }}"
-        AUTHENTIK_SECRET_KEY = "{{ authentik_secret_key | default('change_me_to_a_random_string_in_production_so_it_has_50_chars_min') }}"
         AUTHENTIK_ERROR_REPORTING__ENABLED = "true"
       }
 
@@ -117,13 +124,20 @@ job "authentik" {
         ]
       }
 
+      template {
+        data = <<EOH
+AUTHENTIK_SECRET_KEY="{{ '{{' }} key "authentik/secret-key" {{ '}}' }}"
+AUTHENTIK_REDIS__HOST="{{ '{{' }} range service "redis" {{ '}}' }}{{ '{{' }} .Address {{ '}}' }}{{ '{{' }} end {{ '}}' }}"
+AUTHENTIK_POSTGRESQL__HOST="{{ '{{' }} range service "postgres" {{ '}}' }}{{ '{{' }} .Address {{ '}}' }}{{ '{{' }} end {{ '}}' }}"
+EOH
+        destination = "secrets/authentik.env"
+        env         = true
+      }
+
       env {
-        AUTHENTIK_REDIS__HOST = "127.0.0.1"
-        AUTHENTIK_POSTGRESQL__HOST = "127.0.0.1"
         AUTHENTIK_POSTGRESQL__USER = "{{ authentik_db_user | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__NAME = "{{ authentik_db_name | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__PASSWORD = "{{ authentik_db_password | default('authentik_password') }}"
-        AUTHENTIK_SECRET_KEY = "{{ authentik_secret_key | default('change_me_to_a_random_string_in_production_so_it_has_50_chars_min') }}"
         AUTHENTIK_ERROR_REPORTING__ENABLED = "true"
       }
 


### PR DESCRIPTION
This commit addresses the issue of Authentik crashing on startup due to short default keys or hardcoded URIs.

1. Updates `ansible/roles/authentik/tasks/main.yml` to securely generate a 64-character secret key and store it in the Consul Key-Value store if it does not already exist.
2. Modifies `ansible/roles/authentik/templates/authentik.nomad.j2` to retrieve the `AUTHENTIK_SECRET_KEY` securely via a Consul `template` block using the `key` function.
3. Modifies the Nomad job template to use Consul service discovery (`range service`) to dynamically resolve the IP addresses for both Redis and PostgreSQL instead of hardcoding `127.0.0.1`.