### PR TITLE
Verify MQTT service is started using Consul API

### DIFF
--- a/ansible/roles/mqtt/templates/mqtt.nomad.j2
+++ b/ansible/roles/mqtt/templates/mqtt.nomad.j2
@@ -27,10 +27,8 @@ job "mqtt" {
       port     = "mqtt"
       provider = "consul"
       check {
-        type     = "script"
+        type     = "tcp"
         name     = "mqtt_health"
-        command  = "/bin/sh"
-        args     = ["-c", "nc -z 127.0.0.1 {{ mqtt_port }}"]
         interval = "10s"
         timeout  = "5s"
       }


### PR DESCRIPTION
Before starting the MQTT exporter for monitoring, fetch the Consul management token and verify that the MQTT service is completely started and marked healthy by Consul before continuing. Also fixes the MQTT service health check script failing due to missing `nc` executable.