### PR TITLE
fix: correct ansible paths to fix collection resolution

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
+collections_path = /root/.ansible/collections:/usr/share/ansible/collections
 fact_caching = jsonfile
 fact_caching_connection = /tmp/ansible_facts_cache
 fact_caching_timeout = 86400

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -566,15 +566,14 @@ ensure_python_environment() {
     run_step "Installing Ansible Core" "pip install ansible-core pyyaml"
 
     # --- Find Ansible Playbook executable ---
-    # Since we are in a venv, these are guaranteed to be in the path
-    ANSIBLE_GALAXY_EXEC="$(which ansible-galaxy)"
+    ANSIBLE_GALAXY_EXEC="$VENV_DIR/bin/ansible-galaxy"
 
     # Install Ansible collections
     if [ -x "$ANSIBLE_GALAXY_EXEC" ]; then
         export ANSIBLE_CONFIG="$(pwd)/ansible.cfg"
         run_step "Installing Ansible collections" "$ANSIBLE_GALAXY_EXEC collection install community.general ansible.posix community.docker community.sops"
     else
-        echo "Error: ansible-galaxy not found in venv." >&2
+        echo "Error: ansible-galaxy not found at $ANSIBLE_GALAXY_EXEC." >&2
         exit 1
     fi
 }

--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -249,7 +249,7 @@ def purge_nomad_jobs():
 
 def run_playbook(playbook_path, extra_vars, tags, verbose_level):
     """Runs a single ansible playbook."""
-    cmd = ["ansible-playbook", "-i", INVENTORY_FILE, playbook_path]
+    cmd = [".venv/bin/ansible-playbook", "-i", INVENTORY_FILE, playbook_path]
 
     for key, value in extra_vars.items():
         cmd.extend(["--extra-vars", f"{key}={value}"])

--- a/tests/unit/test_provisioning.py
+++ b/tests/unit/test_provisioning.py
@@ -92,7 +92,7 @@ class TestProvisioning(unittest.TestCase):
 
         args, _ = mock_popen.call_args
         cmd = args[0]
-        self.assertEqual(cmd[0], "ansible-playbook")
+        self.assertEqual(cmd[0], ".venv/bin/ansible-playbook")
         self.assertIn("test.yaml", cmd)
         self.assertIn("--extra-vars", cmd)
         self.assertIn("k=v", cmd)


### PR DESCRIPTION
This fixes an issue where Ansible playbooks were failing to locate collections installed by `ansible-galaxy` due to `sudo` path environments and mismatched virtual environment usage.

---
*PR created automatically by Jules for task [9453837010527184406](https://jules.google.com/task/9453837010527184406) started by @LokiMetaSmith*