### PR TITLE
fix: prevent Ansible from hanging on nomad job run

### DIFF
--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -145,7 +145,7 @@
   changed_when: true
 
 - name: Run Authentik Nomad job
-  ansible.builtin.command: nomad job run {{ nomad_jobs_dir }}/authentik.nomad
+  ansible.builtin.command: nomad job run -detach {{ nomad_jobs_dir }}/authentik.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
     NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"

--- a/ansible/roles/benchmark_models/tasks/benchmark_loop.yaml
+++ b/ansible/roles/benchmark_models/tasks/benchmark_loop.yaml
@@ -8,7 +8,7 @@
 
 - name: "Run benchmark job for model {{ model.name }}"
   ansible.builtin.command:
-    cmd: "nomad job run /tmp/model-benchmark-{{ model.filename }}.nomad"
+    cmd: "nomad job run -detach /tmp/model-benchmark-{{ model.filename }}.nomad"
   register: benchmark_models_job_run_result
   changed_when: "'job registration' in benchmark_models_job_run_result.stdout"
 

--- a/ansible/roles/docker_registry/tasks/main.yaml
+++ b/ansible/roles/docker_registry/tasks/main.yaml
@@ -19,7 +19,7 @@
 
 - name: Run docker-registry job
   ansible.builtin.command:
-    cmd: /usr/local/bin/nomad job run {{ nomad_jobs_dir }}/docker-registry.nomad
+    cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/docker-registry.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
     NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"

--- a/ansible/roles/exo/tasks/main.yaml
+++ b/ansible/roles/exo/tasks/main.yaml
@@ -85,7 +85,7 @@
 
 - name: Run Exo Nomad job
   ansible.builtin.command:
-    cmd: "/usr/local/bin/nomad job run {{ nomad_jobs_dir }}/exo.nomad"
+    cmd: "/usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/exo.nomad"
   environment:
     NOMAD_ADDR: "http://{{ advertise_ip }}:{{ nomad_http_port }}"
   register: exo_job_run

--- a/ansible/roles/forgejo/handlers/main.yaml
+++ b/ansible/roles/forgejo/handlers/main.yaml
@@ -1,5 +1,5 @@
 - name: Run Forgejo Job
-  ansible.builtin.command: nomad job run /opt/nomad/jobs/forgejo.nomad
+  ansible.builtin.command: nomad job run -detach /opt/nomad/jobs/forgejo.nomad
   become: yes
   environment:
     NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"

--- a/ansible/roles/gemini_cli/handlers/main.yaml
+++ b/ansible/roles/gemini_cli/handlers/main.yaml
@@ -1,5 +1,5 @@
 - name: Run Gemini Job
-  ansible.builtin.command: nomad job run /opt/nomad/jobs/gemini.nomad
+  ansible.builtin.command: nomad job run -detach /opt/nomad/jobs/gemini.nomad
   become: yes
   environment:
     NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"

--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -66,7 +66,7 @@
 
 - name: Run home-assistant job asynchronously
   ansible.builtin.command:
-    cmd: /usr/local/bin/nomad job run {{ nomad_jobs_dir }}/home-assistant.nomad
+    cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/home-assistant.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"

--- a/ansible/roles/llama_cpp/handlers/main.yaml
+++ b/ansible/roles/llama_cpp/handlers/main.yaml
@@ -1,6 +1,6 @@
 - name: run nomad llamacpp-rpc job
   ansible.builtin.command:
-    cmd: /usr/local/bin/nomad job run "/tmp/rpc-{{ item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
+    cmd: /usr/local/bin/nomad job run -detach "/tmp/rpc-{{ item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
   loop: "{{ all_models_for_rpc }}"
   environment:
     NOMAD_ADDR: "http://{{ cluster_ip }}:4646"

