### PR TITLE
Fix YAML indentation in home_assistant ansible role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ os-image/config/includes.chroot/opt/
 test_env/
 poc/wasm_tool_bridge/text_processor/target/
 poc/p2p_sync/syncthing
+collections/

--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -69,9 +69,9 @@
     cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/home-assistant.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
-        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   changed_when: true
   become: no # Run nomad client as the ansible user
   async: 300


### PR DESCRIPTION
The `home_assistant` Ansible role had a YAML parsing error on line 72 of `ansible/roles/home_assistant/tasks/main.yaml` because `NOMAD_CACERT`, `NOMAD_CLIENT_CERT`, and `NOMAD_CLIENT_KEY` were indented 8 spaces instead of 4 within the `environment` dictionary. 

This change fixes the indentation to align properly with `NOMAD_ADDR`. I also added `collections/` to `.gitignore` to prevent committing locally installed ansible collections.

An Ansible syntax check was run to verify the fix.

---
*PR created automatically by Jules for task [2018983452805821255](https://jules.google.com/task/2018983452805821255) started by @LokiMetaSmith*