### PR TITLE
Fix monitoring playbook timeout waiting for MQTT service

### DIFF
--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -235,7 +235,7 @@
   block:
     - name: Wait for MQTT service to be ready
       ansible.builtin.wait_for:
-        host: "127.0.0.1"
+        host: "{{ cluster_ip | default('127.0.0.1') }}"
         port: "{{ mqtt_port }}"
         timeout: 300
         state: started


### PR DESCRIPTION
Resolves an issue where the `monitoring.yaml` playbook timed out waiting for the MQTT service on port 1883 because it was polling localhost instead of the correct cluster mesh IP.

---
*PR created automatically by Jules for task [2031484932658062921](https://jules.google.com/task/2031484932658062921) started by @LokiMetaSmith*