### PR TITLE
Fix Debian installer freezing on network detection

### DIFF
--- a/os-image/build_iso.sh
+++ b/os-image/build_iso.sh
@@ -95,7 +95,7 @@ lb config \
   --debian-installer live \
   --win32-loader false \
   --bootappend-live "boot=live components quiet splash nomodeset locales=en_US.UTF-8 keyboard-layouts=us live-config.username=pipecatapp live-config.user-fullname=PipecatApp" \
-  --bootappend-install "auto=true priority=critical file=/preseed.cfg nomodeset"
+  --bootappend-install "auto=true priority=critical file=/preseed.cfg nomodeset netcfg/choose_interface=auto"
 
 echo "=== Injecting project files ==="
 # Explicitly install live-config inside the chroot so autologin functions correctly


### PR DESCRIPTION
Fixes an issue where the Debian image installation process hangs or freezes at the "detect network connection" step (typically waiting for user input during an unattended install). The patch adds `netcfg/choose_interface=auto` to the `--bootappend-install` configuration in the `build_iso.sh` script, which is the standard and recommended kernel boot parameter to instruct the installer to automatically select the network interface.

---
*PR created automatically by Jules for task [17741058449307015828](https://jules.google.com/task/17741058449307015828) started by @LokiMetaSmith*