### PR TITLE
Fix Ansible config ignored in world-writable directories

### DIFF
--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -285,6 +285,7 @@ def run_playbook(playbook_path, extra_vars, tags, verbose_level):
     env = os.environ.copy()
     env["PYTHONUNBUFFERED"] = "1"
     env["ANSIBLE_FORCE_COLOR"] = "1" # Keep colors if possible
+    env["ANSIBLE_CONFIG"] = os.path.abspath("ansible.cfg")
 
     try:
         with open(LOG_FILE, "a") as log_file:


### PR DESCRIPTION
Set ANSIBLE_CONFIG explicitly in `scripts/provisioning.py`. When running the `ansible-playbook` command programmatically via subprocess, the script explicitly sets `env['ANSIBLE_CONFIG'] = os.path.abspath('ansible.cfg')`. This circumvents Ansible's default behavior of ignoring local config files in world-writable directories, ensuring `roles_path` is correctly loaded.

---
*PR created automatically by Jules for task [18002488030343953615](https://jules.google.com/task/18002488030343953615) started by @LokiMetaSmith*