### PR TITLE
Fix YAML indentation in MQTT handler

### DIFF
--- a/ansible/roles/mqtt/handlers/main.yaml
+++ b/ansible/roles/mqtt/handlers/main.yaml
@@ -3,7 +3,7 @@
     cmd: nomad job run -detach {{ nomad_jobs_dir }}/home-assistant.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
-        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   changed_when: true


### PR DESCRIPTION
The ansible handler file `ansible/roles/mqtt/handlers/main.yaml` failed to parse due to a YAML formatting error, preventing `app_services.yaml` from continuing its execution. The error was raised from lines 5 and 6, where the configuration items (`NOMAD_CACERT`, `NOMAD_CLIENT_CERT`, and `NOMAD_CLIENT_KEY`) were deeply indented under the `environment` parameter instead of aligning with `NOMAD_ADDR`.

This change correctly indents the environment variables inside `ansible/roles/mqtt/handlers/main.yaml` so that they can be read correctly.

---
*PR created automatically by Jules for task [5391125608229631098](https://jules.google.com/task/5391125608229631098) started by @LokiMetaSmith*