### PR TITLE
fix: Use npm ci in bootstrap.sh to prevent node_modules rename errors

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -531,7 +531,7 @@ ensure_python_environment() {
         echo "⚠️  Warning: requirements-dev.txt not found. Skipping dependency installation."
     fi
 
-    run_step "Installing OpenCode AI Agent" "npm install"
+    run_step "Installing OpenCode AI Agent" "npm ci"
 
     run_step "Installing Ansible Core" "pip install ansible-core pyyaml"
 


### PR DESCRIPTION
Fixes `bootstrap.sh` to prevent intermittent installation failures when setting up the OpenCode AI Agent dependencies.

---
*PR created automatically by Jules for task [11608928991801850452](https://jules.google.com/task/11608928991801850452) started by @LokiMetaSmith*