### PR TITLE
Fix: Configurable memory limits for Authentik to prevent OOM

### DIFF
--- a/ansible/roles/authentik/defaults/main.yml
+++ b/ansible/roles/authentik/defaults/main.yml
@@ -1,2 +1,4 @@
 nomad_volumes_dir: /opt/nomad/volumes
 nomad_jobs_dir: /opt/nomad/jobs
+authentik_server_memory: 2048
+authentik_worker_memory: 1024

--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -129,7 +129,7 @@ EOH
 
       resources {
         cpu    = 500
-        memory = 512
+        memory = {{ authentik_server_memory | default(2048) }}
       }
     }
 
@@ -166,7 +166,7 @@ EOH
 
       resources {
         cpu    = 500
-        memory = 512
+        memory = {{ authentik_worker_memory | default(1024) }}
       }
     }
   }


### PR DESCRIPTION
Increased Authentik memory limit to prevent gunicorn out-of-memory errors and made it configurable via variables.

---
*PR created automatically by Jules for task [17565834686467732993](https://jules.google.com/task/17565834686467732993) started by @LokiMetaSmith*