### PR TITLE
feat: Introduce TaskyAuditNode primitive and Proof-of-Concept workflow

### DIFF
--- a/pipecatapp/workflow/nodes/__init__.py
+++ b/pipecatapp/workflow/nodes/__init__.py
@@ -5,3 +5,4 @@ from . import system_nodes
 from . import emperor_nodes
 from . import rag_nodes
 from . import ralph_nodes
+from . import tasky_nodes

--- a/pipecatapp/workflow/nodes/tasky_nodes.py
+++ b/pipecatapp/workflow/nodes/tasky_nodes.py
@@ -1,0 +1,118 @@
+import httpx
+import logging
+import json
+import os
+from .registry import registry
+from ..node import Node
+from ..context import WorkflowContext
+
+@registry.register
+class TaskyAuditNode(Node):
+    """
+    Evaluates an execution result against a task checklist defined in Markdown.
+    Updates the markdown with completed items, outputs an audit report, and a boolean indicating if all are complete.
+    """
+    def __init__(self, config):
+        super().__init__(config)
+        self.expected_inputs = {"task_markdown", "execution_result"}
+        self.expected_outputs = {"updated_markdown", "all_completed", "audit_report"}
+
+    async def execute(self, context: WorkflowContext):
+        task_markdown = self.get_input(context, "task_markdown")
+        execution_result = self.get_input(context, "execution_result")
+
+        if not task_markdown:
+            self.set_output(context, "updated_markdown", "")
+            self.set_output(context, "all_completed", False)
+            self.set_output(context, "audit_report", "Error: No task_markdown provided.")
+            return
+
+        if not execution_result:
+            self.set_output(context, "updated_markdown", task_markdown)
+            self.set_output(context, "all_completed", False)
+            self.set_output(context, "audit_report", "Error: No execution_result provided.")
+            return
+
+        node_config = self.config.get("config", {})
+        target_service = node_config.get("model_service", self.config.get("model_service", "rpc-main"))
+
+        consul_http_addr = context.global_inputs.get("consul_http_addr") or os.getenv("CONSUL_HTTP_ADDR")
+
+        updated_markdown = task_markdown
+        all_completed = False
+        audit_report = "Error: Could not reach LLM service."
+
+        if consul_http_addr:
+            try:
+                # Attempt to get the token, handle imports properly
+                token = ""
+                try:
+                    from pipecatapp.utils import secret_manager
+                    token = secret_manager.get_secret("CONSUL_HTTP_TOKEN") or ""
+                except ImportError:
+                    token = os.getenv("CONSUL_HTTP_TOKEN", "")
+
+                headers = {"X-Consul-Token": token} if token else {}
+
+                async with httpx.AsyncClient(headers=headers) as client:
+                    response = await client.get(f"{consul_http_addr}/v1/health/service/{target_service}?passing")
+                    response.raise_for_status()
+                    services = response.json()
+
+                    if not services:
+                        audit_report = f"Error: Service {target_service} not found."
+                    else:
+                        address = services[0]['Service']['Address']
+                        port = services[0]['Service']['Port']
+                        base_url = f"http://{address}:{port}/v1"
+                        chat_url = f"{base_url}/chat/completions"
+
+                        system_prompt = (
+                            "You are a meticulous Tasky PM agent. Your job is to audit execution results against a markdown task specification.\n"
+                            "You must output a JSON object with three keys:\n"
+                            "1. 'updated_markdown': The original markdown but with checklist items `[ ]` updated to `[x]` if and only if the execution result explicitly demonstrates they are completed.\n"
+                            "2. 'all_completed': A boolean true if all checklist criteria in the markdown are now marked `[x]`, otherwise false.\n"
+                            "3. 'audit_report': A short explanation of what was verified, and what is still missing or incomplete.\n"
+                            "IMPORTANT: Output ONLY valid JSON, nothing else."
+                        )
+
+                        user_prompt = f"TASK MARKDOWN:\n```markdown\n{task_markdown}\n```\n\nEXECUTION RESULT:\n```\n{execution_result}\n```\n\nPlease audit."
+
+                        messages = [
+                            {"role": "system", "content": system_prompt},
+                            {"role": "user", "content": user_prompt}
+                        ]
+
+                        payload = {
+                            "model": target_service,
+                            "messages": messages,
+                            "temperature": 0.1,
+                            "response_format": {"type": "json_object"}
+                        }
+
+                        res = await client.post(chat_url, json=payload, timeout=60)
+                        res.raise_for_status()
+
+                        response_content = res.json()["choices"][0]["message"]["content"].strip()
+
+                        try:
+                            # Strip backticks if any
+                            if response_content.startswith("```json"):
+                                response_content = response_content[7:]
+                            if response_content.endswith("```"):
+                                response_content = response_content[:-3]
+
+                            parsed_json = json.loads(response_content.strip())
+                            updated_markdown = parsed_json.get("updated_markdown", task_markdown)
+                            all_completed = parsed_json.get("all_completed", False)
+                            audit_report = parsed_json.get("audit_report", "Could not extract audit report.")
+                        except json.JSONDecodeError:
+                            audit_report = f"Failed to parse LLM JSON output. Raw output:\n{response_content}"
+
+            except Exception as e:
+                logging.error(f"Error in TaskyAuditNode: {e}")
+                audit_report = f"Error during audit execution: {e}"
+
+        self.set_output(context, "updated_markdown", updated_markdown)
+        self.set_output(context, "all_completed", all_completed)
+        self.set_output(context, "audit_report", audit_report)

