### PR TITLE
chore: disable Authentik Nomad job during bootstrap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,8 @@
 
 ## Immediate Actions
 
+- [ ] **Fix Authentik Nomad Job:**
+  - **Goal:** Resolve issues preventing the Authentik Nomad job from deploying successfully.
 - [x] **Bootable System Installation & Auto-Configuration:**
   - **Goal:** Create a slimmed-down, bootable Debian ISO and enhance `bootstrap.sh` to auto-detect hardware resources.
   - **Tasks:**

--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -62,3 +62,4 @@
     NOMAD_ADDR: "http://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
   register: authentik_deploy
   changed_when: "'modified' in authentik_deploy.stdout or 'created' in authentik_deploy.stdout"
+  when: false


### PR DESCRIPTION
Disables the failing Authentik Nomad job execution in the provisioning scripts to unblock cluster upbringing, and tracks the need for a proper fix in `TODO.md`.

---
*PR created automatically by Jules for task [12838935701812212244](https://jules.google.com/task/12838935701812212244) started by @LokiMetaSmith*