### PR TITLE
Fix missing TLS client configurations in Nomad API checks

### DIFF
--- a/ansible/roles/bootstrap_agent/tasks/main.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/main.yaml
@@ -35,8 +35,10 @@
     - name: Wait for at least 1 Nomad peer
       ansible.builtin.uri:
         url: "https://{{ inventory_hostname }}:{{ nomad_http_port }}/v1/status/peers"
-    validate_certs: no
+        validate_certs: no
         return_content: yes
+        client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
+        client_key: "{{ nomad_tls_dir }}/cli.key.pem"
       register: nomad_peers
       until: nomad_peers.json | length >= 1
       retries: 20
@@ -59,6 +61,8 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port }}/v1/status/peers"
     validate_certs: no
     return_content: yes
+    client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
+    client_key: "{{ nomad_tls_dir }}/cli.key.pem"
   register: nomad_peers_summary
   when: ansible_connection == "local"
 

--- a/ansible/roles/moe_gateway/tasks/main.yaml
+++ b/ansible/roles/moe_gateway/tasks/main.yaml
@@ -48,6 +48,8 @@
     validate_certs: no
     method: GET
     status_code: 200
+    client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
+    client_key: "{{ nomad_tls_dir }}/cli.key.pem"
   register: nomad_api_status
   until: nomad_api_status.status == 200
   retries: 12 # Total wait time = retries * delay = 60 seconds

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -543,6 +543,8 @@
     validate_certs: no
     method: GET
     status_code: 200
+    client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
+    client_key: "{{ nomad_tls_dir }}/cli.key.pem"
   register: nomad_api_status
   until: nomad_api_status.status == 200
   retries: 12 # Total wait time = retries * delay = 60 seconds


### PR DESCRIPTION
- Add `client_cert` and `client_key` to `ansible.builtin.uri` module in `bootstrap_agent`, `moe_gateway`, and `pipecatapp` roles.
- Fix indentation of `validate_certs: no` in `bootstrap_agent`.