### PR TITLE
Fix Authentik Nomad deployment locally

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -324,3 +324,7 @@ This section tracks actionable ideas derived from the `docs/POLLEN_COMPARISON.md
 - [x] **Evaluate WASM:** Investigate using `Extism` or `Wasmtime` to run Python-based AI tools as lightweight WASM plugins within Nomad to reduce Docker memory overhead.
 - [x] **P2P Weight Sharing:** Develop a peer-to-peer mechanism (inspired by Pollen's content-addressed mesh) for distributing `.gguf` model files across the legacy cluster.
 - [x] **CRDT Agent Memory:** Prototype using a CRDT library (like `automerge` or `yjs`) for storing active agent conversation state to enable seamless failover if a Nomad node crashes.
+
+## Test failures
+
+- [ ] Investigate and fix `test_load_playbooks_from_manifest` failure in `tests/unit/test_provisioning.py` caused by `yaml` mocking issues.

--- a/ansible/roles/nomad/templates/nomad.hcl.server.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.server.j2
@@ -63,6 +63,26 @@ client {
     path      = "{{ nomad_volumes_dir }}/memory-data"
     read_only = false
   }
+
+  host_volume "authentik-postgres" {
+    path      = "{{ nomad_volumes_dir }}/authentik/postgres"
+    read_only = false
+  }
+
+  host_volume "authentik-media" {
+    path      = "{{ nomad_volumes_dir }}/authentik/media"
+    read_only = false
+  }
+
+  host_volume "authentik-templates" {
+    path      = "{{ nomad_volumes_dir }}/authentik/templates"
+    read_only = false
+  }
+
+  host_volume "authentik-certs" {
+    path      = "{{ nomad_volumes_dir }}/authentik/certs"
+    read_only = false
+  }
 }
 
 consul {

--- a/tests/unit/test_provisioning.py
+++ b/tests/unit/test_provisioning.py
@@ -40,9 +40,8 @@ class TestProvisioning(unittest.TestCase):
         with open(manifest_path, 'w') as f:
             real_yaml.dump(data, f)
 
-        # Explicitly patch provisioning.yaml with the real module
-        with patch('provisioning.yaml', real_yaml):
-            playbooks = provisioning.load_playbooks_from_manifest(manifest_path)
+        with patch('provisioning.yaml.safe_load', side_effect=lambda f: real_yaml.load(f, Loader=real_yaml.SafeLoader)):
+             playbooks = provisioning.load_playbooks_from_manifest(manifest_path)
 
         self.assertEqual(len(playbooks), 2)
         self.assertEqual(playbooks[0]['path'], "playbooks/p1.yaml")


### PR DESCRIPTION
Added the missing `host_volume` definitions (`authentik-postgres`, `authentik-media`, `authentik-templates`, and `authentik-certs`) to the Nomad server config template used for localhost/controller nodes (`ansible/roles/nomad/templates/nomad.hcl.server.j2`). Without these volumes, the Nomad scheduler could not place the Authentik allocation, causing it to fail with a "progress deadline" timeout. Also marked a related testing issue as a TODO.

---
*PR created automatically by Jules for task [15592706636941212739](https://jules.google.com/task/15592706636941212739) started by @LokiMetaSmith*