### PR TITLE
Fix mosquitto configuration to bind listeners to 0.0.0.0 explicitly

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -25,9 +25,9 @@
       persistence_location /mosquitto/data/
       log_dest stdout
       log_type all
-      listener {{ mqtt_port }}
+      listener {{ mqtt_port }} 0.0.0.0
       allow_anonymous true
-      listener {{ mqtt_websocket_port }}
+      listener {{ mqtt_websocket_port }} 0.0.0.0
       protocol websockets
     mode: '0644'
   become: yes


### PR DESCRIPTION
Fix mosquitto configuration to bind listeners to 0.0.0.0 explicitly

Mosquitto configuration in `mqtt` ansible role was updated to explicitly bind the listeners on port 1883 and 9001 to `0.0.0.0`. This prevents Mosquitto from defaulting to local loopback or IPv6 interfaces when using `host` networking in Nomad, resolving issues where Ansible's `wait_for` tasks timing out while checking the Tailscale cluster IP (`100.64.0.1`).

---
*PR created automatically by Jules for task [14176809747391868738](https://jules.google.com/task/14176809747391868738) started by @LokiMetaSmith*