### PR TITLE
Integrate Local and Distributed World Model

### DIFF
--- a/docs/TODO_Hybrid_Architecture.md
+++ b/docs/TODO_Hybrid_Architecture.md
@@ -43,11 +43,11 @@ Objective: Enable the main `pipecatapp` container to perform LLM inference and m
     - [x] Wrap it in a `LocalLLMService` class that adheres to the Pipecat `LLMService` interface.
   - [x] If false (default): Continue using `OpenAILLMService` pointing to `LLAMA_API_SERVICE_NAME`.
 
-- [ ] **Integrate World Model**
-  - [ ] Create `pipecatapp/local_world_model.py`.
-  - [ ] Implement a singleton class `LocalWorldModel` that matches the API of the MQTT-based service.
-  - [ ] In `app.py`, conditionally instantiate `LocalWorldModel` vs `MQTTWorldModelClient` based on `WORLD_MODEL_MODE` (local/distributed).
-  - [ ] Ensure `LocalWorldModel` still publishes updates to MQTT (fire-and-forget) so external observers (Home Assistant) stay in sync, even if the app doesn't read from MQTT.
+- [x] **Integrate World Model**
+  - [x] Create `pipecatapp/local_world_model.py`.
+  - [x] Implement a singleton class `LocalWorldModel` that matches the API of the MQTT-based service.
+  - [x] In `app.py`, conditionally instantiate `LocalWorldModel` vs `MQTTWorldModelClient` based on `WORLD_MODEL_MODE` (local/distributed).
+  - [x] Ensure `LocalWorldModel` still publishes updates to MQTT (fire-and-forget) so external observers (Home Assistant) stay in sync, even if the app doesn't read from MQTT.
 
 - [ ] **Deprecate "Expert" Container**
   - [ ] Update `ansible/roles/pipecatapp/tasks/main.yaml` to make the deployment of `expert-*.nomad` jobs conditional on `deploy_topology != 'monolith'`.

--- a/pipecatapp/agent_factory.py
+++ b/pipecatapp/agent_factory.py
@@ -155,7 +155,14 @@ def create_tools(config: dict, twin_service=None, runner=None) -> dict:
             ha_token=config.get("ha_token")
         )
         tools["git"] = Git_Tool(root_dir="/opt/pipecatapp")
-        tools["orchestrator"] = OrchestratorTool()
+        world_model = None
+        try:
+            from app import app as main_app
+            world_model = getattr(main_app.state, 'world_model', None)
+        except ImportError:
+            pass
+
+        tools["orchestrator"] = OrchestratorTool(world_model=world_model)
         tools["opencode_provider"] = OpenCodeProviderTool()
 
     # Load dynamic skills from memory store

--- a/pipecatapp/app.py
+++ b/pipecatapp/app.py
@@ -74,6 +74,9 @@ from tools.term_everything_tool import TermEverythingTool
 from tools.rag_tool import RAG_Tool
 from tools.ha_tool import HA_Tool
 from tools.git_tool import Git_Tool
+from local_world_model import LocalWorldModel
+from mqtt_world_model_client import MQTTWorldModelClient
+
 from tools.orchestrator_tool import OrchestratorTool
 from tools.llxprt_code_tool import LLxprt_Code_Tool
 from tools.claude_clone_tool import ClaudeCloneTool
@@ -1500,6 +1503,18 @@ async def run_agent():
     # Set initial state for web server
     web_server.app.state.is_ready = False
     web_server.app.state.twin_service_instance = None
+
+    # Initialize World Model
+    world_model_mode = os.getenv("WORLD_MODEL_MODE", "distributed")
+    if world_model_mode == "local":
+        logging.info("Initializing LocalWorldModel (Monolith mode)")
+        world_model = LocalWorldModel()
+    else:
+        logging.info("Initializing MQTTWorldModelClient (Distributed mode)")
+        world_model = MQTTWorldModelClient()
+
+    web_server.app.state.world_model = world_model
+
 
     # Load configuration from Consul
     consul_host = os.getenv("CONSUL_HOST")

