### PR TITLE
Verify MQTT service is started using Consul API

### DIFF
--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -233,6 +233,33 @@
 
 - name: Deploy MQTT Exporter
   block:
+    - name: Fetch Consul management token for monitoring (if undefined)
+      ansible.builtin.slurp:
+        src: /etc/consul.d/management_token
+      register: consul_token_file_monitoring
+      until: consul_token_file_monitoring is success
+      retries: 5
+      delay: 2
+      when: consul_bootstrap_token is undefined
+      ignore_errors: yes
+
+    - name: Set Consul token fact for monitoring (if undefined)
+      set_fact:
+        consul_bootstrap_token: "{{ consul_token_file_monitoring['content'] | b64decode | trim }}"
+      when: consul_bootstrap_token is undefined and consul_token_file_monitoring is success and consul_token_file_monitoring.content is defined
+
+    - name: Wait for MQTT service to be healthy in Consul
+      ansible.builtin.uri:
+        url: "http://{{ advertise_ip }}:{{ consul_http_port }}/v1/health/service/mqtt?passing"
+        method: GET
+        headers:
+          X-Consul-Token: "{{ consul_bootstrap_token | default('') }}"
+        return_content: yes
+        status_code: 200
+      register: consul_check
+      until: consul_check.json | length > 0
+      retries: 150
+      delay: 2
     - name: Wait for MQTT service to be ready
       ansible.builtin.wait_for:
         host: "{{ advertise_ip }}"


### PR DESCRIPTION
Verify MQTT service is started using Consul API

Before starting the MQTT exporter for monitoring, fetch the Consul management token and verify that the MQTT service is completely started and marked healthy by Consul before continuing.

---
*PR created automatically by Jules for task [5170165865051172516](https://jules.google.com/task/5170165865051172516) started by @LokiMetaSmith*