### PR TITLE
Fix partial stack deployments missing models and pipecat

### DIFF
--- a/playbooks/controller.yaml
+++ b/playbooks/controller.yaml
@@ -6,3 +6,11 @@
 - import_playbook: playbooks/services/nomad.yaml
 - import_playbook: playbooks/services/monitoring.yaml
 - import_playbook: playbooks/app_jobs.yaml
+- import_playbook: playbooks/services/app_services.yaml
+- import_playbook: playbooks/services/model_services.yaml
+- import_playbook: playbooks/services/core_ai_services.yaml
+- import_playbook: playbooks/services/ai_experts.yaml
+- import_playbook: playbooks/services/training_services.yaml
+- import_playbook: playbooks/services/distributed_compute.yaml
+- import_playbook: playbooks/services/streaming_services.yaml
+- import_playbook: playbooks/services/final_verification.yaml

--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -752,6 +752,7 @@ def main():
             "playbooks/services/monitoring.yaml",
             "playbooks/services/model_services.yaml",
             "playbooks/services/core_ai_services.yaml",
+            "playbooks/services/ai_experts.yaml",
         ]
 
         # Define what constitutes a "minimal" stack


### PR DESCRIPTION
Fixes the issue where `--deploy-partial-stack` doesn't deploy pipecat or any models by default.

### Fixes
- Added `ai_experts.yaml` to `partial_stack_playbooks` in `scripts/provisioning.py` so that `pipecatapp` and models are correctly deployed.
- Updated `playbooks/controller.yaml` to include application and AI playbooks, as these playbooks are configured with `hosts: controller_nodes[0]` constraints. By omitting them from the controller manifest, the jobs were never submitted to the cluster. Now, the controller can successfully schedule these AI and app workloads on the cluster via Nomad.

---
*PR created automatically by Jules for task [15901371488194526372](https://jules.google.com/task/15901371488194526372) started by @LokiMetaSmith*