### PR TITLE
Fix Authentik Nomad job missing Vault secrets

### DIFF
--- a/ansible/jobs/authentik.nomad
+++ b/ansible/jobs/authentik.nomad
@@ -33,10 +33,8 @@ job "authentik" {
       }
       template {
         data = <<EOH
-{{ with secret "kv/data/authentik/config" }}
-AUTHENTIK_SECRET_KEY={{ .Data.data.secret_key }}
-AUTHENTIK_POSTGRESQL__PASSWORD={{ .Data.data.db_password }}
-{{ end }}
+AUTHENTIK_SECRET_KEY={{ key "authentik/secret-key" }}
+AUTHENTIK_POSTGRESQL__PASSWORD={{ key "authentik/db-password" }}
 EOH
         destination = "secrets/authentik.env"
         env         = true
@@ -79,10 +77,8 @@ EOH
       }
       template {
         data = <<EOH
-{{ with secret "kv/data/authentik/config" }}
-AUTHENTIK_SECRET_KEY={{ .Data.data.secret_key }}
-AUTHENTIK_POSTGRESQL__PASSWORD={{ .Data.data.db_password }}
-{{ end }}
+AUTHENTIK_SECRET_KEY={{ key "authentik/secret-key" }}
+AUTHENTIK_POSTGRESQL__PASSWORD={{ key "authentik/db-password" }}
 EOH
         destination = "secrets/authentik.env"
         env         = true

--- a/ansible/jobs/postgres.nomad
+++ b/ansible/jobs/postgres.nomad
@@ -23,9 +23,7 @@ job "postgres" {
       }
       template {
         data = <<EOH
-{{ with secret "kv/data/authentik/config" }}
-POSTGRES_PASSWORD={{ .Data.data.db_password }}
-{{ end }}
+POSTGRES_PASSWORD={{ key "authentik/db-password" }}
 EOH
         destination = "secrets/postgres.env"
         env         = true

--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -77,6 +77,37 @@
     (authentik_consul_key.status == 404 or
     (authentik_consul_key.status == 200 and authentik_consul_key.json[0].Value | default('') | b64decode | length < 50))
 
+- name: Check if Authentik DB password exists in Consul
+  ansible.builtin.uri:
+    url: "http://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_http_port | default(8500) }}/v1/kv/authentik/db-password"
+    method: GET
+    headers:
+      X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
+    status_code: [200, 404]
+  register: authentik_db_password_key
+  ignore_errors: yes
+
+- name: Generate Authentik DB password
+  ansible.builtin.command: openssl rand -base64 32
+  register: authentik_generated_db_password
+  when: >
+    authentik_db_password_key is not failed and
+    (authentik_db_password_key.status == 404 or
+    (authentik_db_password_key.status == 200 and authentik_db_password_key.json[0].Value | default('') | b64decode | length < 10))
+
+- name: Publish Authentik DB password to Consul
+  ansible.builtin.uri:
+    url: "http://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_http_port | default(8500) }}/v1/kv/authentik/db-password"
+    method: PUT
+    headers:
+      X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
+    body: "{{ authentik_generated_db_password.stdout }}"
+    status_code: [200, 201]
+  when: >
+    authentik_db_password_key is not failed and
+    (authentik_db_password_key.status == 404 or
+    (authentik_db_password_key.status == 200 and authentik_db_password_key.json[0].Value | default('') | b64decode | length < 10))
+
 - name: Template Authentik Nomad job
   ansible.builtin.template:
     src: authentik.nomad.j2

--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -4,9 +4,9 @@ job "authentik" {
 
 update {
   max_parallel      = 1
-  min_healthy_time  = "30s"
-  healthy_deadline  = "10m"
-  progress_deadline = "15m"
+  min_healthy_time  = "60s"
+  healthy_deadline  = "15m"
+  progress_deadline = "30m"
   canary            = 1
   auto_revert       = false
 }
@@ -90,9 +90,7 @@ update {
 
       template {
         data = <<EOH
-{{ '{{' }} with secret "kv/data/authentik/config" {{ '}}' }}
-POSTGRES_PASSWORD="{{ '{{' }} .Data.data.db_password {{ '}}' }}"
-{{ '{{' }} end {{ '}}' }}
+POSTGRES_PASSWORD="{{ '{{' }} key "authentik/db-password" {{ '}}' }}"
 EOH
         destination = "secrets/postgres.env"
         env         = true
@@ -136,9 +134,7 @@ AUTHENTIK_REDIS__HOST="{{ authentik_redis_host | default('redis.service.consul')
 AUTHENTIK_REDIS__PORT="{{ authentik_redis_port | default(16379) }}"
 AUTHENTIK_POSTGRESQL__HOST="{{ authentik_postgres_host | default('postgres.service.consul') }}"
 AUTHENTIK_POSTGRESQL__PORT="{{ authentik_postgres_port | default(15432) }}"
-{{ '{{' }} with secret "kv/data/authentik/config" {{ '}}' }}
-AUTHENTIK_POSTGRESQL__PASSWORD="{{ '{{' }} .Data.data.db_password {{ '}}' }}"
-{{ '{{' }} end {{ '}}' }}
+AUTHENTIK_POSTGRESQL__PASSWORD="{{ '{{' }} key "authentik/db-password" {{ '}}' }}"
 EOH
         destination = "secrets/authentik.env"
         env         = true
@@ -195,9 +191,7 @@ AUTHENTIK_REDIS__HOST="{{ authentik_redis_host | default('redis.service.consul')
 AUTHENTIK_REDIS__PORT="{{ authentik_redis_port | default(16379) }}"
 AUTHENTIK_POSTGRESQL__HOST="{{ authentik_postgres_host | default('postgres.service.consul') }}"
 AUTHENTIK_POSTGRESQL__PORT="{{ authentik_postgres_port | default(15432) }}"
-{{ '{{' }} with secret "kv/data/authentik/config" {{ '}}' }}
-AUTHENTIK_POSTGRESQL__PASSWORD="{{ '{{' }} .Data.data.db_password {{ '}}' }}"
-{{ '{{' }} end {{ '}}' }}
+AUTHENTIK_POSTGRESQL__PASSWORD="{{ '{{' }} key "authentik/db-password" {{ '}}' }}"
 EOH
         destination = "secrets/authentik.env"
         env         = true


### PR DESCRIPTION
Resolves the Nomad deployment loop where the Authentik job was hanging indefinitely in a pending state. Nomad was attempting to fetch secrets from Vault, which is not deployed in this architecture.

- Switched secret management from Vault `secret` lookup to Consul `key` lookup in `authentik.nomad.j2`, `authentik.nomad`, and `postgres.nomad`.
- Added idempotent Ansible tasks in the Authentik role to securely generate and publish the database password (`authentik/db-password`) to Consul KV during bootstrap.
- Increased the health and progress deadlines (`min_healthy_time`, `healthy_deadline`, `progress_deadline`) to give the database more time to initialize on constrained hardware.

---
*PR created automatically by Jules for task [2754990693846287477](https://jules.google.com/task/2754990693846287477) started by @LokiMetaSmith*