### PR TITLE
feat: Add Opengist service

### DIFF
--- a/ansible/roles/opengist/handlers/main.yaml
+++ b/ansible/roles/opengist/handlers/main.yaml
@@ -1,0 +1,5 @@
+- name: Run Opengist Job
+  ansible.builtin.command: nomad job run /opt/nomad/jobs/opengist.nomad
+  become: yes
+  environment:
+    NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"

--- a/ansible/roles/opengist/tasks/main.yaml
+++ b/ansible/roles/opengist/tasks/main.yaml
@@ -1,0 +1,18 @@
+- name: Create Opengist data directory
+  ansible.builtin.file:
+    path: /opt/opengist/data
+    state: directory
+    mode: '0755'
+    owner: "1001"
+    group: "1001"
+  become: yes
+
+- name: Create Opengist Nomad job file
+  ansible.builtin.template:
+    src: opengist.nomad.j2
+    dest: /opt/nomad/jobs/opengist.nomad
+    owner: root
+    group: root
+    mode: '0644'
+  become: yes
+  notify: Run Opengist Job

--- a/ansible/roles/opengist/templates/opengist.nomad.j2
+++ b/ansible/roles/opengist/templates/opengist.nomad.j2
@@ -1,0 +1,66 @@
+job "opengist" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "opengist" {
+    count = 1
+
+    network {
+      mode = "host"
+      port "http" {
+        static = {{ opengist_http_port | default(6157) }}
+      }
+      port "ssh" {
+        static = {{ opengist_ssh_port | default(2222) }}
+      }
+    }
+
+    task "opengist" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/thomiceli/opengist:1.12"
+        ports = ["http", "ssh"]
+
+        volumes = [
+          "/opt/opengist/data:/opengist"
+        ]
+      }
+
+      env {
+        UID = "1001"
+        GID = "1001"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+
+      service {
+        name = "opengist-http"
+        port = "http"
+        tags = ["opengist", "git", "web"]
+
+        check {
+          type     = "http"
+          path     = "/"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      service {
+        name = "opengist-ssh"
+        port = "ssh"
+        tags = ["opengist", "git", "ssh"]
+
+        check {
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -164,9 +164,12 @@ enable_provisioning_api: true
 enable_home_assistant: true
 enable_frigate: false
 enable_paperless: true
+enable_opengist: true
 
 # Service Ports
 paperless_port: 8010
+opengist_http_port: 6157
+opengist_ssh_port: 2222
 
 # The default user for remote connections and service execution.
 target_user: pipecatapp

--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -107,6 +107,7 @@
         - openclaw
         - forgejo
         - paperless
+        - opengist
       loop_control:
         loop_var: role_name
       tags:
@@ -117,6 +118,7 @@
         - tool_server
         - forgejo
         - paperless
+        - opengist
 
     - name: Run Paddler Stack
       when: enable_paddler | default(false)


### PR DESCRIPTION
Adds the Opengist service, an open-source Github Gist clone, to allow async git repo access without needing to provide full SSH access. This provides a self-hosted Pastebin powered by Git for storing snippets.

---
*PR created automatically by Jules for task [1389877010026466461](https://jules.google.com/task/1389877010026466461) started by @LokiMetaSmith*