--- a/test_tasky_poc.py
+++ b/test_tasky_poc.py
@@ -1,0 +1,26 @@
+import asyncio
+from pipecatapp.workflow.runner import WorkflowRunner
+import pipecatapp.workflow.nodes
+
+async def main():
+    runner = WorkflowRunner("workflows/tasky_checklist_poc.yaml")
+
+    # Mock global input context to skip hitting consul if we don't have it running
+    # but since this is a PoC we can just pass mock task markdown and execution results
+    global_inputs = {
+        "task_markdown": "# Connection Pooling\n\nStatus: DOING\nDependencies: [connect, disconnect]\n\n## Criteria\n[ ] Create a pool on first connect\n[ ] Reuse connections across requests\n[ ] Configurable pool size via env var\n[ ] Graceful drain on shutdown\n[ ] Health check pings idle connections",
+        "execution_result": "I implemented connection pooling! The pool is created when the first connection happens. It also reuses connections across subsequent requests. Pool size can be configured using the POOL_SIZE env var. Graceful drain and health checks are not yet implemented.",
+        "consul_http_addr": None # Skip actual LLM call for pure syntax test unless we want to mock it.
+    }
+
+    # Just syntax check and load the workflow. It will fail with "Could not reach LLM service" because we don't mock it, but we can verify the graph parses.
+    try:
+        final_state = await runner.run(global_inputs)
+        print("Final Output:")
+        import json
+        print(json.dumps(final_state, indent=2))
+    except Exception as e:
+        print(f"Error executing workflow: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/test_tasky_nodes.py
+++ b/tests/unit/test_tasky_nodes.py
@@ -1,0 +1,25 @@
+import pytest
+import asyncio
+from pipecatapp.workflow.nodes.tasky_nodes import TaskyAuditNode
+from pipecatapp.workflow.context import WorkflowContext
+
+@pytest.mark.asyncio
+async def test_tasky_audit_node_no_markdown():
+    node = TaskyAuditNode({"id": "test_node", "config": {}, "inputs": [{"name": "task_markdown", "value": ""}, {"name": "execution_result", "value": "done"}]})
+    context = WorkflowContext({"nodes": [{"id": "test_node", "inputs": [{"name": "task_markdown", "value": ""}, {"name": "execution_result", "value": "done"}]}]})
+
+    await node.execute(context)
+
+    # We shouldn't use `get_input` to fetch outputs, outputs are stored in `context.node_outputs`
+    assert context.node_outputs.get("test_node", {}).get("all_completed") is False
+    assert "Error: No task_markdown provided" in context.node_outputs.get("test_node", {}).get("audit_report")
+
+@pytest.mark.asyncio
+async def test_tasky_audit_node_no_execution_result():
+    node = TaskyAuditNode({"id": "test_node", "config": {}, "inputs": [{"name": "task_markdown", "value": "# Todo"}, {"name": "execution_result", "value": ""}]})
+    context = WorkflowContext({"nodes": [{"id": "test_node", "inputs": [{"name": "task_markdown", "value": "# Todo"}, {"name": "execution_result", "value": ""}]}]})
+
+    await node.execute(context)
+
+    assert context.node_outputs.get("test_node", {}).get("all_completed") is False
+    assert "Error: No execution_result provided" in context.node_outputs.get("test_node", {}).get("audit_report")

--- a/workflows/tasky_checklist_poc.yaml
+++ b/workflows/tasky_checklist_poc.yaml
@@ -1,0 +1,35 @@
+name: Tasky Audit Proof of Concept
+description: A workflow that evaluates an execution result against a markdown checklist.
+
+nodes:
+  - id: input_data
+    type: InputNode
+    config:
+      outputs:
+        - task_markdown
+        - execution_result
+
+  - id: tasky_auditor
+    type: TaskyAuditNode
+    inputs:
+      - name: task_markdown
+        source: input_data
+        output: task_markdown
+      - name: execution_result
+        source: input_data
+        output: execution_result
+    config:
+      model_service: rpc-main
+
+  - id: output
+    type: OutputNode
+    inputs:
+      - name: updated_markdown
+        source: tasky_auditor
+        output: updated_markdown
+      - name: all_completed
+        source: tasky_auditor
+        output: all_completed
+      - name: final_report
+        source: tasky_auditor
+        output: audit_report


### PR DESCRIPTION
Evaluated the Tasky methodology and added a new `TaskyAuditNode` primitive to our workflow engine. This node acts as an automated auditor that reviews an execution result against a markdown checklist (updating `[ ]` to `[x]`) and outputs the updated markdown along with an audit report. A PoC workflow YAML is included to demonstrate the integration.

---
*PR created automatically by Jules for task [12698250994181050874](https://jules.google.com/task/12698250994181050874) started by @LokiMetaSmith*