### PR TITLE
fix: use cli certificates for nomad queries over mTLS and match tails…

### DIFF
--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -442,6 +442,17 @@ def print_summary():
 
 
 def get_primary_ip():
+    # Check for tailscale0 first, matching ansible's logic
+    import subprocess
+    try:
+        result = subprocess.run(['ip', '-4', 'addr', 'show', 'tailscale0'], capture_output=True, text=True)
+        if result.returncode == 0:
+            for line in result.stdout.split('\n'):
+                if 'inet ' in line:
+                    return line.strip().split(' ')[1].split('/')[0]
+    except Exception:
+        pass
+
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         s.connect(('10.255.255.255', 1))


### PR DESCRIPTION
…cale ip

nomad was failing to process queries because `cert.pem` and `key.pem` were being incorrectly passed to `NOMAD_CLIENT_CERT` and `NOMAD_CLIENT_KEY`. Instead, we should use `cli.cert.pem` and `cli.key.pem` which are generated for cli access by `tls.yaml`.

This patch updates the environment variables passed to nomad in various Ansible tasks, as well as `scripts/provisioning.py`, to correctly use the CLI certificates for authentication over HTTPS.

Additionally, `scripts/provisioning.py` has been updated to query the `tailscale0` IP address first before falling back to the default socket LAN IP. This matches the behavior of Ansible resolving `cluster_ip` which fixes the false positive "Inactive" reports for Nomad and other apps since they bind to the mesh network, not the LAN network.