### PR TITLE
fix: Update opencode model fallback to include openai provider

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -428,7 +428,7 @@ Your task is to:
         export OPENCODE_API_KEY="${AGENT_API_KEY:-sk-dummy}"
         opencode_cmd+=(--model "${AGENT_MODEL:-openai/qwen2.5-coder}")
     else
-        opencode_cmd+=(--model "${AGENT_MODEL:-gpt-4o-mini}")
+        opencode_cmd+=(--model "${AGENT_MODEL:-openai/gpt-4o-mini}")
     fi
 
     # Run OpenCode headlessly. Catch error explicitly in case set -e is active elsewhere


### PR DESCRIPTION
Updates `bootstrap.sh` to properly use the `provider/model` format (`openai/gpt-4o-mini`) expected by the underlying OpenCode/LiteLLM tool, fixing the `ProviderModelNotFoundError`.

---
*PR created automatically by Jules for task [8143085097632431327](https://jules.google.com/task/8143085097632431327) started by @LokiMetaSmith*