### PR TITLE
fix(bootstrap): export ANSIBLE_CONFIG to fix world-writable warning

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -541,6 +541,7 @@ ensure_python_environment() {
 
     # Install Ansible collections
     if [ -x "$ANSIBLE_GALAXY_EXEC" ]; then
+        export ANSIBLE_CONFIG="$(pwd)/ansible.cfg"
         run_step "Installing Ansible collections" "$ANSIBLE_GALAXY_EXEC collection install community.general ansible.posix community.docker community.sops"
     else
         echo "Error: ansible-galaxy not found in venv." >&2


### PR DESCRIPTION
Adds an explicit export of the `ANSIBLE_CONFIG` environment variable in `bootstrap.sh` right before running `ansible-galaxy`. This resolves a warning seen in the `bootstrap_debug.log` where Ansible ignores the local `ansible.cfg` because it considers the working directory world-writable. This brings the script's behavior in line with how `scripts/provisioning.py` handles the same issue programmatically.

---
*PR created automatically by Jules for task [13763096831158623441](https://jules.google.com/task/13763096831158623441) started by @LokiMetaSmith*