--- a/ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml
+++ b/ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml
@@ -23,7 +23,7 @@
   block:
     - name: Deploy rpc job
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad job run /tmp/rpc-{{ model_item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
+        cmd: "/usr/local/bin/nomad job run -detach /tmp/rpc-{{ model_item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
       register: rpc_job_run
       changed_when: "'Eval ID' in rpc_job_run.stdout"
       environment:

--- a/ansible/roles/magic_mirror/handlers/main.yaml
+++ b/ansible/roles/magic_mirror/handlers/main.yaml
@@ -1,4 +1,4 @@
 - name: Run Magic Mirror Job
   ansible.builtin.command:
-    cmd: nomad job run /opt/nomad/jobs/magic_mirror.nomad
+    cmd: nomad job run -detach /opt/nomad/jobs/magic_mirror.nomad
   listen: "Run Magic Mirror Job"

--- a/ansible/roles/mcp_server/handlers/main.yaml
+++ b/ansible/roles/mcp_server/handlers/main.yaml
@@ -1,3 +1,3 @@
 - name: Run mcp server job
-  ansible.builtin.command: nomad job run {{ nomad_jobs_dir }}/mcp_server.nomad
+  ansible.builtin.command: nomad job run -detach {{ nomad_jobs_dir }}/mcp_server.nomad
   changed_when: true

--- a/ansible/roles/moe_gateway/handlers/main.yaml
+++ b/ansible/roles/moe_gateway/handlers/main.yaml
@@ -1,6 +1,6 @@
 - name: Run moe-gateway job
   ansible.builtin.command:
-    cmd: /usr/local/bin/nomad job run {{ nomad_jobs_dir }}/moe-gateway.nomad
+    cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/moe-gateway.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"

--- a/ansible/roles/mqtt/handlers/main.yaml
+++ b/ansible/roles/mqtt/handlers/main.yaml
@@ -1,6 +1,6 @@
 - name: Restart Home Assistant
   ansible.builtin.command:
-    cmd: nomad job run {{ nomad_jobs_dir }}/home-assistant.nomad
+    cmd: nomad job run -detach {{ nomad_jobs_dir }}/home-assistant.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"

--- a/ansible/roles/nanochat/handlers/main.yaml
+++ b/ansible/roles/nanochat/handlers/main.yaml
@@ -1,6 +1,6 @@
 - name: Run Nanochat Nomad job
   ansible.builtin.command:
-    cmd: "nomad job run {{ nomad_jobs_dir }}/nanochat.nomad"
+    cmd: "nomad job run -detach {{ nomad_jobs_dir }}/nanochat.nomad"
   environment:
     NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
   become: yes

--- a/ansible/roles/opencode/handlers/main.yaml
+++ b/ansible/roles/opencode/handlers/main.yaml
@@ -1,5 +1,5 @@
 - name: Run Opencode Job
-  ansible.builtin.command: nomad job run /opt/nomad/jobs/opencode.nomad
+  ansible.builtin.command: nomad job run -detach /opt/nomad/jobs/opencode.nomad
   become: yes
   environment:
     NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"

--- a/ansible/roles/opengist/handlers/main.yaml
+++ b/ansible/roles/opengist/handlers/main.yaml
@@ -1,5 +1,5 @@
 - name: Run Opengist Job
-  ansible.builtin.command: nomad job run /opt/nomad/jobs/opengist.nomad
+  ansible.builtin.command: nomad job run -detach /opt/nomad/jobs/opengist.nomad
   become: yes
   environment:
     NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"

--- a/ansible/roles/paperless/handlers/main.yaml
+++ b/ansible/roles/paperless/handlers/main.yaml
@@ -1,5 +1,5 @@
 - name: Run Paperless Job
-  command: nomad job run /opt/nomad/jobs/paperless.nomad
+  command: nomad job run -detach /opt/nomad/jobs/paperless.nomad
   environment:
     NOMAD_ADDR: "http://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
   become: yes

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -573,7 +573,7 @@
 
     - name: "Archivist : Run nomad job"
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad job run {{ nomad_jobs_dir }}/archivist.nomad"
+        cmd: "/usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/archivist.nomad"
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
@@ -677,7 +677,7 @@
 
     - name: "Router : Run nomad job"
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad job run {{ nomad_jobs_dir }}/router.nomad"
+        cmd: "/usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/router.nomad"
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"

--- a/ansible/roles/polyphony/handlers/main.yaml
+++ b/ansible/roles/polyphony/handlers/main.yaml
@@ -1,5 +1,5 @@
 - name: Run Polyphony Job
-  ansible.builtin.command: nomad job run /opt/nomad/jobs/polyphony.nomad
+  ansible.builtin.command: nomad job run -detach /opt/nomad/jobs/polyphony.nomad
   environment:
     NOMAD_ADDR: "http://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
   changed_when: true

--- a/ansible/roles/semantic_router/tasks/main.yaml
+++ b/ansible/roles/semantic_router/tasks/main.yaml
@@ -39,7 +39,7 @@
 
 - name: Run Semantic Router Nomad job
   ansible.builtin.command:
-    cmd: /usr/local/bin/nomad job run "{{ nomad_jobs_dir }}/semantic-router.nomad"
+    cmd: /usr/local/bin/nomad job run -detach "{{ nomad_jobs_dir }}/semantic-router.nomad"
   environment:
     NOMAD_ADDR: "http://{{ cluster_ip }}:4646"
   register: nomad_job_run_result

--- a/ansible/roles/sunshine/handlers/main.yaml
+++ b/ansible/roles/sunshine/handlers/main.yaml
@@ -1,4 +1,4 @@
 - name: Run Sunshine Job
   ansible.builtin.command:
-    cmd: nomad job run /opt/nomad/jobs/sunshine.nomad
+    cmd: nomad job run -detach /opt/nomad/jobs/sunshine.nomad
   listen: "Run Sunshine Job"

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -133,7 +133,7 @@
 
     - name: "Tool Server : Run nomad job"
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad job run {{ nomad_jobs_dir }}/tool_server.nomad"
+        cmd: "/usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/tool_server.nomad"
       environment:
         NOMAD_ADDR: "http://{{ cluster_ip }}:4646"
       changed_when: true

--- a/ansible/roles/traefik/tasks/main.yml
+++ b/ansible/roles/traefik/tasks/main.yml
@@ -14,7 +14,7 @@
   become: yes
 
 - name: Run Traefik Nomad job
-  ansible.builtin.command: nomad job run {{ nomad_jobs_dir }}/traefik.nomad
+  ansible.builtin.command: nomad job run -detach {{ nomad_jobs_dir }}/traefik.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
     NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"

--- a/ansible/roles/vllm/tasks/run_single_vllm_job.yaml
+++ b/ansible/roles/vllm/tasks/run_single_vllm_job.yaml
@@ -17,7 +17,7 @@
 
 - name: Run vLLM nomad job for {{ model_item.name }}
   ansible.builtin.command:
-    cmd: /usr/local/bin/nomad job run "{{ nomad_jobs_dir }}/{{ model_item.name }}.nomad"
+    cmd: /usr/local/bin/nomad job run -detach "{{ nomad_jobs_dir }}/{{ model_item.name }}.nomad"
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"

--- a/ansible/roles/world_model_service/tasks/main.yaml
+++ b/ansible/roles/world_model_service/tasks/main.yaml
@@ -136,7 +136,7 @@
 
     - name: "World Model Service : Run nomad job"
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad job run {{ nomad_jobs_dir }}/world_model.nomad"
+        cmd: "/usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/world_model.nomad"
       environment:
         NOMAD_ADDR: "http://{{ cluster_ip }}:4646"
       changed_when: true
@@ -229,7 +229,7 @@
 
 - name: "World Model Service : Register batch nomad job"
   ansible.builtin.command:
-    cmd: "/usr/local/bin/nomad job run {{ nomad_jobs_dir }}/llamacpp-batch.nomad"
+    cmd: "/usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/llamacpp-batch.nomad"
   environment:
     NOMAD_ADDR: "http://{{ cluster_ip }}:4646"
   changed_when: true


### PR DESCRIPTION
Fixes issue where Ansible gets stuck hanging on `nomad job run` by passing the `-detach` flag across all playbook roles.

---
*PR created automatically by Jules for task [9810478057831705807](https://jules.google.com/task/9810478057831705807) started by @LokiMetaSmith*