### PR TITLE
Fix Authentik OOM issue with Gunicorn Web Workers

### DIFF
--- a/ansible/roles/authentik/defaults/main.yml
+++ b/ansible/roles/authentik/defaults/main.yml
@@ -2,3 +2,5 @@ nomad_volumes_dir: /opt/nomad/volumes
 nomad_jobs_dir: /opt/nomad/jobs
 authentik_server_memory: 2048
 authentik_worker_memory: 1024
+authentik_web_workers: 2
+authentik_gunicorn_cmd_args: "--max-requests 250 --max-requests-jitter 50"

--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -122,6 +122,8 @@ EOH
         AUTHENTIK_POSTGRESQL__NAME = "{{ authentik_db_name | default('authentik') }}"
         AUTHENTIK_POSTGRESQL__PASSWORD = "{{ authentik_db_password | default('authentik_password') }}"
         AUTHENTIK_ERROR_REPORTING__ENABLED = "true"
+        AUTHENTIK_WEB__WORKERS = "{{ authentik_web_workers | default(2) }}"
+        GUNICORN_CMD_ARGS = "{{ authentik_gunicorn_cmd_args | default('--max-requests 250 --max-requests-jitter 50') }}"
       }
 
       service {


### PR DESCRIPTION
Fixes an OOM issue with Gunicorn workers in Authentik running on Nomad.

Adds `AUTHENTIK_WEB__WORKERS` to cap the number of worker processes.
Adds `GUNICORN_CMD_ARGS` to enable periodic recycling of workers, preventing memory leaks over time.

---
*PR created automatically by Jules for task [10196797910204637307](https://jules.google.com/task/10196797910204637307) started by @LokiMetaSmith*