### PR TITLE
Fix Ansible fact deprecation warnings

### DIFF
--- a/ansible/roles/common/tasks/network_repair.yaml
+++ b/ansible/roles/common/tasks/network_repair.yaml
@@ -1,6 +1,6 @@
 - name: "Network Repair : Detect OS"
   ansible.builtin.debug:
-    msg: "Detected OS: {{ ansible_distribution }} ({{ ansible_os_family }})"
+    msg: "Detected OS: {{ ansible_facts['distribution'] }} ({{ ansible_facts['os_family'] }})"
 
 - name: "Network Repair : Gather Network Facts"
   ansible.builtin.setup:
@@ -19,13 +19,13 @@
     # Modified to exclude wireless interfaces (wlp*, wlan*) unless wifi_ssid is provided
     physical_interfaces: >-
       {{
-        ansible_interfaces
+        ansible_facts['interfaces']
         | map('regex_search', '^(e|w)[a-zA-Z0-9]+$')
         | select('string')
         | reject('match', '^(wlp|wlan)')
         | list
         +
-        (ansible_interfaces | map('regex_search', '^(wlp|wlan)[a-zA-Z0-9]+$') | select('string') | list if wifi_ssid is defined else [])
+        (ansible_facts['interfaces'] | map('regex_search', '^(wlp|wlan)[a-zA-Z0-9]+$') | select('string') | list if wifi_ssid is defined else [])
       }}
 
 - name: "Network Repair : Identify Down Interfaces"
