### PR TITLE
Fix MQTT timeout in monitoring playbook

### DIFF
--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -235,7 +235,7 @@
   block:
     - name: Wait for MQTT service to be ready
       ansible.builtin.wait_for:
-        host: "{{ cluster_ip | default('127.0.0.1') }}"
+        host: "{{ advertise_ip }}"
         port: "{{ mqtt_port }}"
         timeout: 300
         state: started

--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -24,6 +24,7 @@
       persistence true
       persistence_location /mosquitto/data/
       log_dest stdout
+      log_dest stderr
       log_type all
       listener {{ mqtt_port }} 0.0.0.0
       allow_anonymous true


### PR DESCRIPTION
Fixed the `Timeout when waiting for 100.64.0.1:1883` issue by pointing Ansible's `wait_for` module to `advertise_ip` and improving Mosquitto's Nomad configuration.

---
*PR created automatically by Jules for task [2715880975272164547](https://jules.google.com/task/2715880975272164547) started by @LokiMetaSmith*