### PR TITLE
Fix Authentik postgres volume mount in Nomad template

### DIFF
--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -65,6 +65,9 @@ update {
         image = "postgres:15-alpine"
         network_mode = "{{ authentik_network_mode | default('bridge') }}"
         ports = ["postgres"]
+        volumes = [
+          "{{ nomad_volumes_dir }}/authentik/postgres:/var/lib/postgresql/data"
+        ]
       }
 
       service {

--- a/tests/playbooks/test_authentik.yml
+++ b/tests/playbooks/test_authentik.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  become: yes
+  roles:
+    - ansible/roles/authentik


### PR DESCRIPTION
The Authentik Nomad deployment was failing with a 'progress deadline' error because the `postgresql` task inside `authentik.nomad.j2` lacked the `volumes` block mapping the host database directory (`/opt/nomad/volumes/authentik/postgres`) into the container.

This omission prevented the container from utilizing the pre-provisioned data directory. As the host directory was correctly chowned by Ansible (UID 70) for PostgreSQL but not mounted, the deployment process lacked consistency with expected states, ultimately resulting in the initialization failing and blocking the job's progress. Adding the volume mapping aligns the Nomad template with the Ansible initialization tasks and resolves the permission/initialization failures.

---
*PR created automatically by Jules for task [14442467593357171890](https://jules.google.com/task/14442467593357171890) started by @LokiMetaSmith*