### PR TITLE
Ensure SSH keys are initialized for tools that require them

### DIFF
--- a/pipecatapp/tools/ansible_tool.py
+++ b/pipecatapp/tools/ansible_tool.py
@@ -1,6 +1,7 @@
 import subprocess
 import os
 from pipecatapp.utils.command_runner import CommandRunner
+from pipecatapp.utils.ssh_utils import ensure_ssh_keys_initialized
 try:
     from ..secret_manager import secret_manager
 except ImportError:
@@ -24,6 +25,7 @@ class Ansible_Tool:
         self.name = "ansible_tool"
         # The main playbook synchronizes the repo to /opt/cluster-infra on all nodes.
         self.project_root = "/opt/cluster-infra"
+        ensure_ssh_keys_initialized()
 
     def run_playbook(self, playbook: str = 'playbook.yaml', limit: str = None, tags: str = None, extra_vars: dict = None) -> str:
         """Runs an Ansible playbook to provision or manage nodes in the cluster.

--- a/pipecatapp/tools/git_tool.py
+++ b/pipecatapp/tools/git_tool.py
@@ -1,6 +1,7 @@
 import subprocess
 import os
 from pipecatapp.utils.command_runner import CommandRunner
+from pipecatapp.utils.ssh_utils import ensure_ssh_keys_initialized
 
 class Git_Tool:
     """A tool for interacting with Git repositories.
@@ -21,6 +22,7 @@ class Git_Tool:
             self.root_dir = os.path.realpath(root_dir)
         else:
             self.root_dir = os.path.realpath(os.getcwd())
+        ensure_ssh_keys_initialized()
 
     def _validate_path(self, path: str) -> str:
         """Ensures the path is within the root directory."""

--- a/pipecatapp/tools/spec_loader_tool.py
+++ b/pipecatapp/tools/spec_loader_tool.py
@@ -6,6 +6,7 @@ import glob
 import re
 from typing import List, Optional
 from pipecatapp.utils.command_runner import CommandRunner
+from pipecatapp.utils.ssh_utils import ensure_ssh_keys_initialized
 
 class SpecLoaderTool:
     """
@@ -22,6 +23,7 @@ class SpecLoaderTool:
                 os.makedirs(self.work_dir)
             except OSError as e:
                 self.logger.error(f"Failed to create spec directory: {e}")
+        ensure_ssh_keys_initialized()
 
     def _validate_protocol(self, url: str):
         """Validates that the URL uses a safe protocol."""

--- a/pipecatapp/tools/ssh_tool.py
+++ b/pipecatapp/tools/ssh_tool.py
@@ -1,6 +1,7 @@
 import paramiko
 import os
 import logging
+from pipecatapp.utils.ssh_utils import ensure_ssh_keys_initialized
 
 class SSH_Tool:
     """A tool for executing commands on a remote machine via SSH.
@@ -17,6 +18,7 @@ class SSH_Tool:
         """Initializes the SSH_Tool."""
         self.description = "Execute a command on a remote machine via SSH."
         self.name = "ssh_tool"
+        ensure_ssh_keys_initialized()
 
     def run_command(self, host: str, username: str, command: str, key_filename: str = None, password: str = None) -> str:
         """Executes a command on a remote machine via SSH.

--- a/pipecatapp/utils/ssh_utils.py
+++ b/pipecatapp/utils/ssh_utils.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+
+def ensure_ssh_keys_initialized() -> None:
+    """
+    Ensures that an SSH key pair exists for the current user.
+    If it doesn't exist, generates a new RSA key pair.
+    """
+    ssh_dir = os.path.expanduser("~/.ssh")
+    os.makedirs(ssh_dir, exist_ok=True, mode=0o700)
+    key_path = os.path.join(ssh_dir, "id_rsa")
+
+    if not os.path.exists(key_path):
+        try:
+            subprocess.run(
+                ["ssh-keygen", "-t", "rsa", "-b", "4096", "-f", key_path, "-N", "", "-q"],
+                check=True,
+                capture_output=True
+            )
+        except subprocess.CalledProcessError as e:
+            # We log or print it; for now, print is fine if logger isn't injected.
+            print(f"Error generating SSH key: {e.stderr.decode()}")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -43,7 +43,8 @@ modules_to_mock = [
     'faster_whisper',
     'piper',
     'piper.voice',
-    'daily'
+    'daily',
+
 ]
 
 def mock_module_if_missing(module_name):

--- a/tests/unit/test_git_tool.py
+++ b/tests/unit/test_git_tool.py
@@ -4,14 +4,14 @@ import os
 from unittest.mock import patch, MagicMock
 
 # Add tools directory to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'ansible', 'roles', 'pipecatapp', 'files', 'tools')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp', 'tools')))
 
 from git_tool import Git_Tool
 
 @pytest.fixture
 def git_tool():
     # Mock os.path.isdir to always return True for the tests
-    with patch('os.path.isdir', return_value=True):
+    with patch('os.path.isdir', return_value=True), patch('git_tool.ensure_ssh_keys_initialized'):
         yield Git_Tool()
 
 @patch("pipecatapp.utils.command_runner.CommandRunner.run")
@@ -101,7 +101,7 @@ def test_command_failed(mock_run, git_tool):
 
 def test_directory_not_found():
     """Test handling of a non-existent working directory."""
-    with patch('os.path.isdir', return_value=False):
+    with patch('os.path.isdir', return_value=False), patch('git_tool.ensure_ssh_keys_initialized'):
         tool = Git_Tool()
         result = tool.status("non_existent_dir")
         assert "Error: Working directory" in result and "non_existent_dir" in result

--- a/tests/unit/test_ssh_tool.py
+++ b/tests/unit/test_ssh_tool.py
@@ -4,13 +4,14 @@ import os
 from unittest.mock import patch, MagicMock
 
 # Add tools directory to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'ansible', 'roles', 'pipecatapp', 'files', 'tools')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp', 'tools')))
 
 from ssh_tool import SSH_Tool
 
 @pytest.fixture
 def ssh_tool():
-    return SSH_Tool()
+    with patch('ssh_tool.ensure_ssh_keys_initialized'):
+        return SSH_Tool()
 
 @patch('ssh_tool.paramiko')
 def test_run_command_with_key_success(mock_paramiko, ssh_tool):


### PR DESCRIPTION
Creates a utility to initialize an SSH keypair, and calls it on initialization for the tools that use them.

---
*PR created automatically by Jules for task [11734834942598049067](https://jules.google.com/task/11734834942598049067) started by @LokiMetaSmith*