### PR TITLE
docs: Evaluate Cloudflare Artifacts and propose local ArtifactFS alternative

### DIFF
--- a/ISSUES/CLOUDFLARE_ARTIFACTS_EVALUATION.md
+++ b/ISSUES/CLOUDFLARE_ARTIFACTS_EVALUATION.md
@@ -1,0 +1,16 @@
+# Follow-up: Local Implementation of Lazy-Hydrating Git Clones
+
+## Context
+During the evaluation of Cloudflare Artifacts (`docs/CLOUDFLARE_ARTIFACTS_EVALUATION.md`), it was determined that while the managed service is not suitable for our offline-first architecture, the concept of **ArtifactFS** (lazy-hydrating, blobless Git clones) is highly valuable for reducing agent sandbox startup times.
+
+## Task Description
+Investigate the feasibility of implementing a local, self-hosted equivalent to ArtifactFS for the Pipecat cluster.
+
+### Objectives
+1. Research existing open-source tools for lazy Git hydration (e.g., `git-vfs`, `Scalar`, or custom FUSE filesystems).
+2. Evaluate integration with the existing self-hosted Forgejo instance.
+3. Prototype a lightweight daemon that can perform blobless clones and hydrate file contents on-demand when accessed by an agent inside a Nomad sandbox.
+
+### Acceptance Criteria
+- A technical design document outlining how to achieve fast, lazy Git clones locally.
+- A proof-of-concept script or service demonstrating the functionality against a local Forgejo repository.

--- a/docs/CLOUDFLARE_ARTIFACTS_EVALUATION.md
+++ b/docs/CLOUDFLARE_ARTIFACTS_EVALUATION.md
@@ -1,0 +1,30 @@
+# Cloudflare Artifacts Evaluation
+
+## Overview
+Cloudflare recently announced [Artifacts](https://blog.cloudflare.com/artifacts-git-for-agents-beta/), a versioned file system that speaks Git, designed specifically for AI agents. It leverages Cloudflare Workers and Durable Objects to provide an instantly-available, highly scalable Git API backend.
+
+## Feature Analysis
+
+### Pros for AI Agents
+- **Git Native**: Agents inherently understand Git since it's prevalent in their training data.
+- **Speed**: ArtifactFS offers rapid blob-less cloning to reduce sandbox startup times.
+- **Scalability**: Can instantly create millions of repositories for individual agent sessions.
+- **State Management**: Excellent for persisting session states, configuration, and allowing point-in-time rollbacks ("time-travel").
+
+### Cons & Compatibility with Pipecat Architecture
+The Pipecat architecture emphasizes a **bare-metal, offline-capable** approach deployed via Nomad and Consul on legacy hardware.
+
+- **Offline Capability**: Cloudflare Artifacts fundamentally requires an internet connection to Cloudflare's edge network. This contradicts the project's offline requirement (e.g., using Consul KV for offline SSH key distribution).
+- **Self-Hosting**: Pipecat currently uses a self-hosted instance of Forgejo (`codeberg.org/forgejo/forgejo:9-rootless`) deployed via Nomad to handle Git operations internally. Cloudflare Artifacts is a proprietary managed service.
+- **Vendor Lock-in**: Relying on Cloudflare Workers and Durable Objects tightly couples the agent's memory and state management to Cloudflare's ecosystem, moving away from the open, self-hosted ethos of the project.
+
+## Conclusion
+
+**Is it worth adding? No.**
+
+While Cloudflare Artifacts provides an innovative and highly optimized solution for cloud-native agent frameworks, it fundamentally conflicts with the core architectural principles of this project:
+1. It breaks the offline-first/air-gapped capability.
+2. It introduces a managed external dependency, conflicting with the bare-metal, self-hosted deployment model (Nomad/Consul).
+3. The project already successfully implements local Git repository management via Forgejo.
+
+The concepts introduced by Cloudflare ArtifactFS (like lazy-hydrating Git clones) are valuable and could potentially be explored for custom, local implementations in the future, but the service itself is not a fit for this specific repository.


### PR DESCRIPTION
This PR adds an evaluation of the newly announced Cloudflare Artifacts service. Based on the analysis, the managed service is rejected as it fundamentally conflicts with the project's bare-metal, offline-capable architecture (which already utilizes a self-hosted Forgejo instance via Nomad). 

However, the core concept of "ArtifactFS" (lazy-hydrating blobless Git clones to speed up agent sandbox startup times) is highly valuable. A follow-up issue is included to research implementing this pattern locally within the cluster.

---
*PR created automatically by Jules for task [7684438249230958324](https://jules.google.com/task/7684438249230958324) started by @LokiMetaSmith*