### PR TITLE
Fix test_loop_detection_mechanism async mocking

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -242,7 +242,7 @@ This section tracks identified placeholder files, corrupted binaries, and code t
   - Ensure encryption at rest is considered or implemented for sensitive fields.
 
 ## Technical Debt & Lazy Code
-- [ ] **Fix test_loop_detection_mechanism async mocking:** Update `tests/unit/conftest.py` or `tests/unit/test_pipecat_app_unit.py` to ensure `FrameProcessor.push_frame` and other mocked async methods correctly return `AsyncMock`s to prevent `TypeError: object MagicMock can't be used in 'await' expression` in an environment with missing dependencies.
+- [x] **Fix test_loop_detection_mechanism async mocking:** Update `tests/unit/conftest.py` or `tests/unit/test_pipecat_app_unit.py` to ensure `FrameProcessor.push_frame` and other mocked async methods correctly return `AsyncMock`s to prevent `TypeError: object MagicMock can't be used in 'await' expression` in an environment with missing dependencies.
 
 - [x] **Address Missing Tool Tests:** Create unit tests for tools lacking coverage (e.g., `atproto_tool.py`, `autoloop_tool.py`, `container_registry_tool.py`, `context_upload_tool.py`, `cq_tool.py`, `dependency_scanner_tool.py`, `document_tool.py`, `dynamic_skill_tool.py`, `openclaw_tool.py`, `save_skill_tool.py`, `scale_compute_tool.py`, `scheduler_tool.py`, `search_skills_tool.py`, `skill_builder_tool.py`, `spec_loader_tool.py`, `submit_solution_tool.py`, `update_litellm_tool.py`, `vr_tool.py`, `wol_tool.py`).
 - [x] **Fix Lazy Tests:** Address tests that contain only `pass` without actual assertions (e.g., `tests/unit/test_pipecat_app_unit.py`, `tests/test_event_bus.py`, `tests/verify_dlq.py`).

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -87,7 +87,8 @@ modules_to_mock = [
     'consul.aio',
     'faster_whisper',
     'opentelemetry.instrumentation.fastapi',
-    'piper.voice'
+    'piper.voice',
+    'graphviz'
 ]
 
 def mock_module_if_missing(module_name):
@@ -110,6 +111,11 @@ def mock_module_if_missing(module_name):
 
             m.trace.get_tracer.return_value.start_as_current_span.return_value = DummySpan()
             m.get_tracer.return_value.start_as_current_span.return_value = DummySpan()
+        if module_name == 'pipecat.processors.frame_processor':
+            m.FrameProcessor.push_frame = AsyncMock()
+            m.FrameProcessor.process_frame = AsyncMock()
+        if module_name == 'graphviz':
+            m.Digraph = MagicMock()
         sys.modules[module_name] = m
 
 # Execute mocking at the top level to ensure it runs before test collection

--- a/tests/unit/test_file_editor_security.py
+++ b/tests/unit/test_file_editor_security.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import shutil
 import tempfile
-from ansible.roles.pipecatapp.files.tools.file_editor_tool import FileEditorTool
+from tools.file_editor_tool import FileEditorTool
 
 class TestFileEditorSecurity(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_file_editor_tool.py
+++ b/tests/unit/test_file_editor_tool.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import shutil
 import tempfile
-from ansible.roles.pipecatapp.files.tools.file_editor_tool import FileEditorTool
+from tools.file_editor_tool import FileEditorTool
 
 class TestFileEditorTool(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_pipecat_app_unit.py
+++ b/tests/unit/test_pipecat_app_unit.py
@@ -40,6 +40,9 @@ sys.modules["pipecat.processors"] = mock_pipecat.processors
 sys.modules["pipecat.processors.frame_processor"] = mock_pipecat.processors.frame_processor
 # CRITICAL: Set FrameProcessor to our Mock Class so inheritance works
 sys.modules["pipecat.processors.frame_processor"].FrameProcessor = MockFrameProcessor
+# ADDED TO FIX ASYNC MOCKING
+sys.modules["pipecat.processors.frame_processor"].FrameProcessor.push_frame = AsyncMock()
+sys.modules["pipecat.processors.frame_processor"].FrameProcessor.process_frame = AsyncMock()
 sys.modules["pipecat.services"] = mock_pipecat.services
 sys.modules["pipecat.services.openai"] = mock_pipecat.services.openai
 sys.modules["pipecat.services.openai.llm"] = mock_pipecat.services.openai.llm

--- a/tests/unit/test_simple_llm_node.py
+++ b/tests/unit/test_simple_llm_node.py
@@ -11,8 +11,8 @@ import unittest
 import os
 from unittest.mock import AsyncMock, patch
 # Now we can import
-from ansible.roles.pipecatapp.files.workflow.nodes.llm_nodes import SimpleLLMNode
-from ansible.roles.pipecatapp.files.workflow.context import WorkflowContext
+from workflow.nodes.llm_nodes import SimpleLLMNode
+from workflow.context import WorkflowContext
 
 class TestSimpleLLMNode(unittest.IsolatedAsyncioTestCase):
     async def test_fast_tier_execution(self):


### PR DESCRIPTION
Fix `test_loop_detection_mechanism` async mocking to ensure `FrameProcessor.push_frame` and other mocked async methods correctly return `AsyncMock`s to prevent `TypeError: object MagicMock can't be used in 'await' expression` in an environment with missing dependencies. This solves the item tracked in TODO.md.

---
*PR created automatically by Jules for task [15652705154075529776](https://jules.google.com/task/15652705154075529776) started by @LokiMetaSmith*