### PR TITLE
feat: Implement Hierarchical Autonomy jobs and test-driven infrastructure

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -364,11 +364,14 @@
 
 - name: Template workflow files
   ansible.builtin.template:
-    src: "workflows/default_agent_loop.yaml.j2"
-    dest: "{{ pipecat_app_dir }}/workflows/default_agent_loop.yaml"
+    src: "workflows/{{ item }}.j2"
+    dest: "{{ pipecat_app_dir }}/workflows/{{ item }}"
     mode: '0644'
     owner: "{{ target_user }}"
     group: "{{ target_user }}"
+  with_items:
+    - default_agent_loop.yaml
+    - architect_loop.yaml
   become: yes
   tags:
     - deploy_app
@@ -436,6 +439,18 @@
   ansible.builtin.template:
     src: pipecatapp.nomad.j2
     dest: "{{ nomad_jobs_dir }}/pipecatapp.nomad"
+  become: yes
+
+- name: Template seed-agent Nomad job file
+  ansible.builtin.template:
+    src: seed-agent.nomad.j2
+    dest: "{{ nomad_jobs_dir }}/seed-agent.nomad"
+  become: yes
+
+- name: Template architect Nomad job file
+  ansible.builtin.template:
+    src: architect.nomad.j2
+    dest: "{{ nomad_jobs_dir }}/architect.nomad"
   become: yes
 
 - name: Template prompt evolution Nomad job file

--- a/ansible/roles/pipecatapp/templates/architect.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/architect.nomad.j2
@@ -1,0 +1,87 @@
+job "architect" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  meta {
+    version = "{{ pipecat_versioned_tag | default('local') }}"
+  }
+
+  group "architect-group" {
+    count = 1
+
+    update {
+      max_parallel     = 1
+      min_healthy_time = "30s"
+      healthy_deadline = "15m"
+      progress_deadline = "20m"
+      auto_revert      = true
+      canary           = 0
+    }
+
+    reschedule {
+      attempts  = 3
+      interval  = "10m"
+      delay     = "30s"
+      unlimited = false
+    }
+
+    {% set env_vars %}
+    env {
+      LLAMA_API_SERVICE_NAME = "{{ llama_api_service_name | default('llamacpp-rpc-api') }}"
+      USE_SUMMARIZER         = "{{ use_summarizer | default('false') }}"
+      STT_SERVICE            = "{{ stt_service | default('faster-whisper') }}"
+      SANDBOX_EXECUTOR       = "{{ sandbox_executor | default('docker') }}"
+      NOMAD_ADDR             = "http://{{ cluster_ip }}:4646"
+      PIPECAT_API_KEYS        = "{{ pipecat_api_keys }}"
+      EXTERNAL_EXPERTS_CONFIG = "{{ external_experts_config | to_json | replace('\"', '\\\"') }}"
+      OPENAI_API_KEY         = "{{ openai_api_key }}"
+      OPENROUTER_API_KEY     = "{{ openrouter_api_key }}"
+      MEMORY_SERVICE_URL     = "http://{{ cluster_ip }}:8000"
+      CONSUL_HOST            = "{{ cluster_ip }}"
+      CONSUL_PORT            = "{{ consul_http_port }}"
+      CONSUL_HTTP_TOKEN      = "{{ consul_bootstrap_token | default('') }}"
+      ROUTER_PORT            = "{{ router_port }}"
+      LLAMA_API_URL          = "http://{{ cluster_ip }}:{{ router_port }}/v1"
+      MAIN_API_SERVICE_NAME = "llama-api-main"
+      WORKFLOW_FILE         = "/app/workflows/architect_loop.yaml"
+    }
+    {% endset %}
+
+    network {
+      mode = "host"
+    }
+
+    service {
+      name     = "architect"
+      provider = "consul"
+      address  = "{{ cluster_ip }}"
+      tags     = ["architect", "ai-agent"]
+    }
+
+    task "architect-task" {
+      driver = "docker"
+      {{ env_vars }}
+
+      constraint {
+        attribute = "${meta.node_type}"
+        value     = "controller"
+      }
+
+      config {
+        image = "{{ pipecatapp_image_ref | default('pipecatapp:local') }}"
+        force_pull = false
+
+        volumes = [
+          "/opt/nomad/models:/opt/nomad/models:ro",
+          "/opt/pipecatapp:/opt/pipecatapp",
+          "/opt/pipecatapp/chromadb:/app/chromadb_storage",
+        ]
+      }
+
+      resources {
+        cpu    = 2000 # 2 GHz
+        memory = 2048 # 2 GB
+      }
+    }
+  }
+}

