### PR TITLE
Fix Pipecat App inactive status in provisioning script

### DIFF
--- a/ansible/jobs/pipecatapp.nomad
+++ b/ansible/jobs/pipecatapp.nomad
@@ -28,7 +28,7 @@ job "pipecat-app" {
     network {
       mode = "host"
       port "http" {
-        to = 8000
+        to = 8005
       }
     }
 

--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -494,7 +494,7 @@ def print_final_status(args, executed_playbooks):
     interfaces = [
         ("Nomad UI", 4646, f"https://{ip}:4646", True),
         ("Consul UI", 8500, f"https://{ip}:8500", True),
-        ("Pipecat App", 8000, f"https://{ip}:8000", stack_mode != "Infrastructure Only"),
+        ("Pipecat App", 8005, f"https://{ip}:8005", stack_mode != "Infrastructure Only"),
         ("Home Assistant", 8123, f"https://{ip}:8123", stack_mode != "Infrastructure Only" and stack_mode != "Minimal"),
     ]
 
@@ -765,7 +765,7 @@ def main():
 
         # Wait for ports before app services
         if "app_services.yaml" in normalized_path:
-            wait_for_ports_freed([8000, 8081, 1883])
+            wait_for_ports_freed([8005, 8081, 1883])
 
         # Cleanup before Core AI
         if "core_ai_services.yaml" in normalized_path:

--- a/tests/unit/test_provisioning.py
+++ b/tests/unit/test_provisioning.py
@@ -53,10 +53,10 @@ class TestProvisioning(unittest.TestCase):
         mock_check.side_effect = [True, False]
 
         with patch('sys.stdout', new=StringIO()) as fake_out:
-            provisioning.wait_for_ports_freed([8000], timeout=1)
+            provisioning.wait_for_ports_freed([8005], timeout=1)
             output = fake_out.getvalue()
-            self.assertIn("Waiting for ports [8000]", output)
-            self.assertIn("Port 8000 is free", output)
+            self.assertIn("Waiting for ports [8005]", output)
+            self.assertIn("Port 8005 is free", output)
 
     @patch('subprocess.run')
     def test_cleanup_memory_for_core_ai(self, mock_run):


### PR DESCRIPTION
Fix Pipecat App showing as inactive in provisioning script by correcting port

The `scripts/provisioning.py` was hardcoded to check port `8000` for the `Pipecat App`, while the `pipecatapp.nomad.j2` template deploys the app on `8005` (`nanochat_port`). This port mismatch caused the script to report the app as `(Inactive)`.

This change updates the scripts and corresponding tests to correctly check the `8005` port instead.

---
*PR created automatically by Jules for task [18095624814750974512](https://jules.google.com/task/18095624814750974512) started by @LokiMetaSmith*