### PR TITLE
feat: Node-RED workflow converter

### DIFF
--- a/pipecatapp/web_server.py
+++ b/pipecatapp/web_server.py
@@ -630,6 +630,43 @@ async def get_workflow_definition(workflow_name: str, api_key: str = Security(ge
         # Security fix: Do not expose internal exception details
         raise HTTPException(status_code=500, detail="An error occurred while loading the workflow.")
 
+
+@app.post("/api/workflows/import/nodered", summary="Import Node-RED Flow", description="Imports a Node-RED flow JSON and converts it to a Pipecat workflow.", tags=["Workflow"])
+async def import_nodered_flow(payload: Dict = Body(...), api_key: str = Security(get_api_key), rate_limit: None = Depends(strict_limiter)):
+    """
+    Imports a Node-RED flow JSON and returns the converted Pipecat workflow definition.
+    Payload: { "nodered_data": [ ... ] }
+    """
+    nodered_data = payload.get("nodered_data")
+    if not nodered_data or not isinstance(nodered_data, list):
+        raise HTTPException(status_code=400, detail="Invalid Node-RED data format. Expected a JSON array.")
+
+    try:
+        from pipecatapp.workflow.nodered_converter import NodeRedConverter
+        workflow = NodeRedConverter.nodered_to_workflow(nodered_data=nodered_data)
+        return workflow
+    except Exception as e:
+        logger.error(f"Node-RED import failed: {e}")
+        raise HTTPException(status_code=500, detail="Failed to convert Node-RED flow.")
+
+@app.post("/api/workflows/export/nodered", summary="Export Node-RED Flow", description="Exports a Pipecat workflow definition to a Node-RED flow JSON.", tags=["Workflow"])
+async def export_nodered_flow(payload: Dict = Body(...), api_key: str = Security(get_api_key), rate_limit: None = Depends(strict_limiter)):
+    """
+    Exports a Pipecat workflow definition to a Node-RED flow JSON.
+    Payload: { "workflow": { ... } }
+    """
+    workflow = payload.get("workflow")
+    if not workflow or not isinstance(workflow, dict):
+        raise HTTPException(status_code=400, detail="Invalid workflow data format. Expected a JSON object.")
+
+    try:
+        from pipecatapp.workflow.nodered_converter import NodeRedConverter
+        nodered_data = NodeRedConverter.workflow_to_nodered(workflow=workflow)
+        return nodered_data
+    except Exception as e:
+        logger.error(f"Node-RED export failed: {e}")
+        raise HTTPException(status_code=500, detail="Failed to export to Node-RED flow.")
+
 @app.post("/api/workflows/save", summary="Save Workflow", description="Saves a workflow definition to a YAML file.", tags=["Workflow"])
 async def save_workflow_definition(payload: Dict = Body(...), api_key: str = Security(get_api_key), rate_limit: None = Depends(strict_limiter)):
     """

--- a/pipecatapp/workflow/nodered_converter.py
+++ b/pipecatapp/workflow/nodered_converter.py
@@ -1,0 +1,174 @@
+import json
+import logging
+from typing import Dict, Any, List
+
+class NodeRedConverter:
+    """
+    Converts between Node-RED Flow format (.json) and Pipecat Workflow format (.yaml).
+    """
+
+    @staticmethod
+    def nodered_to_workflow(nodered_path: str = None, nodered_data: List[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """
+        Parses a Node-RED flow and converts it into a Pipecat Workflow definition.
+        Accepts either a file path or direct JSON data.
+        """
+        if nodered_data is None:
+            if nodered_path is None:
+                logging.error("Either nodered_path or nodered_data must be provided.")
+                return {}
+            try:
+                with open(nodered_path, 'r', encoding='utf-8') as f:
+                    nodered_data = json.load(f)
+            except Exception as e:
+                logging.error(f"Failed to read Node-RED file {nodered_path}: {e}")
+                return {}
+
+        workflow = {
+            "name": "Generated from Node-RED",
+            "nodes": []
+        }
+
+        # 1. Map Nodes
+        for nr_node in nodered_data:
+            # Skip special global config nodes or flows if any (usually don't have x, y)
+            if "x" not in nr_node and "y" not in nr_node:
+                # Sometimes subflows or configs. We can skip or keep them depending on needs.
+                if nr_node.get("type") == "tab":
+                     continue # Skip flow tabs
+
+            workflow_node = {
+                "id": nr_node.get("id"),
+                "type": NodeRedConverter._infer_node_type(nr_node),
+                "config": NodeRedConverter._extract_config(nr_node),
+                "position": {
+                    "x": nr_node.get("x", 0.0),
+                    "y": nr_node.get("y", 0.0),
+                    "z": nr_node.get("z", 0.0) # Flow/tab ID usually
+                },
+                "dimensions": {
+                    "width": 200.0, # Default width
+                    "height": 50.0, # Default height
+                    "depth": 0.0
+                },
+                "style": {
+                    "color": "#cccccc",
+                    "shape": "box"
+                }
+            }
+            workflow["nodes"].append(workflow_node)
+
+        # 2. Map Edges (Connections)
+        # Node-RED format: "wires": [ ["target1", "target2"], ["target3"] ]
+        # outer index is the output port. inner elements are target node IDs.
+        for nr_node in nodered_data:
+            source_id = nr_node.get("id")
+            wires = nr_node.get("wires", [])
+
+            for port_idx, targets in enumerate(wires):
+                for target_id in targets:
+                    target_node = next((n for n in workflow["nodes"] if n["id"] == target_id), None)
+                    if target_node:
+                        if "inputs" not in target_node:
+                            target_node["inputs"] = []
+
+                        target_node["inputs"].append({
+                            "name": f"input_from_{source_id}_{port_idx}",
+                            "connection": {
+                                "from_node": source_id,
+                                "output_name": f"output_{port_idx}"
+                            }
+                        })
+
+        return workflow
+
+    @staticmethod
+    def _infer_node_type(node: Dict[str, Any]) -> str:
+        """
+        Infers the Pipecat node type based on Node-RED node type.
+        """
+        nr_type = node.get("type", "")
+        if nr_type == "inject":
+            return "input"
+        elif nr_type == "debug":
+            return "output"
+        elif nr_type == "function":
+            return "python_code"
+        elif nr_type == "http in":
+            return "http_server"
+        elif nr_type == "http request":
+            return "http_client"
+        return nr_type # Default to the Node-RED type as fallback
+
+    @staticmethod
+    def _extract_config(node: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Extracts configuration from the Node-RED node content.
+        """
+        config = {}
+        for key, value in node.items():
+            if key not in ["id", "type", "x", "y", "z", "wires"]:
+                config[key] = value
+        return config
+
+    @staticmethod
+    def workflow_to_nodered(workflow: Dict[str, Any], output_path: str = None) -> List[Dict[str, Any]]:
+        """
+        Converts a Pipecat Workflow back into a Node-RED Flow format.
+        """
+        nodered_nodes = []
+
+        # 1. Map Nodes
+        for wf_node in workflow.get("nodes", []):
+            nr_node = {
+                "id": wf_node.get("id"),
+                "type": wf_node.get("type", "unknown"),
+                "x": wf_node.get("position", {}).get("x", 0.0),
+                "y": wf_node.get("position", {}).get("y", 0.0),
+                "wires": []
+            }
+
+            # Map config back (flatten it)
+            for k, v in wf_node.get("config", {}).items():
+                nr_node[k] = v
+
+            # Add z (tab ID) if present
+            z_pos = wf_node.get("position", {}).get("z")
+            if z_pos:
+                 nr_node["z"] = z_pos
+
+            nodered_nodes.append(nr_node)
+
+        # 2. Map Edges (Connections)
+        # We need to look at each target node's inputs and map it back to the source node's `wires` array.
+        for wf_node in workflow.get("nodes", []):
+            target_id = wf_node.get("id")
+            for inp in wf_node.get("inputs", []):
+                if "connection" in inp:
+                    source_id = inp["connection"]["from_node"]
+                    # Usually "output_name" looks like "output_0" or "output". Try to infer index.
+                    output_name = inp["connection"].get("output_name", "output_0")
+                    port_idx = 0
+                    if output_name.startswith("output_"):
+                         try:
+                             port_idx = int(output_name.split("_")[1])
+                         except ValueError:
+                             pass
+
+                    # Find the source node in our Node-RED nodes list
+                    nr_source_node = next((n for n in nodered_nodes if n["id"] == source_id), None)
+                    if nr_source_node:
+                        # Ensure the `wires` array has enough sub-arrays to reach `port_idx`
+                        while len(nr_source_node["wires"]) <= port_idx:
+                            nr_source_node["wires"].append([])
+
+                        nr_source_node["wires"][port_idx].append(target_id)
+
+        if output_path:
+             try:
+                 with open(output_path, 'w', encoding='utf-8') as f:
+                     json.dump(nodered_nodes, f, indent=2)
+             except Exception as e:
+                 logging.error(f"Failed to write Node-RED file {output_path}: {e}")
+
+        return nodered_nodes

--- a/tests/unit/test_nodered_converter.py
+++ b/tests/unit/test_nodered_converter.py
@@ -1,0 +1,77 @@
+import json
+import os
+import asyncio
+from pipecatapp.workflow.nodered_converter import NodeRedConverter
+
+def test_nodered_conversion():
+    sample_nodered = [
+      {
+        "id": "node_debug",
+        "type": "debug",
+        "name": "",
+        "active": True,
+        "complete": False,
+        "x": 640,
+        "y": 200,
+        "wires": []
+      },
+      {
+        "id": "node_inject",
+        "type": "inject",
+        "name": "",
+        "topic": "",
+        "payload": "",
+        "repeat": "",
+        "once": False,
+        "x": 240,
+        "y": 200,
+        "wires": [
+          [
+            "node_function"
+          ]
+        ]
+      },
+      {
+        "id": "node_function",
+        "type": "function",
+        "name": "Format timestamp",
+        "func": "return msg;",
+        "outputs": 1,
+        "x": 440,
+        "y": 200,
+        "wires": [
+          [
+            "node_debug"
+          ]
+        ]
+      }
+    ]
+
+    workflow = NodeRedConverter.nodered_to_workflow(nodered_data=sample_nodered)
+
+    assert len(workflow["nodes"]) == 3, "Workflow should have 3 nodes"
+
+    debug_node = next(n for n in workflow["nodes"] if n["id"] == "node_debug")
+    assert debug_node["type"] == "output", "debug node mapped incorrectly"
+    assert debug_node["inputs"][0]["connection"]["from_node"] == "node_function"
+
+    inject_node = next(n for n in workflow["nodes"] if n["id"] == "node_inject")
+    assert inject_node["type"] == "input", "inject node mapped incorrectly"
+
+    function_node = next(n for n in workflow["nodes"] if n["id"] == "node_function")
+    assert function_node["type"] == "python_code", "function node mapped incorrectly"
+    assert function_node["inputs"][0]["connection"]["from_node"] == "node_inject"
+
+    nr_out = NodeRedConverter.workflow_to_nodered(workflow)
+
+    assert len(nr_out) == 3, "Converted back to Node-RED should have 3 nodes"
+
+    nr_inject = next(n for n in nr_out if n["id"] == "node_inject")
+    assert nr_inject["wires"][0] == ["node_function"], "Wires array missing or incorrect for inject node"
+
+    nr_function = next(n for n in nr_out if n["id"] == "node_function")
+    assert nr_function["wires"][0] == ["node_debug"], "Wires array missing or incorrect for function node"
+
+if __name__ == "__main__":
+    test_nodered_conversion()
+    print("Node-RED conversion test passed.")


### PR DESCRIPTION
This PR adds a utility to import and export Node-RED flows within the custom workflow engine. It accomplishes this via the `NodeRedConverter` which transforms Node-RED JSON definitions into the internal Pipecat workflow structure (translating `wires` arrays to Pipecat input connections and vice-versa) and provides the associated HTTP API endpoints in `web_server.py` to leverage the conversion feature programmatically.

---
*PR created automatically by Jules for task [4507714479840081851](https://jules.google.com/task/4507714479840081851) started by @LokiMetaSmith*