### PR TITLE
fix: resolve forgejo port collision with pds

### DIFF
--- a/ansible/roles/forgejo/templates/forgejo.nomad.j2
+++ b/ansible/roles/forgejo/templates/forgejo.nomad.j2
@@ -8,10 +8,10 @@ job "forgejo" {
     network {
       mode = "host"
       port "http" {
-        static = 3000
+        static = {{ forgejo_http_port | default(3002) }}
       }
       port "ssh" {
-        static = 2222
+        static = {{ forgejo_ssh_port | default(3022) }}
       }
     }
 

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -205,6 +205,8 @@ pds_plc_rotation_key_k256_private_key_hex: "000000000000000000000000000000000000
 pds_data_directory: "/opt/pds"
 pds_blobstore_disk_location: "/opt/pds/blocks"
 pds_port: 3000
+forgejo_http_port: 3002
+forgejo_ssh_port: 3022
 
 # -- OpenWorkers Configuration --
 openworkers_enabled: true


### PR DESCRIPTION
The `forgejo` Nomad job was failing to reach a healthy state because its hardcoded HTTP port (`3000`) collided with the `pds_port` which was also defined as `3000` in `group_vars/all.yaml`. This fix introduces `forgejo_http_port` and `forgejo_ssh_port` variables into the Ansible group variables, assigning them non-colliding values, and updates the `forgejo.nomad.j2` template to dynamically bind to these configurable ports.

---
*PR created automatically by Jules for task [4170618927959001849](https://jules.google.com/task/4170618927959001849) started by @LokiMetaSmith*