### PR TITLE
Fix Authentik Nomad job retry logic

### DIFF
--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -119,6 +119,31 @@
   become: yes
   changed_when: false
 
+- name: Check Authentik Nomad job status
+  ansible.builtin.command: nomad job status authentik
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+  register: authentik_job_status
+  failed_when: false
+  changed_when: false
+
+- name: Purge stuck Authentik job
+  ansible.builtin.command: nomad job stop -purge authentik
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+  when: >
+    authentik_job_status.rc == 0 and
+    ('Status = dead' in authentik_job_status.stdout or
+     'Status = failed' in authentik_job_status.stdout or
+     'Failed due to progress deadline' in authentik_job_status.stdout)
+  changed_when: true
+
 - name: Run Authentik Nomad job
   ansible.builtin.command: nomad job run {{ nomad_jobs_dir }}/authentik.nomad
   environment:


### PR DESCRIPTION
This commit resolves the issue where a failed deployment (e.g., progress deadline) causes subsequent runs of the Authentik Nomad job to fail immediately without attempting to redeploy. We now check the status of the `authentik` job beforehand, and if it's stuck in a failed/dead state, we purge it using `nomad job stop -purge authentik` before running `nomad job run`.

---
*PR created automatically by Jules for task [6765261766814716222](https://jules.google.com/task/6765261766814716222) started by @LokiMetaSmith*