### PR TITLE
Parameterize Authentik Nomad template variables

### DIFF
--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -13,7 +13,7 @@ update {
 
   group "authentik" {
     network {
-      mode = "bridge"
+      mode = "{{ authentik_network_mode | default('bridge') }}"
       port "http" {
         static = {{ authentik_http_port | default(9000) }}
         to     = 9000
@@ -35,6 +35,7 @@ update {
 
       config {
         image = "redis:7.2-alpine"
+        network_mode = "{{ authentik_network_mode | default('bridge') }}"
         ports = ["redis"]
       }
 
@@ -60,6 +61,7 @@ update {
 
       config {
         image = "postgres:15-alpine"
+        network_mode = "{{ authentik_network_mode | default('bridge') }}"
         ports = ["postgres"]
       }
 
@@ -92,6 +94,7 @@ update {
       config {
         image        = "ghcr.io/goauthentik/server:2024.2.2"
         args         = ["server"]
+        network_mode = "{{ authentik_network_mode | default('bridge') }}"
         ports        = ["http", "https"]
         volumes = [
           "{{ nomad_volumes_dir }}/authentik/media:/media",
@@ -103,8 +106,8 @@ update {
         data = <<EOH
 CONSUL_HTTP_TOKEN = "{{ consul_bootstrap_token | default('') }}"
 AUTHENTIK_SECRET_KEY="{{ '{{' }} key "authentik/secret-key" {{ '}}' }}"
-AUTHENTIK_REDIS__HOST="redis.service.consul"
-AUTHENTIK_POSTGRESQL__HOST="postgres.service.consul"
+AUTHENTIK_REDIS__HOST="{{ authentik_redis_host | default('redis.service.consul') }}"
+AUTHENTIK_POSTGRESQL__HOST="{{ authentik_postgres_host | default('postgres.service.consul') }}"
 EOH
         destination = "secrets/authentik.env"
         env         = true
@@ -123,7 +126,7 @@ EOH
         tags = [
           "traefik.enable=true",
           "traefik.http.routers.authentik.rule=Host(`authentik.service.consul`)",
-          "traefik.http.services.authentik.loadbalancer.server.port=9000"
+          "traefik.http.services.authentik.loadbalancer.server.port={{ authentik_internal_port | default(9000) }}"
         ]
       }
 
@@ -139,6 +142,7 @@ EOH
       config {
         image        = "ghcr.io/goauthentik/server:2024.2.2"
         args         = ["worker"]
+        network_mode = "{{ authentik_network_mode | default('bridge') }}"
         volumes = [
           "{{ nomad_volumes_dir }}/authentik/media:/media",
           "{{ nomad_volumes_dir }}/authentik/certs:/certs",
@@ -150,8 +154,8 @@ EOH
         data = <<EOH
 CONSUL_HTTP_TOKEN = "{{ consul_bootstrap_token | default('') }}"
 AUTHENTIK_SECRET_KEY="{{ '{{' }} key "authentik/secret-key" {{ '}}' }}"
-AUTHENTIK_REDIS__HOST="redis.service.consul"
-AUTHENTIK_POSTGRESQL__HOST="postgres.service.consul"
+AUTHENTIK_REDIS__HOST="{{ authentik_redis_host | default('redis.service.consul') }}"
+AUTHENTIK_POSTGRESQL__HOST="{{ authentik_postgres_host | default('postgres.service.consul') }}"
 EOH
         destination = "secrets/authentik.env"
         env         = true

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -50,6 +50,12 @@ traefik_https_port: 443
 traefik_api_port: 8080
 authentik_http_port: 9000
 authentik_https_port: 9443
+authentik_network_mode: "bridge"
+authentik_redis_host: "redis.service.consul"
+authentik_postgres_host: "postgres.service.consul"
+authentik_redis_port: 16379
+authentik_postgres_port: 15432
+authentik_internal_port: 9000
 beszel_agent_port: 45876
 beszel_hub_port: 8090
 statsping_http_port: 8088


### PR DESCRIPTION
Adds variables to the Authentik Nomad template and `group_vars/all.yaml` to make networking and port configuration more flexible, while explicitly keeping the correct architectural defaults (bridge mode, Consul DNS discovery).

---
*PR created automatically by Jules for task [15067294940465156487](https://jules.google.com/task/15067294940465156487) started by @LokiMetaSmith*