### PR TITLE
fix: ensure Authentik secret key meets minimum length requirement

### DIFF
--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -59,7 +59,10 @@
 - name: Generate Authentik secret key
   ansible.builtin.command: openssl rand -hex 50
   register: authentik_generated_key
-  when: authentik_consul_key is not failed and authentik_consul_key.status == 404
+  when: >
+    authentik_consul_key is not failed and
+    (authentik_consul_key.status == 404 or
+    (authentik_consul_key.status == 200 and authentik_consul_key.json[0].Value | default('') | b64decode | length < 50))
 
 - name: Publish Authentik secret key to Consul
   ansible.builtin.uri:
@@ -69,7 +72,10 @@
       X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
     body: "{{ authentik_generated_key.stdout }}"
     status_code: [200, 201]
-  when: authentik_consul_key is not failed and authentik_consul_key.status == 404
+  when: >
+    authentik_consul_key is not failed and
+    (authentik_consul_key.status == 404 or
+    (authentik_consul_key.status == 200 and authentik_consul_key.json[0].Value | default('') | b64decode | length < 50))
 
 - name: Template Authentik Nomad job
   ansible.builtin.template:

--- a/ansible/roles/docker_registry/tasks/main.yaml
+++ b/ansible/roles/docker_registry/tasks/main.yaml
@@ -22,9 +22,9 @@
     cmd: /usr/local/bin/nomad job run {{ nomad_jobs_dir }}/docker-registry.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
-        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
   register: nomad_job_run
 
 - name: Allow Docker Registry port in UFW

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -550,9 +550,9 @@
   failed_when: false
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
-        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
 
 - name: Flush handlers to ensure service is enabled and started
   ansible.builtin.meta: flush_handlers

--- a/patch_authentik.diff
+++ b/patch_authentik.diff
@@ -1,0 +1,37 @@
+<<<<<<< SEARCH
+- name: Generate Authentik secret key
+  ansible.builtin.command: openssl rand -hex 50
+  register: authentik_generated_key
+  when: authentik_consul_key is not failed and authentik_consul_key.status == 404
+
+- name: Publish Authentik secret key to Consul
+  ansible.builtin.uri:
+    url: "http://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_http_port | default(8500) }}/v1/kv/authentik/secret-key"
+    method: PUT
+    headers:
+      X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
+    body: "{{ authentik_generated_key.stdout }}"
+    status_code: [200, 201]
+  when: authentik_consul_key is not failed and authentik_consul_key.status == 404
+=======
+- name: Generate Authentik secret key
+  ansible.builtin.command: openssl rand -hex 50
+  register: authentik_generated_key
+  when: >
+    authentik_consul_key is not failed and
+    (authentik_consul_key.status == 404 or
+    (authentik_consul_key.status == 200 and authentik_consul_key.json[0].Value | default('') | b64decode | length < 50))
+
+- name: Publish Authentik secret key to Consul
+  ansible.builtin.uri:
+    url: "http://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_http_port | default(8500) }}/v1/kv/authentik/secret-key"
+    method: PUT
+    headers:
+      X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
+    body: "{{ authentik_generated_key.stdout }}"
+    status_code: [200, 201]
+  when: >
+    authentik_consul_key is not failed and
+    (authentik_consul_key.status == 404 or
+    (authentik_consul_key.status == 200 and authentik_consul_key.json[0].Value | default('') | b64decode | length < 50))
+>>>>>>> REPLACE


### PR DESCRIPTION
Fixes an issue where Authentik would fail to boot (resulting in Nomad 'progress deadline' timeouts) if the `AUTHENTIK_SECRET_KEY` generated or stored in Consul was shorter than 50 characters. The fix modifies the `main.yml` task to check the length of the base64-decoded value from Consul and regenerate the key if it does not meet the length requirement. Additionally, a YAML indentation issue in the `docker_registry` role was corrected to allow the Ansible syntax check tests to pass.

---
*PR created automatically by Jules for task [5000864133894838278](https://jules.google.com/task/5000864133894838278) started by @LokiMetaSmith*