### PR TITLE
Fix Authentik Nomad job progress deadline failure

### DIFF
--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -14,6 +14,9 @@ update {
   group "authentik" {
     network {
       mode = "{{ authentik_network_mode | default('bridge') }}"
+      dns {
+        servers = ["{{ cluster_ip | default('172.17.0.1') }}", "8.8.8.8"]
+      }
       port "http" {
         static = {{ authentik_http_port | default(9000) }}
         to     = 9000
@@ -68,6 +71,7 @@ update {
 
       config {
         image = "postgres:15-alpine"
+        user = "root"
         ports = ["postgres"]
         volumes = [
           "{{ nomad_volumes_dir }}/authentik/postgres:/var/lib/postgresql/data"


### PR DESCRIPTION
Fixes the continuous "progress deadline" deployment failures in the Authentik Nomad job. 

1. **Volume Permissions:** The `postgresql` task was entering a CrashLoopBackOff because the container's entrypoint lacked permissions to modify its own data directory. Setting `user = "root"` allows the entrypoint to `chown` the folder correctly before stepping down.
2. **DNS Service Discovery:** Tasks within the `bridge` network lacked a resolver for `.consul` domains. Added a `dns` configuration inside the `network` block pointing to `cluster_ip` to allow the containers to locate their respective databases.

---
*PR created automatically by Jules for task [6624496505472024795](https://jules.google.com/task/6624496505472024795) started by @LokiMetaSmith*