### PR TITLE
Fix SSH Key Import to Correct User Account

### DIFF
--- a/ansible/roles/common-tools/tasks/main.yaml
+++ b/ansible/roles/common-tools/tasks/main.yaml
@@ -29,9 +29,19 @@
     proto: udp
   become: yes
 
+- name: Ensure .ssh directory exists for user
+  ansible.builtin.file:
+    path: /home/user/.ssh
+    state: directory
+    owner: user
+    group: user
+    mode: '0700'
+  become: yes
+  when: github_ssh_users | length > 0
+
 - name: Import GitHub SSH keys for specified users
-  ansible.builtin.command: ssh-import-id "gh:{{ item }}"
+  ansible.builtin.command: ssh-import-id -o /home/user/.ssh/authorized_keys "gh:{{ item }}"
   loop: "{{ github_ssh_users }}"
   when: github_ssh_users | length > 0
   become: yes
-  become_user: "{{ target_user }}"
+  become_user: user

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -163,7 +163,7 @@ enable_paperless: true
 paperless_port: 8010
 
 # The default user for remote connections and service execution.
-target_user: ubuntu
+target_user: pipecatapp
 target_user_home: "/home/{{ target_user }}"
 
 # GitHub usernames to automatically import SSH keys for via ssh-import-id


### PR DESCRIPTION
Fixes the issue where SSH keys from GitHub were incorrectly imported into the `root` account's `authorized_keys`. It accurately separates human access (`user`) from agent access (`pipecatapp`).

---
*PR created automatically by Jules for task [5246433231022991728](https://jules.google.com/task/5246433231022991728) started by @LokiMetaSmith*