### PR TITLE
fix: Remove network_mode = bridge from Nomad job docker tasks

### DIFF
--- a/ansible/jobs/authentik.nomad
+++ b/ansible/jobs/authentik.nomad
@@ -25,7 +25,6 @@ job "authentik" {
       config {
         image = "ghcr.io/goauthentik/server:2024.2.2"
         args  = ["server"]
-        network_mode = "bridge"
         ports = ["http"]
         volumes = [
           "/opt/nomad/volumes/authentik/media:/media",
@@ -72,7 +71,6 @@ EOH
       config {
         image = "ghcr.io/goauthentik/server:2024.2.2"
         args  = ["worker"]
-        network_mode = "bridge"
         volumes = [
           "/opt/nomad/volumes/authentik/media:/media",
           "/opt/nomad/volumes/authentik/certs:/certs",

--- a/ansible/jobs/postgres.nomad
+++ b/ansible/jobs/postgres.nomad
@@ -20,7 +20,6 @@ job "postgres" {
       driver = "docker"
       config {
         image = "postgres:15-alpine"
-        network_mode = "bridge"
       }
       template {
         data = <<EOH

--- a/ansible/jobs/redis.nomad
+++ b/ansible/jobs/redis.nomad
@@ -33,7 +33,6 @@ job "redis" {
       driver = "docker"
       config {
         image = "redis:7.2-alpine"
-        network_mode = "bridge"
       }
       service {
         name = "redis"


### PR DESCRIPTION
Removes `network_mode = "bridge"` from `ansible/jobs/authentik.nomad`, `ansible/jobs/postgres.nomad`, and `ansible/jobs/redis.nomad` to fix 'progress deadline' deployment failures.

---
*PR created automatically by Jules for task [12738825759919155412](https://jules.google.com/task/12738825759919155412) started by @LokiMetaSmith*