### PR TITLE
Fix YAML parsing error in moe_gateway role

### DIFF
--- a/ansible/roles/moe_gateway/tasks/main.yaml
+++ b/ansible/roles/moe_gateway/tasks/main.yaml
@@ -72,9 +72,9 @@
   failed_when: false
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
-        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
 
 - name: Deploy moe-gateway Job
   block:


### PR DESCRIPTION
This PR fixes a YAML parsing error in the `moe_gateway` Ansible role (`ansible/roles/moe_gateway/tasks/main.yaml`). The error was caused by incorrect indentation of `NOMAD_CACERT`, `NOMAD_CLIENT_CERT`, and `NOMAD_CLIENT_KEY` under the `environment` dictionary. The variables have been properly aligned with `NOMAD_ADDR`.

The fix has been verified locally using `ansible-playbook --syntax-check playbooks/services/app_services.yaml`.

---
*PR created automatically by Jules for task [5400095647797680740](https://jules.google.com/task/5400095647797680740) started by @LokiMetaSmith*