--- a/pipecatapp/local_world_model.py
+++ b/pipecatapp/local_world_model.py
@@ -1,0 +1,107 @@
+import threading
+import json
+import logging
+import os
+import httpx
+from typing import Dict, Any
+
+try:
+    import paho.mqtt.client as mqtt
+except ImportError:
+    mqtt = None
+
+logger = logging.getLogger(__name__)
+
+class LocalWorldModel:
+    """
+    A singleton class representing the local world model state.
+    It provides methods to get the state and dispatch jobs, matching
+    the API of the MQTT-based world model service.
+    When WORLD_MODEL_MODE is local, this class is used to store state
+    in-memory and optionally fire-and-forget MQTT updates to keep
+    external observers (like Home Assistant) in sync.
+    """
+    _instance = None
+    _lock = threading.Lock()
+
+    def __new__(cls):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super(LocalWorldModel, cls).__new__(cls)
+                cls._instance._initialized = False
+            return cls._instance
+
+    def __init__(self):
+        if self._initialized:
+            return
+
+        self.world_state: Dict[str, Any] = {}
+        self.state_lock = threading.Lock()
+
+        self.mqtt_host = os.getenv("MQTT_HOST", "localhost")
+        self.mqtt_port = int(os.getenv("MQTT_PORT", "1883"))
+
+        self.mqtt_client = None
+        if mqtt is not None:
+            try:
+                self.mqtt_client = mqtt.Client(callback_api_version=mqtt.CallbackAPIVersion.VERSION2)
+            except AttributeError:
+                self.mqtt_client = mqtt.Client()
+
+            try:
+                # We connect but do not loop_forever or subscribe
+                # This is just for fire-and-forget publishing.
+                self.mqtt_client.connect(self.mqtt_host, self.mqtt_port, 60)
+                self.mqtt_client.loop_start()
+            except Exception as e:
+                logger.warning(f"LocalWorldModel could not connect to MQTT broker at {self.mqtt_host}:{self.mqtt_port} for publishing: {e}")
+                self.mqtt_client = None
+
+        self._initialized = True
+
+    def get_state(self) -> Dict[str, Any]:
+        """Returns the current world state."""
+        with self.state_lock:
+            return self.world_state.copy()
+
+    def update_state(self, topic: str, payload: Any):
+        """
+        Updates the local state and fires an MQTT message.
+        """
+        with self.state_lock:
+            keys = topic.split('/')
+            current_level = self.world_state
+            for key in keys[:-1]:
+                current_level = current_level.setdefault(key, {})
+            current_level[keys[-1]] = payload
+
+        if self.mqtt_client:
+            try:
+                payload_str = json.dumps(payload) if not isinstance(payload, str) else payload
+                self.mqtt_client.publish(topic, payload_str)
+            except Exception as e:
+                logger.error(f"Failed to publish MQTT message on topic {topic}: {e}")
+
+    async def dispatch_job(self, model_name: str, prompt: str, cpu: int = 1000, memory: int = 4096, gpu_count: int = 1, context: str = "") -> Any:
+        """
+        Dispatches a Nomad batch job directly.
+        """
+        nomad_addr = os.getenv("NOMAD_ADDR", "http://localhost:4646")
+        job_id = "llamacpp-batch"
+        url = f"{nomad_addr}/v1/job/{job_id}/dispatch"
+
+        payload = {
+            "Meta": {
+                "model_name": model_name,
+                "prompt": prompt,
+                "cpu": str(cpu),
+                "memory": str(memory),
+                "gpu_count": str(gpu_count),
+                "context": context,
+            }
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, json=payload)
+            response.raise_for_status()
+            return response.json()

