### PR TITLE
feat: Configure Traefik for pipecatapp SSL termination

### DIFF
--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -76,7 +76,16 @@ job "{{ job_name | default('pipecat-app') }}" {
       port     = "http"
       provider = "consul"
       address  = "{{ cluster_ip }}"
-      tags     = ["pipecat", "ai-agent", "version=1.0"]
+      tags     = [
+        "pipecat",
+        "ai-agent",
+        "version=1.0",
+        "traefik.enable=true",
+        "traefik.http.routers.pipecatapp.rule=Host(`pipecatapp.{{ cluster_domain | default('local.mesh') }}`) || Host(`localhost`) || Host(`127.0.0.1`)",
+        "traefik.http.routers.pipecatapp.entrypoints=websecure",
+        "traefik.http.routers.pipecatapp.tls=true",
+        "traefik.http.routers.pipecatapp.tls.certresolver=local"
+      ]
 
       check {
         name     = "alive"


### PR DESCRIPTION
- Configured Traefik as reverse proxy for `pipecat-app`.
- Appended Traefik route tags to pipecatapp template `service` block for Traefik to consume.
- Configured Traefik route to allow requests for cluster domain and `localhost` mappings.

---
*PR created automatically by Jules for task [17986008708572026403](https://jules.google.com/task/17986008708572026403) started by @LokiMetaSmith*