### PR TITLE
fix: use cli certificates for nomad queries over mTLS

### DIFF
--- a/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
@@ -21,8 +21,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
 
 - name: Deploy the main Llama.cpp RPC service to Nomad
   ansible.builtin.command:
@@ -33,8 +33,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   when: job_file.changed or job_status.rc != 0
 
 - name: Check for Consul management token file

--- a/ansible/roles/docker_registry/tasks/main.yaml
+++ b/ansible/roles/docker_registry/tasks/main.yaml
@@ -23,8 +23,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
     NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   register: nomad_job_run
 
 - name: Allow Docker Registry port in UFW
@@ -49,8 +49,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: nomad_status
       ignore_errors: true
 

--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -70,8 +70,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   changed_when: true
   become: no # Run nomad client as the ansible user
   async: 300

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -188,8 +188,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   when: build_llama_cpp
 
 - name: Stop and purge any existing expert jobs if llama.cpp was rebuilt
@@ -202,8 +202,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   when: build_llama_cpp
 
 - name: Check if benchmark log file exists

--- a/ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml
+++ b/ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml
@@ -29,8 +29,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   rescue:
     - name: Fetch Nomad allocations for debugging
       ansible.builtin.shell: >
@@ -39,8 +39,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       ignore_errors: yes
 
     - name: Fetch Nomad allocation logs
@@ -50,8 +50,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       when: alloc_id.stdout != ""
       ignore_errors: yes
 

--- a/ansible/roles/moe_gateway/handlers/main.yaml
+++ b/ansible/roles/moe_gateway/handlers/main.yaml
@@ -4,7 +4,7 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   become: no
   changed_when: true

--- a/ansible/roles/moe_gateway/tasks/main.yaml
+++ b/ansible/roles/moe_gateway/tasks/main.yaml
@@ -72,8 +72,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
 
 - name: Deploy moe-gateway Job
   block:
@@ -83,8 +83,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
       become: no
       register: moe_gateway_job_run
@@ -111,8 +111,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: moe_job_status
       ignore_errors: yes
       become: no
@@ -127,8 +127,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: moe_allocs
       ignore_errors: yes
       become: no
@@ -149,8 +149,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: moe_logs_stdout
       ignore_errors: yes
       become: no
@@ -167,8 +167,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: moe_logs_stderr
       ignore_errors: yes
       become: no

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -64,8 +64,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
 
 - name: Deploy Beszel
@@ -89,8 +89,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
 
     - name: Template beszel-hub job
@@ -105,8 +105,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
 
 - name: Deploy Statsping
@@ -130,8 +130,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
 
 - name: Deploy Memory Audit
@@ -148,8 +148,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
   rescue:
     - name: Get MQTT Exporter job status
@@ -158,8 +158,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: mqtt_exporter_job_status
       ignore_errors: yes
 
@@ -173,8 +173,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: mqtt_exporter_allocs
       ignore_errors: yes
 
@@ -194,8 +194,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: mqtt_exporter_logs_stdout
       ignore_errors: yes
       when: (mqtt_exporter_alloc_id.stdout | trim | length > 0) and (mqtt_exporter_alloc_id.stdout | trim != 'null')
@@ -211,8 +211,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: mqtt_exporter_logs_stderr
       ignore_errors: yes
       when: (mqtt_exporter_alloc_id.stdout | trim | length > 0) and (mqtt_exporter_alloc_id.stdout | trim != 'null')
@@ -245,8 +245,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
 
 - name: Deploy Prometheus
@@ -263,8 +263,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
 
 - name: Deploy Grafana
@@ -281,6 +281,6 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true

--- a/ansible/roles/mqtt/handlers/main.yaml
+++ b/ansible/roles/mqtt/handlers/main.yaml
@@ -4,6 +4,6 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   changed_when: true

--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -68,8 +68,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   register: nomad_status_json
   changed_when: false
   ignore_errors: yes
@@ -147,8 +147,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   register: mqtt_job_check
   failed_when: false
   changed_when: false
@@ -159,8 +159,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   when: mqtt_job_check.rc == 0
   changed_when: true
 
@@ -217,8 +217,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
       register: mqtt_job_run
       #  notify: Restart Home Assistant
@@ -242,8 +242,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: mqtt_job_status
       ignore_errors: yes
 
@@ -257,8 +257,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: nomad_node_status
       ignore_errors: yes
 
