### PR TITLE
chore: check off re-enable authentik nomad job in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 ## Immediate Actions
 
 - [x] **Fix Authentik Nomad Job:**
-  - [ ] **Re-enable Authentik Nomad Job:** The job was temporarily disabled during cluster upbringing. Re-enable it and investigate the 'progress deadline' issue once the rest of the cluster is running.
+  - [x] **Re-enable Authentik Nomad Job:** The job was temporarily disabled during cluster upbringing. Re-enable it and investigate the 'progress deadline' issue once the rest of the cluster is running.
   - **Goal:** Resolve issues preventing the Authentik Nomad job from deploying successfully.
 - [x] **Bootable System Installation & Auto-Configuration:**
   - **Goal:** Create a slimmed-down, bootable Debian ISO and enhance `bootstrap.sh` to auto-detect hardware resources.


### PR DESCRIPTION
The "Re-enable Authentik Nomad Job" item was already complete in the codebase as seen in the patch diff provided and the configuration files (ansible/roles/authentik/tasks/main.yml, playbooks/app_jobs.yaml, etc.), but the TODO.md file was not updated to reflect this. This PR simply updates TODO.md to mark it as checked.

---
*PR created automatically by Jules for task [17146115773744700548](https://jules.google.com/task/17146115773744700548) started by @LokiMetaSmith*