@@ -37,7 +37,7 @@
     # We construct a list of active interfaces first to simplify rejection.
     active_interfaces: >-
       {{
-        ansible_interfaces
+        ansible_facts['interfaces']
         | select('in', hostvars[inventory_hostname])
         | selectattr('active', 'defined', hostvars[inventory_hostname])
         | selectattr('active', 'equalto', true, hostvars[inventory_hostname])
@@ -85,7 +85,7 @@
       ignore_errors: yes
       become: yes
 
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 # --- NixOS Logic ---
 - block:
@@ -95,7 +95,7 @@
         state: restarted
       ignore_errors: yes
       become: yes
-  when: ansible_os_family == 'NixOS' or ansible_distribution == 'NixOS'
+  when: ansible_facts['os_family'] == 'NixOS' or ansible_facts['distribution'] == 'NixOS'
 
 # --- Post-Repair Checks ---
 - name: "Network Repair : Check Internet Connectivity (8.8.8.8)"

--- a/ansible/roles/headscale/tasks/main.yaml
+++ b/ansible/roles/headscale/tasks/main.yaml
@@ -88,5 +88,5 @@
 - name: Set headscale auth key fact
   set_fact:
     headscale_auth_key: "{{ headscale_auth_key_output.stdout_lines[-1] }}"
-    headscale_server_url: "http://{{ ansible_default_ipv4.address }}:{{ headscale_port }}"
+    headscale_server_url: "http://{{ ansible_facts['default_ipv4'].address }}:{{ headscale_port }}"
   when: headscale_auth_key_output.stdout_lines is defined and headscale_auth_key_output.stdout_lines | length > 0

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -117,7 +117,7 @@
 
     - name: Build llama.cpp
       ansible.builtin.command:
-        cmd: cmake --build build --config Release -j {{ ansible_processor_vcpus }}
+        cmd: cmake --build build --config Release -j {{ ansible_facts['processor_vcpus'] }}
       args:
         chdir: "{{ llama_cpp_build_dir }}"
         creates: "{{ llama_cpp_build_dir }}/build/bin/llama-server"

--- a/ansible/roles/magic_mirror/tasks/main.yaml
+++ b/ansible/roles/magic_mirror/tasks/main.yaml
@@ -10,7 +10,7 @@
 
 - name: Debug bind address
   ansible.builtin.debug:
-    msg: "Magic Mirror will bind to IP: {{ (ansible_default_ipv4 | default({})).get('address', '127.0.0.1') }}"
+    msg: "Magic Mirror will bind to IP: {{ (ansible_facts['default_ipv4'] | default({})).get('address', '127.0.0.1') }}"
 
 - name: Deploy Magic Mirror
   block:
@@ -24,7 +24,7 @@
 
     - name: Determine correct libasound package
       ansible.builtin.set_fact:
-        libasound_pkg: "{{ 'libasound2t64' if ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int >= 24 else 'libasound2' }}"
+        libasound_pkg: "{{ 'libasound2t64' if ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] | int >= 24 else 'libasound2' }}"
 
     - name: Install libasound
       ansible.builtin.apt:

--- a/ansible/roles/magic_mirror/templates/magic_mirror.nomad.j2
+++ b/ansible/roles/magic_mirror/templates/magic_mirror.nomad.j2
@@ -51,7 +51,7 @@ EOH
         check {
           type     = "script"
           command  = "/bin/bash"
-          args     = ["-c", "echo > /dev/tcp/{{ (ansible_default_ipv4 | default({})).get('address', '127.0.0.1') }}/41111"]
+          args     = ["-c", "echo > /dev/tcp/{{ (ansible_facts['default_ipv4'] | default({})).get('address', '127.0.0.1') }}/41111"]
           interval = "10s"
           timeout  = "2s"
         }

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -489,7 +489,7 @@
     model_list: "{{ expert_models[current_expert] | default([]) }}" # Corrected default
     worker_count: 1
     rpc_pool_job_name: "llamacpp-rpc-pool"
-    # DO NOT redefine ansible_memtotal_mb here
+    # DO NOT redefine ansible_facts['memtotal_mb'] here
     # The benchmark data calculation can stay if needed, adjust variable names if necessary
     benchmark_data_for_expert: >-
       {{
@@ -502,12 +502,12 @@
         (benchmark_data_for_expert | map(attribute='tokens_per_second') | list | sum / (benchmark_data_for_expert | length))
         if (benchmark_data_for_expert | length > 0) else 0
       }}
-    # expert_tags definition can stay, but ensure it doesn't redefine ansible_memtotal_mb
+    # expert_tags definition can stay, but ensure it doesn't redefine ansible_facts['memtotal_mb']
     current_expert_tags: >-
       [
         "expert={{ current_expert }}",
         "avg_tps={{ avg_tokens | float | round(2) }}",
-        "memory_mb={{ ansible_memtotal_mb }}", # Access global fact directly
+        "memory_mb={{ ansible_facts['memtotal_mb'] }}", # Access global fact directly
         "models={{ model_list | map(attribute='filename') | join(',') }}"
       ]
 

--- a/ansible/roles/semantic_router/defaults/main.yaml
+++ b/ansible/roles/semantic_router/defaults/main.yaml
@@ -3,4 +3,4 @@ semantic_router_port: 8000
 semantic_router_image_name: "semantic-router:latest"
 semantic_router_build_dir: "/opt/semantic_router"
 nomad_jobs_dir: "/opt/nomad/jobs"
-cluster_ip: "{{ ansible_default_ipv4.address }}"
+cluster_ip: "{{ ansible_facts['default_ipv4'].address }}"

--- a/ansible/tasks/create_expert_job.yaml
+++ b/ansible/tasks/create_expert_job.yaml
@@ -13,9 +13,9 @@
     # Note: pipecat_image_id and pipecat_api_keys are inherited from global/play scope
     # to avoid recursive loop errors if redefined here as "{{ var }}".
     avg_tokens: "{{ (expert_benchmark_data.get(current_expert, {})).get('avg_tokens', 0) | float | round(2) }}"
-    # DO NOT redefine ansible_memtotal_mb here
+    # DO NOT redefine ansible_facts['memtotal_mb'] here
     current_expert_tags:
       - "expert={{ current_expert }}"
       - "avg_tps={{ avg_tokens }}"
-      - "memory_mb={{ ansible_memtotal_mb }}"
+      - "memory_mb={{ ansible_facts['memtotal_mb'] }}"
       - "models={{ model_list | map(attribute='filename') | join(',') }}"

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -28,7 +28,7 @@ cluster_subnet_prefix: "10.0.0"
 # Determine the cluster IP dynamically:
 # 1. Try to get the IP of the 'tailscale0' interface (mesh network).
 # 2. Fallback to the legacy alias logic if the mesh isn't up yet.
-cluster_ip: "{{ ansible_facts.get('tailscale0', {}).get('ipv4', {}).get('address', ansible_default_ipv4.address if ansible_default_ipv4 is defined else '127.0.0.1') }}"
+cluster_ip: "{{ ansible_facts.get('tailscale0', {}).get('ipv4', {}).get('address', ansible_facts['default_ipv4'].address if ansible_facts['default_ipv4'] is defined else '127.0.0.1') }}"
 
 
 ansible_python_interpreter: /usr/bin/python3

--- a/playbooks/benchmark_single_model.yaml
+++ b/playbooks/benchmark_single_model.yaml
@@ -22,7 +22,7 @@
             | default('0')
             | float
           ),
-          'timestamp': ansible_date_time.iso8601,
+          'timestamp': ansible_facts['date_time'].iso8601,
           'rc': benchmark_result.rc,
           'stdout': (benchmark_result.stdout | regex_replace('\\s+', ' ') | truncate(400)),
           'stderr': (benchmark_result.stderr | regex_replace('\\s+', ' ') | truncate(400))

--- a/playbooks/deploy_expert.yaml
+++ b/playbooks/deploy_expert.yaml
@@ -19,7 +19,7 @@
     current_expert_tags:
       - "expert={{ current_expert }}"
       - "avg_tps={{ avg_tokens_for_template }}"
-      - "memory_mb={{ ansible_memtotal_mb }}"
+      - "memory_mb={{ ansible_facts['memtotal_mb'] }}"
       - "models={{ model_list | map(attribute='filename') | join(',') }}"
 
   tasks:
@@ -51,7 +51,7 @@
             'job_name': job_name,
             'service_name': service_name,
             'rpc_pool_job_name': rpc_pool_job_name,
-            'ansible_memtotal_mb': ansible_memtotal_mb
+            'ansible_memtotal_mb': ansible_facts['memtotal_mb']
           } | to_json }}"
         dest: "{{ playbook_dir }}/tmp/expert-{{ current_expert }}-vars.json"
         mode: '0644'

