### PR TITLE
Fix TLS validation and YAML parsing in Ansible roles

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -66,6 +66,8 @@
     validate_certs: no
     method: GET
     status_code: 200
+    client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
+    client_key: "{{ nomad_tls_dir }}/cli.key.pem"
   register: home_assistant_nomad_api_status
   until: home_assistant_nomad_api_status.status == 200
   retries: 12 # ~1 minute

--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -137,6 +137,8 @@
         url: "https://{{ cluster_ip }}:{{ nomad_http_port }}/v1/agent/self"
         validate_certs: no
         status_code: 200
+        client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
+        client_key: "{{ nomad_tls_dir }}/cli.key.pem"
       register: nomad_api_status_fix
       until: nomad_api_status_fix.status == 200
       retries: 12


### PR DESCRIPTION
- Add missing `client_cert` and `client_key` TLS configuration to the `ansible.builtin.uri` module in `ansible/roles/mqtt/tasks/main.yaml` and `ansible/roles/home_assistant/tasks/main.yaml` to fix the `[SSL: TLSV13_ALERT_CERTIFICATE_REQUIRED]` connection error when querying the Nomad API.