### PR TITLE
Fix FastAPI Mocking test discovery issue

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -313,6 +313,6 @@ This section tracks actionable ideas derived from the `docs/FLOWISE_ANALYSIS.md`
 ## Suggested New Items
 
 - [ ] **Fix Missing Test Dependencies:** Update requirements-dev.txt to include `pytest`, `pytest-asyncio`, and `httpx` to fix the test suite.
-- [ ] **Fix FastAPI Mocking:** Ensure FastAPI and `fastapi.responses` are properly mocked in test collection so `app.py` doesn't crash test discovery.
+- [x] **Fix FastAPI Mocking:** Ensure FastAPI and `fastapi.responses` are properly mocked in test collection so `app.py` doesn't crash test discovery.
 - [ ] **Implement Mobile UI Fixes for LiteGraph:** As noted in `litegraph.js` TODOs, improve the `dialog_close_on_mouse_leave` logic to work nicely on touch devices.
 - [ ] **Fix Type Filtering in LiteGraph:** Complete the `do_type_filter` implementation in `litegraph.js` to prevent users from making invalid edge connections based on `registered_slot_[in/out]_types`.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,6 @@
+# Plan to Fix TODO Item
+
+1. **Fix FastAPI Mocking**: Ensure FastAPI and `fastapi.responses` are properly mocked in test collection so `app.py` doesn't crash test discovery.
+   - I will add `fastapi.responses` and `pmm_memory` to the `modules_to_mock` list in `tests/unit/conftest.py`.
+   - I will verify this fixes test discovery in `tests/unit/test_pipecat_app_unit.py`.
+   - I will update `TODO.md` to check off only this specific item to follow the instructions precisely.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -85,6 +85,7 @@ modules_to_mock = [
     'yaml',
     'jinja2',
     'fastapi',
+    'fastapi.responses',
     'openai',
     'supervisor',
     'starlette',
@@ -95,7 +96,8 @@ modules_to_mock = [
     'faster_whisper',
     'opentelemetry.instrumentation.fastapi',
     'piper.voice',
-    'graphviz'
+    'graphviz',
+    'pmm_memory'
 ]
 
 def mock_module_if_missing(module_name):


### PR DESCRIPTION
This PR addresses the TODO item "Fix FastAPI Mocking". It adds the missing `fastapi.responses` and `pmm_memory` modules to the `modules_to_mock` list in `tests/unit/conftest.py`, which resolves `ModuleNotFoundError` issues that were crashing test discovery when `app.py` was imported. The corresponding task in `TODO.md` has been marked as completed.

---
*PR created automatically by Jules for task [6608661028734098353](https://jules.google.com/task/6608661028734098353) started by @LokiMetaSmith*