--- a/pipecatapp/mqtt_world_model_client.py
+++ b/pipecatapp/mqtt_world_model_client.py
@@ -1,0 +1,51 @@
+import httpx
+import os
+import logging
+from typing import Dict, Any
+
+logger = logging.getLogger(__name__)
+
+class MQTTWorldModelClient:
+    """
+    Client for interacting with the distributed MQTT-based World Model Service.
+    """
+    def __init__(self):
+        self.world_model_url = os.getenv("WORLD_MODEL_URL", f"http://{os.getenv('CLUSTER_IP', '127.0.0.1')}:8000")
+
+    def get_state(self) -> Dict[str, Any]:
+        """Fetches the state from the external service."""
+        try:
+            with httpx.Client() as client:
+                response = client.get(f"{self.world_model_url}/state")
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Error fetching state from world model: {e.response.text}")
+            return {}
+        except Exception as e:
+            logger.error(f"Error connecting to world model at {self.world_model_url}: {e}")
+            return {}
+
+    async def dispatch_job(self, model_name: str, prompt: str, cpu: int = 1000, memory: int = 4096, gpu_count: int = 1, context: str = "") -> Any:
+        """Dispatches a Nomad batch job via the external service."""
+        url = f"{self.world_model_url}/dispatch-job"
+        payload = {
+            "model_name": model_name,
+            "prompt": prompt,
+            "cpu": cpu,
+            "memory": memory,
+            "gpu_count": gpu_count,
+            "context": context,
+        }
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(url, json=payload)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as e:
+                logger.error(f"Error dispatching job: {e.response.text}")
+                return {"error": e.response.text}
+            except Exception as e:
+                logger.error(f"Error connecting to world model at {self.world_model_url}: {e}")
+                return {"error": str(e)}

--- a/pipecatapp/tools/orchestrator_tool.py
+++ b/pipecatapp/tools/orchestrator_tool.py
@@ -1,12 +1,33 @@
 import httpx
 import os
+import logging
+import asyncio
+import concurrent.futures
+from typing import Dict, Any
+
+logger = logging.getLogger(__name__)
 
 class OrchestratorTool:
-    def __init__(self):
-        self.world_model_url = os.getenv("WORLD_MODEL_URL", f"http://{os.getenv("CLUSTER_IP", "127.0.0.1")}:8000")
+    def __init__(self, world_model=None):
+        self.world_model = world_model
+        if self.world_model is None:
+            self.world_model_url = os.getenv("WORLD_MODEL_URL", f"http://{os.getenv('CLUSTER_IP', '127.0.0.1')}:8000")
 
     def dispatch_job(self, model_name: str, prompt: str, cpu: int = 1000, memory: int = 4096, gpu_count: int = 1, context: str = ""):
         """Dispatches a Nomad batch job to run a model with the given prompt, resources, and optional context."""
+        if self.world_model is not None and hasattr(self.world_model, 'dispatch_job'):
+            # Tools need to return a sync value. dispatch_job in world model is async.
+            try:
+                # Check if we are running in an event loop
+                asyncio.get_running_loop()
+                # Run the coroutine in another thread to avoid blocking or 'Event loop is running' errors
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    future = pool.submit(asyncio.run, self.world_model.dispatch_job(model_name, prompt, cpu, memory, gpu_count, context))
+                    return future.result()
+            except RuntimeError:
+                # No event loop, we can use asyncio.run directly
+                return asyncio.run(self.world_model.dispatch_job(model_name, prompt, cpu, memory, gpu_count, context))
+
         with httpx.Client() as client:
             try:
                 response = client.post(

--- a/tests/unit/test_orchestrator_tool.py
+++ b/tests/unit/test_orchestrator_tool.py
@@ -13,7 +13,7 @@ def test_orchestrator_tool_instantiation():
     """Tests that the OrchestratorTool class can be instantiated."""
     # Test default URL
     tool = OrchestratorTool()
-    assert tool.world_model_url == "http://localhost:8000"
+    assert tool.world_model_url == f"http://{os.getenv('CLUSTER_IP', '127.0.0.1')}:8000"
 
     # Test with environment variable
     os.environ["WORLD_MODEL_URL"] = "http://test:8000"
@@ -40,7 +40,7 @@ def test_dispatch_job_success(mock_client_cls):
     assert result == {"status": "dispatched", "job_id": "123"}
 
     mock_client.post.assert_called_once_with(
-        "http://localhost:8000/dispatch-job",
+        f"http://{os.getenv('CLUSTER_IP', '127.0.0.1')}:8000/dispatch-job",
         json={
             "model_name": "test-model",
             "prompt": "hello",


### PR DESCRIPTION
Resolves the "Integrate World Model" subtask from the hybrid architecture roadmap. The application can now switch between in-memory `LocalWorldModel` for monolithic edge nodes and external `MQTTWorldModelClient` for multi-node deployments. Also ensures proper sync-to-async boundary safety in `OrchestratorTool`.

---
*PR created automatically by Jules for task [16555524532553594184](https://jules.google.com/task/16555524532553594184) started by @LokiMetaSmith*