### PR TITLE
Fix connection refused error when deploying Traefik Nomad job

### DIFF
--- a/playbooks/app_jobs.yaml
+++ b/playbooks/app_jobs.yaml
@@ -32,6 +32,10 @@
         - wait
 
   roles:
+    - role: traefik
+      tags:
+        - traefik
+        - proxy
     - role: authentik
       tags:
         - authentik

--- a/playbooks/services/core_infra.yaml
+++ b/playbooks/services/core_infra.yaml
@@ -49,7 +49,3 @@
       tags:
         - tpm_ssh
         - common
-    - role: traefik
-      tags:
-        - traefik
-        - proxy


### PR DESCRIPTION
The `traefik` role was trying to execute `nomad job run` within the `core_infra.yaml` playbook. This caused a connection refused error because Nomad hasn't started yet (since handlers for systemd units only run at the end of the `core_infra` playbook). Moving the `traefik` role to the `app_jobs.yaml` playbook correctly places the application workload after the infrastructure components (Consul and Nomad) have been successfully bootstrapped and started. I also verified the syntax changes with the playbook syntax tests.

---
*PR created automatically by Jules for task [15650590154777175259](https://jules.google.com/task/15650590154777175259) started by @LokiMetaSmith*