--- a/playbooks/fix_cluster.yaml
+++ b/playbooks/fix_cluster.yaml
@@ -7,10 +7,10 @@
       ansible.builtin.set_fact:
         is_controller_candidate: true
       when:
-        - ansible_processor_vcpus is defined
-        - ansible_processor_vcpus >= 2
-        - ansible_memtotal_mb is defined
-        - ansible_memtotal_mb >= 8000
+        - ansible_facts['processor_vcpus'] is defined
+        - ansible_facts['processor_vcpus'] >= 2
+        - ansible_facts['memtotal_mb'] is defined
+        - ansible_facts['memtotal_mb'] >= 8000
 
     - name: Add suitable candidates to the 'new_controllers' group
       ansible.builtin.add_host:
@@ -42,8 +42,8 @@
 
     - name: Find block devices
       ansible.builtin.set_fact:
-        block_devices: "{{ ansible_devices.keys() | select('match', '^(s|xv)d[a-z]+$') | list }}"
-      when: ansible_devices is defined
+        block_devices: "{{ ansible_facts['devices'].keys() | select('match', '^(s|xv)d[a-z]+$') | list }}"
+      when: ansible_facts['devices'] is defined
 
     - name: Check SMART health for each block device
       ansible.builtin.command:

--- a/playbooks/network/verify.yaml
+++ b/playbooks/network/verify.yaml
@@ -27,7 +27,7 @@
 
         - name: "Check 4: Verify connectivity to Headscale Controller"
           uri:
-            url: "http://{{ hostvars[groups['controller_nodes'][0]]['ansible_default_ipv4']['address'] }}:{{ headscale_port }}/health"
+            url: "http://{{ hostvars[groups['controller_nodes'][0]]['ansible_facts']['default_ipv4']['address'] }}:{{ headscale_port }}/health"
             method: GET
             status_code: 200
             return_content: no


### PR DESCRIPTION
Replaces legacy top-level `ansible_*` fact lookups with the modern `ansible_facts['...']` notation across playbooks, templates, variables, and role defaults. This addresses the `INJECT_FACTS_AS_VARS` depreciation warning to make sure the playbooks remain functional with future Ansible core 2.24 releases.

---
*PR created automatically by Jules for task [7650329685271861640](https://jules.google.com/task/7650329685271861640) started by @LokiMetaSmith*