### PR TITLE
fix: add CONSUL_HTTP_TOKEN to Authentik nomad tasks

### DIFF
--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -104,6 +104,7 @@ EOH
       }
 
       env {
+        CONSUL_HTTP_TOKEN = "{{ consul_bootstrap_token | default('') }}"
         AUTHENTIK_POSTGRESQL__USER = "{{ authentik_db_user | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__NAME = "{{ authentik_db_name | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__PASSWORD = "{{ authentik_db_password | default('authentik_password') }}"
@@ -157,6 +158,7 @@ EOH
       }
 
       env {
+        CONSUL_HTTP_TOKEN = "{{ consul_bootstrap_token | default('') }}"
         AUTHENTIK_POSTGRESQL__USER = "{{ authentik_db_user | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__NAME = "{{ authentik_db_name | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__PASSWORD = "{{ authentik_db_password | default('authentik_password') }}"


### PR DESCRIPTION
When Consul ACLs are enabled, Nomad tasks attempting to read from the Consul KV store (via the `template` block) or perform other Consul operations may fail silently or cause health check failures if the required Consul token is not provided. This caused the Authentik server and worker tasks to fail their health checks and hit the progress deadline timeout.

This adds `CONSUL_HTTP_TOKEN` to the `env` block of the `server` and `worker` tasks within the Authentik Nomad job configuration.