### PR TITLE
Deprecate "Expert" Container deployment in monolith topology

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -477,7 +477,10 @@
   loop: "{{ verified_experts | default([]) }}"
   loop_control:
     loop_var: current_expert # Using the previously updated loop variable name
-  when: verified_experts is defined and verified_experts | length > 0
+  when: >
+    verified_experts is defined and
+    verified_experts | length > 0 and
+    deploy_topology != 'monolith'
   vars:
     # Define ONLY loop-specific variables here
     nomad_namespace: "{{ nomad_namespace }}"
@@ -513,7 +516,9 @@
     msg: >
       ⚠️  No verified experts found! Skipping expert job creation.
       (Check /var/log/llama_benchmarks.jsonl for failed benchmarks.)
-  when: verified_experts is not defined or verified_experts | length == 0
+  when: >
+    deploy_topology != 'monolith' and
+    (verified_experts is not defined or verified_experts | length == 0)
 
 - name: Copy test runner Nomad job template
   ansible.builtin.copy:

--- a/docs/TODO_Hybrid_Architecture.md
+++ b/docs/TODO_Hybrid_Architecture.md
@@ -49,8 +49,8 @@ Objective: Enable the main `pipecatapp` container to perform LLM inference and m
   - [x] In `app.py`, conditionally instantiate `LocalWorldModel` vs `MQTTWorldModelClient` based on `WORLD_MODEL_MODE` (local/distributed).
   - [x] Ensure `LocalWorldModel` still publishes updates to MQTT (fire-and-forget) so external observers (Home Assistant) stay in sync, even if the app doesn't read from MQTT.
 
-- [ ] **Deprecate "Expert" Container**
-  - [ ] Update `ansible/roles/pipecatapp/tasks/main.yaml` to make the deployment of `expert-*.nomad` jobs conditional on `deploy_topology != 'monolith'`.
+- [x] **Deprecate "Expert" Container**
+  - [x] Update `ansible/roles/pipecatapp/tasks/main.yaml` to make the deployment of `expert-*.nomad` jobs conditional on `deploy_topology != 'monolith'`.
 
 ## Phase 3: Adaptive Service Discovery
 

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -5,6 +5,9 @@
 # The tier of the node for deployment topology. Valid options: edge, mid, core
 node_tier: "mid"
 
+# Deployment topology setting: monolith vs distributed
+deploy_topology: "distributed"
+
 expected_cluster_size: "{{ groups['workers'] | length if 'workers' in groups else 1 }}"
 
 # This variable dynamically determines the node ID based on the hostname.


### PR DESCRIPTION
Deprecates the deployment of standalone "expert" Nomad containers when the deployment topology is configured as "monolith", in support of the hybrid architecture transition. Also marks the corresponding TODO item as complete.

---
*PR created automatically by Jules for task [17272369727729134953](https://jules.google.com/task/17272369727729134953) started by @LokiMetaSmith*