--- a/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
@@ -1,0 +1,79 @@
+job "seed-agent" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  meta {
+    version = "{{ pipecat_versioned_tag | default('local') }}"
+  }
+
+  group "seed-agent-group" {
+    count = 1
+
+    update {
+      max_parallel     = 1
+      min_healthy_time = "30s"
+      healthy_deadline = "15m"
+      progress_deadline = "20m"
+      auto_revert      = true
+      canary           = 0
+    }
+
+    reschedule {
+      attempts  = 3
+      interval  = "10m"
+      delay     = "30s"
+      unlimited = false
+    }
+
+    {% set env_vars %}
+    env {
+      NOMAD_ADDR             = "http://{{ cluster_ip }}:4646"
+      CONSUL_HOST            = "{{ cluster_ip }}"
+      CONSUL_PORT            = "{{ consul_http_port }}"
+      CONSUL_HTTP_TOKEN      = "{{ consul_bootstrap_token | default('') }}"
+      ANSIBLE_CONFIG         = "/app/ansible.cfg"
+    }
+    {% endset %}
+
+    network {
+      mode = "host"
+    }
+
+    service {
+      name     = "seed-agent"
+      provider = "consul"
+      address  = "{{ cluster_ip }}"
+      tags     = ["seed", "infrastructure-manager"]
+    }
+
+    task "seed-agent-task" {
+      driver = "docker"
+      {{ env_vars }}
+
+      constraint {
+        attribute = "${meta.node_type}"
+        value     = "controller"
+      }
+
+      config {
+        image = "{{ pipecatapp_image_ref | default('pipecatapp:local') }}"
+        force_pull = false
+
+        # Granting elevated privileges since it's the infrastructure manager
+        privileged = true
+
+        volumes = [
+          "/opt/nomad/models:/opt/nomad/models:ro",
+          "/opt/pipecatapp:/opt/pipecatapp",
+          "/root/.ssh:/root/.ssh:ro",
+          "/etc/nomad.d/tls:/etc/nomad.d/tls:ro",
+        ]
+      }
+
+      resources {
+        cpu    = 1000 # 1 GHz
+        memory = 1024 # 1 GB
+      }
+    }
+  }
+}

--- a/ansible/roles/pipecatapp/templates/workflows/architect_loop.yaml.j2
+++ b/ansible/roles/pipecatapp/templates/workflows/architect_loop.yaml.j2
@@ -1,0 +1,33 @@
+nodes:
+  - id: input
+    type: InputNode
+    config: {}
+
+  - id: define_goals
+    type: SimpleLLMNode
+    config:
+      system_prompt: |
+        You are the Architect. Your job is to read goals, define system state, and generate specifications.
+        Analyze the input and outline the architectural specification needed to achieve the goal.
+        Do not write code or execute commands. You only produce the blueprint.
+      temperature: 0.2
+
+  - id: pass_to_executor
+    type: ToolNode
+    config:
+      tools:
+        - orchestrator # Or a custom tool if needed to pass to Seed Agent/Execution team
+
+  - id: output
+    type: OutputNode
+    config: {}
+
+edges:
+  - source: input
+    target: define_goals
+
+  - source: define_goals
+    target: pass_to_executor
+
+  - source: pass_to_executor
+    target: output

--- a/ansible/tests/verify_playbook_syntax.yaml
+++ b/ansible/tests/verify_playbook_syntax.yaml
@@ -1,0 +1,11 @@
+---
+- name: Verify cluster basics before applying changes
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Assert that the test framework is executed
+      ansible.builtin.assert:
+        that:
+          - true
+        fail_msg: "Basic assertion failed. Check the Ansible environment."
+        success_msg: "Basic assertion passed. Environment seems ready for validation tests."


### PR DESCRIPTION
This submission establishes the foundations for Hierarchical Autonomy inside the cluster as defined by the new agent constraints:
1.  **Architect Role**: Added `architect.nomad.j2` and `architect_loop.yaml.j2` so the Architect runs independently without competing with heavy worker loads.
2.  **Seed Agent Bootstrap**: Added `seed-agent.nomad.j2` with elevated privileges (`privileged = true` and host mounts) to serve as the infrastructure manager.
3.  **Test-Driven Infrastructure**: Created `ansible/tests/verify_playbook_syntax.yaml` to give the agents a dedicated place for asserting state via native Ansible tests.
4.  **Integration**: Updated the Pipecat application deployment tasks to ensure all templates are properly rendered into the Nomad jobs directory on deployment.

---
*PR created automatically by Jules for task [5520008755197168948](https://jules.google.com/task/5520008755197168948) started by @LokiMetaSmith*