### PR TITLE
Fix Authentik Nomad job progress deadline timeout by defining explicit host volumes

### DIFF
--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -66,15 +66,41 @@ update {
       }
     }
 
+    volume "authentik-postgres" {
+      type      = "host"
+      read_only = false
+      source    = "authentik-postgres"
+    }
+
+    volume "authentik-media" {
+      type      = "host"
+      read_only = false
+      source    = "authentik-media"
+    }
+
+    volume "authentik-templates" {
+      type      = "host"
+      read_only = false
+      source    = "authentik-templates"
+    }
+
+    volume "authentik-certs" {
+      type      = "host"
+      read_only = false
+      source    = "authentik-certs"
+    }
+
     task "postgresql" {
       driver = "docker"
+
+      volume_mount {
+        volume      = "authentik-postgres"
+        destination = "/var/lib/postgresql/data"
+      }
 
       config {
         image = "postgres:15-alpine"
         ports = ["postgres"]
-        volumes = [
-          "{{ nomad_volumes_dir }}/authentik/postgres:/var/lib/postgresql/data"
-        ]
       }
 
       service {
@@ -116,14 +142,20 @@ EOH
     task "server" {
       driver = "docker"
 
+      volume_mount {
+        volume      = "authentik-media"
+        destination = "/media"
+      }
+
+      volume_mount {
+        volume      = "authentik-templates"
+        destination = "/templates"
+      }
+
       config {
         image        = "ghcr.io/goauthentik/server:2024.2.2"
         args         = ["server"]
         ports        = ["http", "https"]
-        volumes = [
-          "{{ nomad_volumes_dir }}/authentik/media:/media",
-          "{{ nomad_volumes_dir }}/authentik/templates:/templates"
-        ]
       }
 
       template {
@@ -173,14 +205,24 @@ EOH
     task "worker" {
       driver = "docker"
 
+      volume_mount {
+        volume      = "authentik-media"
+        destination = "/media"
+      }
+
+      volume_mount {
+        volume      = "authentik-certs"
+        destination = "/certs"
+      }
+
+      volume_mount {
+        volume      = "authentik-templates"
+        destination = "/templates"
+      }
+
       config {
         image        = "ghcr.io/goauthentik/server:2024.2.2"
         args         = ["worker"]
-        volumes = [
-          "{{ nomad_volumes_dir }}/authentik/media:/media",
-          "{{ nomad_volumes_dir }}/authentik/certs:/certs",
-          "{{ nomad_volumes_dir }}/authentik/templates:/templates"
-        ]
       }
 
       template {

--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -100,6 +100,26 @@ client {
     read_only = false
   }
   
+  host_volume "authentik-postgres" {
+    path      = "{{ nomad_volumes_dir }}/authentik/postgres"
+    read_only = false
+  }
+
+  host_volume "authentik-media" {
+    path      = "{{ nomad_volumes_dir }}/authentik/media"
+    read_only = false
+  }
+
+  host_volume "authentik-templates" {
+    path      = "{{ nomad_volumes_dir }}/authentik/templates"
+    read_only = false
+  }
+
+  host_volume "authentik-certs" {
+    path      = "{{ nomad_volumes_dir }}/authentik/certs"
+    read_only = false
+  }
+
 }
 
 tls {

--- a/ansible/roles/nomad/templates/server.hcl.j2
+++ b/ansible/roles/nomad/templates/server.hcl.j2
@@ -94,6 +94,26 @@ client {
     read_only = false
   }
 
+  host_volume "authentik-postgres" {
+    path      = "{{ nomad_volumes_dir }}/authentik/postgres"
+    read_only = false
+  }
+
+  host_volume "authentik-media" {
+    path      = "{{ nomad_volumes_dir }}/authentik/media"
+    read_only = false
+  }
+
+  host_volume "authentik-templates" {
+    path      = "{{ nomad_volumes_dir }}/authentik/templates"
+    read_only = false
+  }
+
+  host_volume "authentik-certs" {
+    path      = "{{ nomad_volumes_dir }}/authentik/certs"
+    read_only = false
+  }
+
 }
 
 tls {


### PR DESCRIPTION
The `authentik` Nomad deployment was failing with a `progress deadline` error during provisioning. 

Root Cause: The Nomad job defined Docker-specific `volumes` arrays mapping to host directories. When deploying stateful services through Nomad, it's best practice (and required by stricter Nomad validations) to declare `host_volume` blocks in the Nomad agent configuration (`client.hcl` and `server.hcl`) and consume them in the job template using native `volume` and `volume_mount` blocks. Without these declarations, the scheduler couldn't verify the directories, resulting in placement stalling and ultimately timing out.

Fix:
- Added explicit `host_volume` declarations for `authentik-postgres`, `authentik-media`, `authentik-templates`, and `authentik-certs` to `ansible/roles/nomad/templates/client.hcl.j2` and `server.hcl.j2`.
- Updated `ansible/roles/authentik/templates/authentik.nomad.j2` to utilize native Nomad `volume` groups and `volume_mount` directives within the `postgresql`, `server`, and `worker` tasks, completely eliminating the legacy Docker `volumes` bind mappings.

---
*PR created automatically by Jules for task [5172752067886713816](https://jules.google.com/task/5172752067886713816) started by @LokiMetaSmith*