### PR TITLE
fix: Use advertise_ip for Ansible MQTT wait_for check and script heal…

### DIFF
--- a/ansible/roles/mqtt/templates/mqtt.nomad.j2
+++ b/ansible/roles/mqtt/templates/mqtt.nomad.j2
@@ -27,12 +27,12 @@ job "mqtt" {
       port     = "mqtt"
       provider = "consul"
       check {
-        type     = "tcp"
+        type     = "script"
         name     = "mqtt_health"
-        port     = "mqtt"
+        command  = "/bin/sh"
+        args     = ["-c", "nc -z 127.0.0.1 {{ mqtt_port }}"]
         interval = "10s"
         timeout  = "5s"
-        address_mode = "host"
       }
     }
 


### PR DESCRIPTION
…th check for Nomad

This commit fixes a deployment timeout when the `monitoring` playbook attempts to wait for the MQTT service.

- Switched the host in `ansible/roles/monitoring/tasks/main.yml` from `cluster_ip` to `advertise_ip` to align with the canonical address used by Consul/Nomad.
- Updated the MQTT Nomad job `mqtt.nomad.j2` to use an internal `script` health check (`nc -z 127.0.0.1 {{ mqtt_port }}`) instead of the native `tcp` check, avoiding false-positive failures in `host` network mode.
- Added `log_dest stderr` to `mosquitto.conf` in `ansible/roles/mqtt/tasks/main.yaml` for comprehensive logs during startup and health check failures as recommended by project memories.