### PR TITLE
Fix YAML syntax and indentation errors in Ansible roles

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -135,7 +135,7 @@
     - name: Wait for Nomad API to be ready after restart
       ansible.builtin.uri:
         url: "https://{{ cluster_ip }}:{{ nomad_http_port }}/v1/agent/self"
-    validate_certs: no
+        validate_certs: no
         status_code: 200
       register: nomad_api_status_fix
       until: nomad_api_status_fix.status == 200

--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -437,7 +437,6 @@
     url: "https://{{ cluster_ip }}:{{ nomad_http_port }}/v1/agent/self"
     validate_certs: no
     status_code: 200
-    validate_certs: no
     client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
     client_key: "{{ nomad_tls_dir }}/cli.key.pem"
   register: nomad_api_status


### PR DESCRIPTION
Fixes the errors highlighted in the user prompt regarding Ansible YAML parsing.

---
*PR created automatically by Jules for task [12699117658459470965](https://jules.google.com/task/12699117658459470965) started by @LokiMetaSmith*