### PR TITLE
fix: resolve authentik nomad deployment failure due to network_mode conflict

### DIFF
--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -37,7 +37,6 @@ update {
 
       config {
         image = "redis:7.2-alpine"
-        network_mode = "{{ authentik_network_mode | default('bridge') }}"
         ports = ["redis"]
       }
 
@@ -63,7 +62,6 @@ update {
 
       config {
         image = "postgres:15-alpine"
-        network_mode = "{{ authentik_network_mode | default('bridge') }}"
         ports = ["postgres"]
         volumes = [
           "{{ nomad_volumes_dir }}/authentik/postgres:/var/lib/postgresql/data"
@@ -99,7 +97,6 @@ update {
       config {
         image        = "ghcr.io/goauthentik/server:2024.2.2"
         args         = ["server"]
-        network_mode = "{{ authentik_network_mode | default('bridge') }}"
         ports        = ["http", "https"]
         volumes = [
           "{{ nomad_volumes_dir }}/authentik/media:/media",
@@ -155,7 +152,6 @@ EOH
       config {
         image        = "ghcr.io/goauthentik/server:2024.2.2"
         args         = ["worker"]
-        network_mode = "{{ authentik_network_mode | default('bridge') }}"
         volumes = [
           "{{ nomad_volumes_dir }}/authentik/media:/media",
           "{{ nomad_volumes_dir }}/authentik/certs:/certs",


### PR DESCRIPTION
Resolves the "progress deadline" deployment failure for the Authentik job by fixing a Docker networking conflict. By removing `network_mode` from the Docker configs of the Redis, Postgres, Server, and Worker tasks, the Docker driver will properly attach to the Nomad-managed CNI network namespace instead of overriding it.

---
*PR created automatically by Jules for task [8445223543578171826](https://jules.google.com/task/8445223543578171826) started by @LokiMetaSmith*