### PR TITLE
Add local network fallback for LLM discovery

### DIFF
--- a/ansible/roles/opencode/templates/opencode.nomad.j2
+++ b/ansible/roles/opencode/templates/opencode.nomad.j2
@@ -22,25 +22,110 @@ job "opencode" {
     task "opencode-server" {
       driver = "raw_exec"
 
+      template {
+        data = <<EOH
+import socket
+import urllib.request
+import json
+import os
+import time
+
+def scan_network_for_llms():
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(('10.255.255.255', 1))
+        local_ip = s.getsockname()[0]
+        s.close()
+    except Exception:
+        local_ip = '127.0.0.1'
+
+    ports = [11434, 8080]
+
+    # Check localhost and local ip first
+    for ip in ['127.0.0.1', local_ip]:
+        for port in ports:
+            try:
+                # Fast connection check
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(0.5)
+                res = sock.connect_ex((ip, port))
+                sock.close()
+                if res == 0:
+                    url = f"http://{ip}:{port}/v1"
+                    # simple verify
+                    try:
+                        urllib.request.urlopen(f"http://{ip}:{port}/api/tags" if port == 11434 else f"http://{ip}:{port}/health", timeout=0.5)
+                    except Exception:
+                        pass
+                    return url
+            except Exception:
+                pass
+
+    # Subnet scan
+    if local_ip != '127.0.0.1':
+        parts = local_ip.split('.')
+        base_ip = f"{parts[0]}.{parts[1]}.{parts[2]}."
+
+        for i in range(1, 255):
+            ip = f"{base_ip}{i}"
+            if ip == local_ip:
+                continue
+            for port in ports:
+                try:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    sock.settimeout(0.1)
+                    res = sock.connect_ex((ip, port))
+                    sock.close()
+                    if res == 0:
+                        url = f"http://{ip}:{port}/v1"
+                        return url
+                except Exception:
+                    pass
+    return ""
+
+def discover_from_consul():
+    try:
+        req = urllib.request.Request("http://127.0.0.1:8500/v1/health/service/llamacpp-rpc-api?passing")
+        with urllib.request.urlopen(req, timeout=2) as response:
+            if response.status == 200:
+                data = json.loads(response.read().decode())
+                if data:
+                    addr = data[0]['Service']['Address']
+                    port = data[0]['Service']['Port']
+                    return f"http://{addr}:{port}/v1"
+    except Exception:
+        pass
+    return ""
+
+def main():
+    llm_url = discover_from_consul()
+    if not llm_url:
+        import sys
+        print("No LLM in Consul, scanning network...", file=sys.stderr)
+        llm_url = scan_network_for_llms()
+
+    if llm_url:
+        print(f"export OPENAI_BASE_URL='{llm_url}'")
+        print(f"export OPENAI_API_KEY='dummy'")
+        print(f"export LLAMA_API_URL='{llm_url}'")
+
+if __name__ == "__main__":
+    main()
+EOH
+        destination = "local/discover.py"
+      }
+
       config {
         command = "/bin/sh"
         args    = [
           "-c",
-          "cd /tmp && exec {{ opencode_bin_path | default('/usr/bin/opencode') }} serve --port ${NOMAD_PORT_http} --hostname 0.0.0.0"
+          "cd /tmp && eval $(python3 ${NOMAD_TASK_DIR}/discover.py) && exec {{ opencode_bin_path | default('/usr/bin/opencode') }} serve --port ${NOMAD_PORT_http} --hostname 0.0.0.0"
         ]
       }
-
-      # Mount the cluster infrastructure directory to allow the agent to edit it
-      # Note: raw_exec runs as root/host user, so it has access to the filesystem.
-      # We just need to make sure it runs in the right directory or we pass the project path.
-      # The help says `opencode [project]`. `opencode serve` might not take a project arg directly
-      # but it probably serves the current directory or allows opening projects via API.
-      # For now, we set the working directory to the cluster infra.
 
       env {
         OPENAI_API_KEY      = "{{ openai_api_key | default('') }}"
         ANTHROPIC_API_KEY   = "{{ anthropic_api_key | default('') }}"
-        # Add other providers as needed
       }
     }
 
@@ -51,7 +136,7 @@ job "opencode" {
 
       check {
         type     = "http"
-        path     = "/global/health" # Verify health endpoint
+        path     = "/global/health"
         interval = "20s"
         timeout  = "10s"
       }

--- a/ansible/roles/tool_server/tools/council_tool.py
+++ b/ansible/roles/tool_server/tools/council_tool.py
@@ -3,6 +3,7 @@ import json
 import os
 import logging
 import aiohttp
+from pipecatapp.network_scanner import scan_network_for_llms
 from typing import List, Dict, Any, Optional
 
 class CouncilTool:
@@ -46,6 +47,13 @@ class CouncilTool:
                         logging.debug(f"Expert {expert_name} not found or error: {e}")
         except Exception as e:
             logging.error(f"Error initializing ClientSession for discovery: {e}")
+
+
+        # Fallback to local network scan if no local experts found
+        if not experts:
+            fallback_url = await scan_network_for_llms()
+            if fallback_url:
+                experts['fallback'] = fallback_url
 
         return experts
 

--- a/ansible/roles/tool_server/tools/planner_tool.py
+++ b/ansible/roles/tool_server/tools/planner_tool.py
@@ -4,6 +4,7 @@ import asyncio
 import httpx
 import os
 import re
+from pipecatapp.network_scanner import scan_network_for_llms
 
 class PlannerTool:
     """
@@ -47,7 +48,14 @@ class PlannerTool:
         if llm_base_url:
             return llm_base_url
 
+
+        # Network scan fallback
+        fallback_url = await scan_network_for_llms()
+        if fallback_url:
+            return fallback_url
+
         # Final fallback
+
         return os.getenv("LLAMA_API_URL", "http://localhost:8081/v1")
 
     async def _call_llm(self, prompt: str) -> list:

--- a/pipecatapp/app.py
+++ b/pipecatapp/app.py
@@ -20,6 +20,7 @@ import inspect
 import threading
 from contextlib import asynccontextmanager
 from collections import defaultdict
+from pipecatapp.network_scanner import scan_network_for_llms
 
 from pipecat.frames.frames import (
     Frame,
@@ -1024,6 +1025,12 @@ async def discover_services(service_names: list, consul_http_addr: str, delay=10
                 except Exception as e:
                     logging.error(f"Unexpected error discovering {service_name}: {e}")
 
+            # Fallback to local network scan before sleeping
+            fallback_url = await scan_network_for_llms()
+            if fallback_url:
+                logging.info(f"Using fallback network LLM at {fallback_url}")
+                return fallback_url
+
             logging.info(f"No healthy services found in list {service_names}, retrying in {delay} seconds...")
             await asyncio.sleep(delay)
 
@@ -1072,6 +1079,13 @@ async def discover_main_llm_service(consul_http_addr=None, delay=10):
                         logging.info(f"Consul returned empty list for {service_name} at {url}")
             except Exception as e:
                 logging.warning(f"Could not find service {service_name}: {e}")
+
+            # Fallback to local network scan
+            fallback_url = await scan_network_for_llms()
+            if fallback_url:
+                logging.info(f"Using fallback network LLM at {fallback_url}")
+                return fallback_url
+
             await asyncio.sleep(delay)
 
 # -----------------------

--- a/pipecatapp/network_scanner.py
+++ b/pipecatapp/network_scanner.py
@@ -1,0 +1,110 @@
+import socket
+import asyncio
+import logging
+import httpx
+
+logger = logging.getLogger(__name__)
+
+async def check_llm_service(ip: str, port: int, timeout: float = 0.5) -> str | None:
+    """Checks if a specific IP:Port hosts a reachable LLM service."""
+    url = f"http://{ip}:{port}"
+    try:
+        # Check port first quickly
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(ip, port),
+            timeout=timeout
+        )
+        writer.close()
+        await writer.wait_closed()
+
+        # If port is open, verify it's an LLM
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            if port == 11434:
+                # Ollama specific check
+                try:
+                    resp = await client.get(f"{url}/api/tags")
+                    if resp.status_code == 200:
+                        return f"{url}/v1" # Use OpenAI compatible endpoint for Ollama
+                except Exception:
+                    pass
+            else:
+                # Llama.cpp or other OpenAI compatible
+                try:
+                    resp = await client.get(f"{url}/v1/models")
+                    if resp.status_code == 200 and "github" not in resp.headers.get("Server", "").lower() and "github" not in resp.headers.get("x-github-request-id", "").lower():
+                         return f"{url}/v1"
+                except Exception:
+                    pass
+                try:
+                    resp = await client.get(f"{url}/health")
+                    # Make sure it's not a generic 200 from a web server
+                    if resp.status_code == 200 and "github" not in resp.headers.get("Server", "").lower() and "github" not in resp.headers.get("x-github-request-id", "").lower():
+                        return f"{url}/v1"
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+    return None
+
+def get_local_ip() -> str:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        # Doesn't have to be reachable
+        s.connect(('10.255.255.255', 1))
+        ip = s.getsockname()[0]
+    except Exception:
+        ip = '127.0.0.1'
+    finally:
+        s.close()
+    return ip
+
+async def scan_network_for_llms(timeout: float = 0.5) -> str | None:
+    """
+    Scans localhost and the local subnet for instances of Ollama or Llama.cpp.
+    Returns the first found base_url (e.g., http://192.168.1.100:11434/v1).
+    """
+    logger.info("Starting local network scan for LLM services...")
+    local_ip = get_local_ip()
+    ports = [11434, 8080] # Ollama, Llama.cpp/OpenAI
+
+    # 1. Check localhost and local IP first (fast path)
+    priority_tasks = []
+    for ip in ['127.0.0.1', local_ip]:
+        for port in ports:
+            priority_tasks.append(check_llm_service(ip, port, timeout))
+
+    priority_results = await asyncio.gather(*priority_tasks)
+    for result in priority_results:
+        if result:
+            logger.info(f"Discovered local LLM at {result}")
+            return result
+
+    # 2. Check the rest of the /24 subnet
+    if local_ip == '127.0.0.1':
+        return None
+
+    parts = local_ip.split('.')
+    base_ip = f"{parts[0]}.{parts[1]}.{parts[2]}."
+
+    logger.debug(f"Scanning subnet {base_ip}0/24")
+
+    # Batch the tasks to avoid too many open sockets at once
+    ips_to_check = [f"{base_ip}{i}" for i in range(1, 255) if f"{base_ip}{i}" != local_ip]
+
+    batch_size = 50
+    for i in range(0, len(ips_to_check), batch_size):
+        batch_ips = ips_to_check[i:i+batch_size]
+        tasks = []
+        for ip in batch_ips:
+            for port in ports:
+                tasks.append(check_llm_service(ip, port, timeout))
+
+        results = await asyncio.gather(*tasks)
+        for result in results:
+            if result:
+                logger.info(f"Discovered network LLM at {result}")
+                return result
+
+    logger.info("No local network LLMs discovered.")
+    return None

--- a/pipecatapp/tools/council_tool.py
+++ b/pipecatapp/tools/council_tool.py
@@ -5,6 +5,7 @@ import logging
 import aiohttp
 from typing import List, Dict, Any, Optional
 from pipecatapp.net_utils import format_url
+from pipecatapp.network_scanner import scan_network_for_llms
 
 class CouncilTool:
     """A tool to convene a council of AI experts (both local and external) to deliberate on a query."""
@@ -48,6 +49,13 @@ class CouncilTool:
                         logging.debug(f"Expert {expert_name} not found or error: {e}")
         except Exception as e:
             logging.error(f"Error initializing ClientSession for discovery: {e}")
+
+
+        # Fallback to local network scan if no local experts found
+        if not experts:
+            fallback_url = await scan_network_for_llms()
+            if fallback_url:
+                experts['fallback'] = fallback_url
 
         return experts
 

--- a/pipecatapp/tools/planner_tool.py
+++ b/pipecatapp/tools/planner_tool.py
@@ -4,6 +4,7 @@ import asyncio
 import httpx
 import os
 import re
+from pipecatapp.network_scanner import scan_network_for_llms
 
 class PlannerTool:
     """
@@ -28,7 +29,7 @@ class PlannerTool:
 
         # Fallback to Consul discovery
         try:
-            consul_addr = getattr(self.twin_service, 'consul_http_addr', f'http://{os.getenv("CLUSTER_IP", "127.0.0.1")}:8500')
+            consul_addr = getattr(self.twin_service, 'consul_http_addr', f'http://{os.getenv('CLUSTER_IP', '127.0.0.1')}:8500')
             service_name = app_config.get("llama_api_service_name", "llamacpp-rpc-api")
 
             async with httpx.AsyncClient() as client:
@@ -47,8 +48,15 @@ class PlannerTool:
         if llm_base_url:
             return llm_base_url
 
+
+        # Network scan fallback
+        fallback_url = await scan_network_for_llms()
+        if fallback_url:
+            return fallback_url
+
         # Final fallback
-        return os.getenv("LLAMA_API_URL", f"http://{os.getenv("CLUSTER_IP", "127.0.0.1")}:8081/v1")
+
+        return os.getenv("LLAMA_API_URL", f"http://{os.getenv('CLUSTER_IP', '127.0.0.1')}:8081/v1")
 
     async def _call_llm(self, prompt: str) -> list:
         """Calls the LLM to generate a plan."""

--- a/tests/unit/test_council_tool.py
+++ b/tests/unit/test_council_tool.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch, AsyncMock
 # Add tools directory to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'ansible', 'roles', 'pipecatapp', 'files', 'tools')))
 
-from council_tool import CouncilTool
+from pipecatapp.tools.council_tool import CouncilTool
 
 # Mock TwinService
 class MockTwinService:

--- a/tests/unit/test_planner_tool.py
+++ b/tests/unit/test_planner_tool.py
@@ -2,7 +2,7 @@ import pytest
 import json
 import os
 from unittest.mock import MagicMock, AsyncMock, patch
-from ansible.roles.pipecatapp.files.tools.planner_tool import PlannerTool
+from pipecatapp.tools.planner_tool import PlannerTool
 
 @pytest.fixture
 def mock_twin_service():
@@ -36,7 +36,7 @@ async def test_discover_llm_url_fallback(planner_tool):
     # Mock fallback to default
     url = await planner_tool._discover_llm_url()
     port = os.getenv("ROUTER_PORT", "8081")
-    assert url == f"http://localhost:{port}/v1"
+    assert url == f"http://127.0.0.1:{port}/v1"
 
 @pytest.mark.asyncio
 async def test_discover_llm_url_env_var(planner_tool):


### PR DESCRIPTION
This patch adds a fallback mechanism that automatically discovers locally-hosted LLM instances (like Ollama or Llama.cpp) running on the same network subnet when primary Consul-managed services are unavailable.

It includes:
- A fast async scanner utility in `pipecatapp/network_scanner.py` that checks standard ports `11434` and `8080`.
- Updates to core `pipecatapp` components (`app.py`, `CouncilTool`, `PlannerTool`) to gracefully degrade to these discovered instances.
- A standalone sync python script injected into the `opencode` Nomad deployment that sets `OPENAI_BASE_URL` before executing the underlying node process.

---
*PR created automatically by Jules for task [17119332754112333658](https://jules.google.com/task/17119332754112333658) started by @LokiMetaSmith*