### PR TITLE
feat: Add unblocked issues workflow

### DIFF
--- a/.github/workflows/unblocked-issues.yml
+++ b/.github/workflows/unblocked-issues.yml
@@ -1,0 +1,57 @@
+name: Work on Unblocked Issues
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  detect-unblocked:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    outputs:
+      matrix: ${{ steps.finder.outputs.issues }}
+      found: ${{ steps.finder.outputs.has_issues }}
+    steps:
+      - name: Find Unblocked Issues
+        id: finder
+        uses: google-labs-code/on-unblocked@v1
+
+  implement:
+    needs: detect-unblocked
+    if: needs.detect-unblocked.outputs.found == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    strategy:
+      matrix:
+        issue-number: ${{ fromJson(needs.detect-unblocked.outputs.matrix) }}
+
+    steps:
+      - name: Get issue details
+        id: get_issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ matrix.issue-number }}
+            });
+            return issue.data;
+
+      - name: Invoke Jules on Unblocked Issue
+        # SECURITY: Only allow trusted users' issues
+        if: ${{ contains(fromJSON('["your-username", "trusted-collaborator"]'), fromJson(steps.get_issue.outputs.result).user.login) }}
+        uses: google-labs-code/jules-invoke@v1
+        with:
+          prompt: |
+            An issue has been unblocked and is ready for implementation:
+
+            ## ${{ fromJson(steps.get_issue.outputs.result).title }}
+
+            ${{ fromJson(steps.get_issue.outputs.result).body }}
+
+            Please implement this feature following the project's coding standards.
+          jules_api_key: ${{ secrets.JULES_API_KEY }}

--- a/ISSUES/2024-04-16-test-unblocked-issues-workflow.md
+++ b/ISSUES/2024-04-16-test-unblocked-issues-workflow.md
@@ -1,0 +1,9 @@
+# Test Unblocked Issues Workflow
+
+## Context
+A new GitHub Actions workflow has been added in `.github/workflows/unblocked-issues.yml` to automatically invoke an AI agent (Jules) when issues are unblocked (closed). The `auto-merge.yml` workflow requires any pull request to be accompanied by a new issue definition in the `ISSUES/` directory to merge automatically. We also need to ensure that the unblocked-issues workflow correctly functions as intended, triggering off `issues: closed` events and reading the properties properly.
+
+## Acceptance Criteria
+- Verify the behavior of `.github/workflows/unblocked-issues.yml` by monitoring a closed issue in a testing environment or via a mock event payload to `on-unblocked@v1`.
+- Ensure Jules is correctly invoked with the right prompt variables when an authorized user closes an issue.
+- Consider refactoring `.github/workflows/unblocked-issues.yml` to support different target branches or configurable settings (like the trusted user list).


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow (`unblocked-issues.yml`) that triggers when an issue is closed. It extracts the issue details and uses the `jules-invoke` action to prompt the AI agent to implement the unblocked feature.\n\nAlso included is a required `ISSUES/` documentation file to allow auto-merging according to the continuous motion guidelines.

---
*PR created automatically by Jules for task [7954293516255408346](https://jules.google.com/task/7954293516255408346) started by @LokiMetaSmith*