### PR TITLE
Fix `nomad ui` command by installing xdg-utils

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -39,6 +39,7 @@
       - python3-pip
       - libcurl4-openssl-dev
       - rsync
+      - xdg-utils
     state: present
 
 - name: Manage /etc/hosts file on controller for name resolution


### PR DESCRIPTION
Added `xdg-utils` to the `common` Ansible role to ensure the `xdg-open` executable is available system-wide. This fixes the issue where running `nomad ui` fails because it cannot find the tool needed to automatically open URLs.

---
*PR created automatically by Jules for task [10754855216585879139](https://jules.google.com/task/10754855216585879139) started by @LokiMetaSmith*