### PR TITLE
fix: Enable running the Authentik Nomad job

### DIFF
--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -145,7 +145,6 @@
   changed_when: true
 
 - name: Run Authentik Nomad job
-  when: false
   ansible.builtin.command: nomad job run {{ nomad_jobs_dir }}/authentik.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"


### PR DESCRIPTION
The deployment of the Authentik Nomad job was being skipped because of a hardcoded `when: false` condition. I have removed it to allow the `nomad job run` command to be executed properly in `ansible/roles/authentik/tasks/main.yml`.

---
*PR created automatically by Jules for task [10110387329046116240](https://jules.google.com/task/10110387329046116240) started by @LokiMetaSmith*