### PR TITLE
feat: default to running benchmarks on new setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ os-image/config/package-lists/live.list.chroot
 os-image/config/package-lists/syslinux-utils.list.chroot
 os-image/config/includes.chroot/opt/
 \nautoloop-results/
+llama_benchmarks.jsonl

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -200,6 +200,12 @@
     NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port }}"
   when: build_llama_cpp
 
+- name: Check if benchmark log file exists
+  ansible.builtin.stat:
+    path: /var/log/llama_benchmarks.jsonl
+  register: benchmark_log_stat
+  become: yes
+
 - name: Run model benchmarking if enabled
   block:
     - name: Prepare for model benchmarking
@@ -227,7 +233,7 @@
       loop: "{{ all_models_to_benchmark }}"
       loop_control:
         loop_var: model_item
-  when: run_benchmarks | default(false) | bool
+  when: run_benchmarks | default(false) | bool or not benchmark_log_stat.stat.exists
 
 - name: Read benchmark log file
   ansible.builtin.slurp:


### PR DESCRIPTION
Update benchmark logic to run by default on new setups

- Added check for `/var/log/llama_benchmarks.jsonl` in the `llama_cpp` ansible role.
- If the log does not exist, benchmarks run by default even without the `--benchmark` flag.
- The `--benchmark` flag continues to work as an explicit override.
- Ignored `llama_benchmarks.jsonl` in `.gitignore` to avoid accidental local commits.

---
*PR created automatically by Jules for task [14153174053505303637](https://jules.google.com/task/14153174053505303637) started by @LokiMetaSmith*