### PR TITLE
fix: clarify skipped services in provisioning output and fix nomad query

### DIFF
--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -455,8 +455,21 @@ def get_primary_ip():
 def print_final_status(args, executed_playbooks):
     print_header("Final Status Report")
 
-    # 1. Node Role & Controller info
+    # Determine stack mode
+    if args.deploy_full_stack:
+        stack_mode = "Full"
+    elif args.deploy_partial_stack:
+        stack_mode = "Partial"
+    elif args.deploy_minimal_stack:
+        stack_mode = "Minimal"
+    else:
+        stack_mode = "Infrastructure Only"
+
+    # 1. Node Role & Configuration info
     print(f"{Colors.BOLD}Node Role:{Colors.ENDC} {args.role}")
+    print(f"{Colors.BOLD}Deployment Tier:{Colors.ENDC} {args.tier}")
+    print(f"{Colors.BOLD}Stack Profile:{Colors.ENDC} {stack_mode}")
+
     if args.role == "worker" and args.controller_ip:
         print(f"{Colors.BOLD}Controller IP:{Colors.ENDC} {args.controller_ip}")
     elif args.role == "controller" or args.role == "all":
@@ -468,15 +481,21 @@ def print_final_status(args, executed_playbooks):
     print(f"  • {Colors.OKCYAN}Node IP Address:{Colors.ENDC} {ip}")
 
     interfaces = [
-        ("Nomad UI", 4646, f"http://{ip}:4646"),
-        ("Consul UI", 8500, f"http://{ip}:8500"),
-        ("Pipecat App", 8000, f"http://{ip}:8000"),
-        ("Home Assistant", 8123, f"http://{ip}:8123"),
+        ("Nomad UI", 4646, f"https://{ip}:4646", True),
+        ("Consul UI", 8500, f"https://{ip}:8500", True),
+        ("Pipecat App", 8000, f"https://{ip}:8000", stack_mode != "Infrastructure Only"),
+        ("Home Assistant", 8123, f"https://{ip}:8123", stack_mode != "Infrastructure Only" and stack_mode != "Minimal"),
     ]
 
-    for name, port, url in interfaces:
+    for name, port, url, should_be_active in interfaces:
         is_open = check_port_open(ip, port)
-        status = f"{Colors.OKGREEN}(Active){Colors.ENDC}" if is_open else f"{Colors.FAIL}(Inactive){Colors.ENDC}"
+        if is_open:
+            status = f"{Colors.OKGREEN}(Active){Colors.ENDC}"
+        else:
+            if not should_be_active:
+                status = f"{Colors.WARNING}(Skipped - Profile: {stack_mode}){Colors.ENDC}"
+            else:
+                status = f"{Colors.FAIL}(Inactive){Colors.ENDC}"
         print(f"  • {Colors.OKCYAN}{name:<15}:{Colors.ENDC} {url:<25} {status}")
 
     # 3. Intended Services
@@ -518,8 +537,15 @@ def print_final_status(args, executed_playbooks):
     try:
         # Check if nomad is reachable
         env = os.environ.copy()
-        env["NOMAD_ADDR"] = f"http://{ip}:4646"
+        env["NOMAD_ADDR"] = f"https://{ip}:4646"
+        env["NOMAD_TLS_SKIP_VERIFY"] = "1"
         result = subprocess.run(["nomad", "job", "status", "-short"], capture_output=True, text=True, env=env)
+
+        # If it fails, fallback to 127.0.0.1 in case nomad is only bound locally
+        if result.returncode != 0:
+            env["NOMAD_ADDR"] = "https://127.0.0.1:4646"
+            result = subprocess.run(["nomad", "job", "status", "-short"], capture_output=True, text=True, env=env)
+
         if result.returncode == 0 and result.stdout.strip():
             print(f"\n{Colors.BOLD}Running Nomad Jobs:{Colors.ENDC}")
             lines = result.stdout.strip().split('\n')

--- a/tests/unit/test_provisioning.py
+++ b/tests/unit/test_provisioning.py
@@ -30,15 +30,20 @@ class TestProvisioning(unittest.TestCase):
         provisioning.INVENTORY_FILE = self.original_inventory
 
     def test_load_playbooks_from_manifest(self):
+        import yaml as real_yaml
         manifest_path = os.path.join(self.test_dir, "test_manifest.yaml")
         data = [
             {"import_playbook": "playbooks/p1.yaml", "tags": ["t1"]},
             {"import_playbook": "playbooks/p2.yaml"}
         ]
-        with open(manifest_path, 'w') as f:
-            yaml.dump(data, f)
 
-        playbooks = provisioning.load_playbooks_from_manifest(manifest_path)
+        with open(manifest_path, 'w') as f:
+            real_yaml.dump(data, f)
+
+        # Explicitly patch provisioning.yaml with the real module
+        with patch('provisioning.yaml', real_yaml):
+            playbooks = provisioning.load_playbooks_from_manifest(manifest_path)
+
         self.assertEqual(len(playbooks), 2)
         self.assertEqual(playbooks[0]['path'], "playbooks/p1.yaml")
         self.assertEqual(playbooks[0]['tags'], ["t1"])


### PR DESCRIPTION
The `bootstrap.sh` wrapper logic often drops the provisioning script into an `infrastructure-only` mode depending on the selected tier. When this occurs, services like Pipecat App or Home Assistant are intentionally omitted, but the terminal output misleadingly reported them as `(Inactive)`, confusing end users.

This fixes the issue by calculating the true active stack profile (Full, Partial, Minimal, or Infrastructure Only) and injecting a more descriptive label `(Skipped - Profile: [mode])` for the omitted services.

Additionally, this ensures the Python `subprocess` querying the Nomad status uses `https://` alongside `NOMAD_TLS_SKIP_VERIFY`, as the underlying stack was recently upgraded to enforce TLS.

---
*PR created automatically by Jules for task [13469407395842771274](https://jules.google.com/task/13469407395842771274) started by @LokiMetaSmith*