### PR TITLE
chore: temporarily disable Authentik nomad job

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@
 ## Immediate Actions
 
 - [x] **Fix Authentik Nomad Job:**
+  - [ ] **Re-enable Authentik Nomad Job:** The job was temporarily disabled during cluster upbringing. Re-enable it and investigate the 'progress deadline' issue once the rest of the cluster is running.
   - **Goal:** Resolve issues preventing the Authentik Nomad job from deploying successfully.
 - [x] **Bootable System Installation & Auto-Configuration:**
   - **Goal:** Create a slimmed-down, bootable Debian ISO and enhance `bootstrap.sh` to auto-detect hardware resources.

--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -145,6 +145,7 @@
   changed_when: true
 
 - name: Run Authentik Nomad job
+  when: false
   ansible.builtin.command: nomad job run {{ nomad_jobs_dir }}/authentik.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"


### PR DESCRIPTION
As requested, disabled the Authentik nomad job via the ansible playbook (`when: false`) and added a TODO item to address its progress deadline timeout issue later, allowing the rest of the cluster to be provisioned.

---
*PR created automatically by Jules for task [3709935611719024017](https://jules.google.com/task/3709935611719024017) started by @LokiMetaSmith*