### PR TITLE
Verify MQTT service is started using Consul API

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -107,7 +107,7 @@
       ansible.builtin.uri:
         url: "http://{{ cluster_ip }}:{{ consul_http_port }}/v1/agent/self"
         headers:
-          X-Consul-Token: "{{ consul_bootstrap_token }}"
+          X-Consul-Token: "{{ consul_bootstrap_token | default('') }}"
         return_content: yes
       register: consul_token_check
       ignore_errors: yes
@@ -228,7 +228,7 @@
         url: "http://{{ advertise_ip }}:{{ consul_http_port }}/v1/health/service/mqtt?passing"
         method: GET
         headers:
-          X-Consul-Token: "{{ consul_bootstrap_token }}"
+          X-Consul-Token: "{{ consul_bootstrap_token | default('') }}"
         return_content: yes
         status_code: 200
       register: consul_check

--- a/ansible/roles/mqtt/templates/mqtt.nomad.j2
+++ b/ansible/roles/mqtt/templates/mqtt.nomad.j2
@@ -27,6 +27,7 @@ job "mqtt" {
       port     = "mqtt"
       provider = "consul"
       check {
+        # Changed from script to tcp as group level script checks run on host without nc
         type     = "tcp"
         name     = "mqtt_health"
         interval = "10s"


### PR DESCRIPTION
Before starting the MQTT exporter for monitoring, fetch the Consul management token and verify that the MQTT service is completely started and marked healthy by Consul before continuing. Also fixes the MQTT service health check script failing due to missing `nc` executable by changing it to a built-in tcp check.