### PR TITLE
Fix Nomad Authentik progress deadline failure by removing conflicting Docker network_mode

### DIFF
--- a/ansible/jobs/authentik.nomad
+++ b/ansible/jobs/authentik.nomad
@@ -25,7 +25,6 @@ job "authentik" {
       config {
         image = "ghcr.io/goauthentik/server:2024.2.2"
         args  = ["server"]
-        network_mode = "bridge"
         ports = ["http"]
         volumes = [
           "/opt/nomad/volumes/authentik/media:/media",
@@ -72,7 +71,6 @@ EOH
       config {
         image = "ghcr.io/goauthentik/server:2024.2.2"
         args  = ["worker"]
-        network_mode = "bridge"
         volumes = [
           "/opt/nomad/volumes/authentik/media:/media",
           "/opt/nomad/volumes/authentik/certs:/certs",

--- a/ansible/jobs/postgres.nomad
+++ b/ansible/jobs/postgres.nomad
@@ -20,7 +20,6 @@ job "postgres" {
       driver = "docker"
       config {
         image = "postgres:15-alpine"
-        network_mode = "bridge"
       }
       template {
         data = <<EOH

--- a/ansible/jobs/redis.nomad
+++ b/ansible/jobs/redis.nomad
@@ -33,7 +33,6 @@ job "redis" {
       driver = "docker"
       config {
         image = "redis:7.2-alpine"
-        network_mode = "bridge"
       }
       service {
         name = "redis"


### PR DESCRIPTION
Fixes issue where Authentik Nomad deployment fails due to a progress deadline timeout. The root cause was a conflict between the Nomad group network mode (`bridge`) and the Docker task `network_mode` (`bridge`), which forced containers onto the default Docker bridge instead of the Nomad CNI namespace, breaking connectivity and port mappings.

---
*PR created automatically by Jules for task [15826204806233215034](https://jules.google.com/task/15826204806233215034) started by @LokiMetaSmith*