### PR TITLE
feat: integrate ssh-import-id for github ssh key injection

### DIFF
--- a/ansible/roles/common-tools/tasks/main.yaml
+++ b/ansible/roles/common-tools/tasks/main.yaml
@@ -28,3 +28,10 @@
     port: '60000:61000'
     proto: udp
   become: yes
+
+- name: Import GitHub SSH keys for specified users
+  ansible.builtin.command: ssh-import-id "gh:{{ item }}"
+  loop: "{{ github_ssh_users }}"
+  when: github_ssh_users | length > 0
+  become: yes
+  become_user: "{{ target_user }}"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -26,6 +26,7 @@ show_help() {
     echo "  --controller-ip <ip>         Required if --role is 'worker'. IP address of the controller node."
     echo "  --tags <tags>                Comma-separated list of Ansible tags to run."
     echo "  --user <user>                Specify the target user for Ansible. Default: pipecatapp."
+    echo "  --github-ssh-user <user>     Specify a GitHub username to import SSH keys for. Can be used multiple times."
     echo "  --purge-jobs                 Stop and purge all running Nomad jobs."
     echo "  --clean-git                  Clean the repository of all untracked files (interactive prompt)."
     echo "  --system-cleanup             Perform a full system cleanup (Purge Jobs, Clean System, Clean Git), with interactive prompts."
@@ -301,6 +302,13 @@ for ((i=0; i<${#ARGS[@]}; i++)); do
             if [[ -n "$NEXT_ARG" && ! "$NEXT_ARG" =~ ^- ]]; then
                 ROLE="$NEXT_ARG"
                 PROCESSED_ARGS+=("--role" "$ROLE")
+                SKIP_NEXT=true
+            fi
+            ;;
+        --github-ssh-user)
+            NEXT_ARG="${ARGS[$((i+1))]}"
+            if [[ -n "$NEXT_ARG" && ! "$NEXT_ARG" =~ ^- ]]; then
+                PROCESSED_ARGS+=("--github-ssh-user" "$NEXT_ARG")
                 SKIP_NEXT=true
             fi
             ;;

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -166,6 +166,9 @@ paperless_port: 8010
 target_user: ubuntu
 target_user_home: "/home/{{ target_user }}"
 
+# GitHub usernames to automatically import SSH keys for via ssh-import-id
+github_ssh_users: []
+
 # --- Exo Configuration ---
 # By default, Exo is disabled. To enable it, set this to true.
 exo_enable: false

--- a/os-image/build_iso.sh
+++ b/os-image/build_iso.sh
@@ -100,7 +100,7 @@ lb config \
 echo "=== Injecting project files ==="
 # Explicitly install live-config inside the chroot so autologin functions correctly
 mkdir -p config/package-lists
-echo "live-boot live-config live-config-systemd" > config/package-lists/live.list.chroot
+echo "live-boot live-config live-config-systemd ssh-import-id" > config/package-lists/live.list.chroot
 
 # Ensure the root of the repo is copied to /opt/pipecat-cluster
 # The `lb build` command automatically includes files placed in `config/includes.chroot/`

--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -461,6 +461,7 @@ def main():
     parser.add_argument("--controller-ip", help="IP of the controller (required for workers)")
     parser.add_argument("--tags", help="Ansible tags to run")
     parser.add_argument("--user", default="pipecatapp", dest="target_user", help="Target user for Ansible")
+    parser.add_argument("--github-ssh-user", action="append", default=[], help="GitHub username to import SSH keys for. Can be used multiple times.")
     parser.add_argument("--debug", action="store_true", help="Enable verbose logging (Legacy flag)")
     parser.add_argument("--verbose", type=int, default=0, help="Verbosity level (0-4)")
     parser.add_argument("--continue", action="store_true", dest="continue_run", help="Resume from last state")
@@ -508,6 +509,9 @@ def main():
     extra_vars = {
         "target_user": args.target_user
     }
+
+    if args.github_ssh_user:
+        extra_vars["github_ssh_users"] = json.dumps(args.github_ssh_user)
 
     if args.role == "worker":
         extra_vars["controller_ip"] = args.controller_ip


### PR DESCRIPTION
Implemented support for `ssh-import-id` to automatically retrieve and install SSH keys from specified GitHub users during the system bootstrap and provisioning process. The tool is installed into the generated base OS image and can be configured via runtime arguments or `group_vars`.

---
*PR created automatically by Jules for task [3037776315455055887](https://jules.google.com/task/3037776315455055887) started by @LokiMetaSmith*