@@ -272,8 +272,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: mqtt_allocs
       ignore_errors: yes
 
@@ -293,8 +293,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: mqtt_logs_stdout
       ignore_errors: yes
       when: (mqtt_alloc_id.stdout | trim | length > 0) and (mqtt_alloc_id.stdout | trim != 'null')
@@ -310,8 +310,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: mqtt_logs_stderr
       ignore_errors: yes
       when: (mqtt_alloc_id.stdout | trim | length > 0) and (mqtt_alloc_id.stdout | trim != 'null')

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -556,8 +556,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
     NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
 
 - name: Flush handlers to ensure service is enabled and started
   ansible.builtin.meta: flush_handlers
@@ -577,8 +577,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
       become: no
       register: archivist_job_run
@@ -589,8 +589,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: arch_job_status
       failed_when: false
       become: no
@@ -605,8 +605,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: arch_allocs
       failed_when: false
       become: no
@@ -627,8 +627,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: arch_logs_stdout
       failed_when: false
       become: no
@@ -645,8 +645,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: arch_logs_stderr
       failed_when: false
       become: no
@@ -681,8 +681,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
       become: no
       register: router_job_run
@@ -697,8 +697,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: router_job_status
       failed_when: false
       become: no
@@ -713,8 +713,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: router_allocs
       failed_when: false
       become: no
@@ -735,8 +735,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: litellm_logs_stdout
       failed_when: false
       become: no
@@ -753,8 +753,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: litellm_logs_stderr
       failed_when: false
       become: no
@@ -771,8 +771,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: llama_logs_stdout
       failed_when: false
       become: no
@@ -789,8 +789,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: llama_logs_stderr
       failed_when: false
       become: no
@@ -864,8 +864,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
       become: no
       register: pipecat_job_run
@@ -890,8 +890,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: pipecat_job_status
       failed_when: false
       become: no
@@ -906,8 +906,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: pipecat_allocs
       failed_when: false
       become: no
@@ -928,8 +928,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: pipecat_logs_stdout
       failed_when: false
       become: no
@@ -946,8 +946,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       register: pipecat_logs_stderr
       failed_when: false
       become: no

--- a/ansible/roles/traefik/tasks/main.yml
+++ b/ansible/roles/traefik/tasks/main.yml
@@ -18,8 +18,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
     NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   register: traefik_deploy
   changed_when: "'modified' in traefik_deploy.stdout or 'created' in traefik_deploy.stdout"
   become: yes

--- a/ansible/roles/vllm/tasks/run_single_vllm_job.yaml
+++ b/ansible/roles/vllm/tasks/run_single_vllm_job.yaml
@@ -21,8 +21,8 @@
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   register: nomad_job_run_result
   changed_when: "'Job registration successful' in nomad_job_run_result.stdout"
   failed_when: nomad_job_run_result.rc != 0 and 'Job registration successful' not in nomad_job_run_result.stdout

--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -539,6 +539,8 @@ def print_final_status(args, executed_playbooks):
         env = os.environ.copy()
         env["NOMAD_ADDR"] = f"https://{ip}:4646"
         env["NOMAD_TLS_SKIP_VERIFY"] = "1"
+        env["NOMAD_CLIENT_CERT"] = "/etc/nomad.d/tls/cli.cert.pem"
+        env["NOMAD_CLIENT_KEY"] = "/etc/nomad.d/tls/cli.key.pem"
         result = subprocess.run(["nomad", "job", "status", "-short"], capture_output=True, text=True, env=env)
 
         # If it fails, fallback to 127.0.0.1 in case nomad is only bound locally


### PR DESCRIPTION
When attempting to query Nomad (e.g. `nomad job status`) or launch jobs from Ansible, the provisioning tasks and scripts were failing due to incorrect or missing mutual TLS client certificates. The previous configuration was referencing `cert.pem` and `key.pem` (which are server/node certificates), rather than `cli.cert.pem` and `cli.key.pem` (which are generated explicitly for client usage). This fix updates all relevant Ansible tasks and the `scripts/provisioning.py` file to supply the correct `cli.cert.pem` and `cli.key.pem` files, fixing "Unable to query Nomad (is it running?)" errors.

---
*PR created automatically by Jules for task [9804288585653140955](https://jules.google.com/task/9804288585653140955) started by @LokiMetaSmith*