### PR TITLE
Fix Authentik Nomad job database connections

### DIFF
--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -23,9 +23,11 @@ update {
         to     = 9443
       }
       port "redis" {
+        static = {{ authentik_redis_port | default(16379) }}
         to = 6379
       }
       port "postgres" {
+        static = {{ authentik_postgres_port | default(15432) }}
         to = 5432
       }
     }
@@ -107,7 +109,9 @@ update {
 CONSUL_HTTP_TOKEN="{{ consul_bootstrap_token | default('') }}"
 AUTHENTIK_SECRET_KEY="{{ '{{' }} key "authentik/secret-key" {{ '}}' }}"
 AUTHENTIK_REDIS__HOST="{{ authentik_redis_host | default('redis.service.consul') }}"
+AUTHENTIK_REDIS__PORT="{{ authentik_redis_port | default(16379) }}"
 AUTHENTIK_POSTGRESQL__HOST="{{ authentik_postgres_host | default('postgres.service.consul') }}"
+AUTHENTIK_POSTGRESQL__PORT="{{ authentik_postgres_port | default(15432) }}"
 EOH
         destination = "secrets/authentik.env"
         env         = true
@@ -134,6 +138,12 @@ EOH
         cpu    = 500
         memory = {{ authentik_server_memory | default(2048) }}
       }
+
+      restart {
+        interval = "30s"
+        delay    = "15s"
+        mode     = "delay"
+      }
     }
 
     task "worker" {
@@ -155,7 +165,9 @@ EOH
 CONSUL_HTTP_TOKEN="{{ consul_bootstrap_token | default('') }}"
 AUTHENTIK_SECRET_KEY="{{ '{{' }} key "authentik/secret-key" {{ '}}' }}"
 AUTHENTIK_REDIS__HOST="{{ authentik_redis_host | default('redis.service.consul') }}"
+AUTHENTIK_REDIS__PORT="{{ authentik_redis_port | default(16379) }}"
 AUTHENTIK_POSTGRESQL__HOST="{{ authentik_postgres_host | default('postgres.service.consul') }}"
+AUTHENTIK_POSTGRESQL__PORT="{{ authentik_postgres_port | default(15432) }}"
 EOH
         destination = "secrets/authentik.env"
         env         = true
@@ -171,6 +183,12 @@ EOH
       resources {
         cpu    = 500
         memory = {{ authentik_worker_memory | default(1024) }}
+      }
+
+      restart {
+        interval = "30s"
+        delay    = "15s"
+        mode     = "delay"
       }
     }
   }


### PR DESCRIPTION
Fixed critical connectivity issues in the Authentik Nomad job configuration. Instead of separating the tasks into discrete Nomad jobs (which would violate constraints and disrupt dynamic service discovery), the `network` block was updated to use statically mapped host ports via Ansible Jinja2 variables. These corresponding static port configurations were successfully routed into the Authentik environment variables for server and worker blocks, enabling the Consul DNS (`*.service.consul`) architecture to correctly communicate between containers across the bridge network. Restart blocks were additionally implemented to combat startup race conditions.

---
*PR created automatically by Jules for task [15059119063714193992](https://jules.google.com/task/15059119063714193992) started by @LokiMetaSmith*