### PR TITLE
fix: Update Authentik Nomad job to use Consul DNS for dependencies

### DIFF
--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -29,6 +29,17 @@ job "authentik" {
         ports = ["redis"]
       }
 
+      service {
+        name = "redis"
+        port = "redis"
+        check {
+          name     = "alive"
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
       resources {
         cpu    = 100
         memory = 128
@@ -44,6 +55,17 @@ job "authentik" {
         volumes = [
           "{{ nomad_volumes_dir }}/authentik/postgres:/var/lib/postgresql/data"
         ]
+      }
+
+      service {
+        name = "postgres"
+        port = "postgres"
+        check {
+          name     = "alive"
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
       }
 
       env {
@@ -74,8 +96,8 @@ job "authentik" {
       template {
         data = <<EOH
 AUTHENTIK_SECRET_KEY="{{ '{{' }} key "authentik/secret-key" {{ '}}' }}"
-AUTHENTIK_REDIS__HOST="{{ '{{' }} range service "redis" {{ '}}' }}{{ '{{' }} .Address {{ '}}' }}{{ '{{' }} end {{ '}}' }}"
-AUTHENTIK_POSTGRESQL__HOST="{{ '{{' }} range service "postgres" {{ '}}' }}{{ '{{' }} .Address {{ '}}' }}{{ '{{' }} end {{ '}}' }}"
+AUTHENTIK_REDIS__HOST="redis.service.consul"
+AUTHENTIK_POSTGRESQL__HOST="postgres.service.consul"
 EOH
         destination = "secrets/authentik.env"
         env         = true
@@ -127,8 +149,8 @@ EOH
       template {
         data = <<EOH
 AUTHENTIK_SECRET_KEY="{{ '{{' }} key "authentik/secret-key" {{ '}}' }}"
-AUTHENTIK_REDIS__HOST="{{ '{{' }} range service "redis" {{ '}}' }}{{ '{{' }} .Address {{ '}}' }}{{ '{{' }} end {{ '}}' }}"
-AUTHENTIK_POSTGRESQL__HOST="{{ '{{' }} range service "postgres" {{ '}}' }}{{ '{{' }} .Address {{ '}}' }}{{ '{{' }} end {{ '}}' }}"
+AUTHENTIK_REDIS__HOST="redis.service.consul"
+AUTHENTIK_POSTGRESQL__HOST="postgres.service.consul"
 EOH
         destination = "secrets/authentik.env"
         env         = true

--- a/test_authentik.yaml
+++ b/test_authentik.yaml
@@ -1,0 +1,7 @@
+- hosts: all
+  become: yes
+  vars:
+    target_user: "root"
+  tasks:
+    - import_role:
+        name: authentik


### PR DESCRIPTION
Fixes the issue where the Authentik Nomad job fails to start and reaches a progress deadline due to empty database connection strings.

The original Nomad template used `{{ range service "redis" }}` within a `consul-template` block to find the Redis and Postgres IPs. However, because `redis` and `postgres` weren't registered as services with Nomad/Consul within their task definitions, the range loop returned nothing. This resulted in empty host IPs in the generated environment file, causing the Authentik containers to crash instantly on boot.

This fix:
1. Adds `service` blocks with health checks for `redis` and `postgres` in the Nomad job template so they register with Consul.
2. Updates the `authentik.env` template to use standard Consul DNS (`redis.service.consul` and `postgres.service.consul`) instead of dynamic template ranges, which is a more resilient pattern for these internal service connections.

---
*PR created automatically by Jules for task [16822849981466525528](https://jules.google.com/task/16822849981466525528) started by @LokiMetaSmith*