### PR TITLE
fix: correctly mount workflows and deploy stream settings

### DIFF
--- a/ansible/roles/pipecatapp/templates/architect.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/architect.nomad.j2
@@ -44,6 +44,8 @@ job "architect" {
       LLAMA_API_URL          = "http://{{ cluster_ip }}:{{ router_port }}/v1"
       MAIN_API_SERVICE_NAME = "llama-api-main"
       WORKFLOW_FILE         = "/app/workflows/architect_loop.yaml"
+      PRIMARY_MODEL         = "gemma"
+      FALLBACK_MODEL        = "olmo"
     }
     {% endset %}
 
@@ -75,6 +77,7 @@ job "architect" {
           "/opt/nomad/models:/opt/nomad/models:ro",
           "/opt/pipecatapp:/opt/pipecatapp",
           "/opt/pipecatapp/chromadb:/app/chromadb_storage",
+          "/opt/pipecatapp/workflows:/app/workflows",
         ]
       }
 

--- a/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
@@ -32,6 +32,11 @@ job "seed-agent" {
       CONSUL_PORT            = "{{ consul_http_port }}"
       CONSUL_HTTP_TOKEN      = "{{ consul_bootstrap_token | default('') }}"
       ANSIBLE_CONFIG         = "/app/ansible.cfg"
+      PRIMARY_MODEL          = "gemma"
+      FALLBACK_MODEL         = "olmo"
+      PIPECAT_API_KEYS        = "{{ pipecat_api_keys }}"
+      OPENAI_API_KEY         = "{{ openai_api_key }}"
+      OPENROUTER_API_KEY     = "{{ openrouter_api_key }}"
     }
     {% endset %}
 

--- a/ansible/roles/pipecatapp/templates/workflows/architect_loop.yaml.j2
+++ b/ansible/roles/pipecatapp/templates/workflows/architect_loop.yaml.j2
@@ -11,6 +11,11 @@ nodes:
         Analyze the input and outline the architectural specification needed to achieve the goal.
         Do not write code or execute commands. You only produce the blueprint.
       temperature: 0.2
+      stream: false
+      model: "gemma"
+      fallback_models: ["olmo"]
+      retry_on_403: true
+      timeout: 60
 
   - id: pass_to_executor
     type: ToolNode

--- a/ansible/roles/pipecatapp/templates/workflows/default_agent_loop.yaml.j2
+++ b/ansible/roles/pipecatapp/templates/workflows/default_agent_loop.yaml.j2
@@ -69,6 +69,12 @@ nodes:
 
   - id: "call_vision_llm"
     type: "VisionLLMNode"
+    config:
+      stream: false
+      model: "gemma"
+      fallback_models: ["olmo"]
+      retry_on_403: true
+      timeout: 60
     inputs:
       - name: "messages"
         connection:

--- a/pipecatapp/workflows/adversarial_simulation.yaml
+++ b/pipecatapp/workflows/adversarial_simulation.yaml
@@ -9,6 +9,8 @@ nodes:
 
   - id: "DraftingStep"
     type: "SimpleLLMNode"
+    config:
+      stream: false
     model_tier: "balanced"
     inputs:
       - name: "user_text"
@@ -20,6 +22,8 @@ nodes:
 
   - id: "ProfilingStep"
     type: "SimpleLLMNode"
+    config:
+      stream: false
     model_tier: "capable"
     inputs:
       - name: "user_text"
@@ -35,6 +39,8 @@ nodes:
 
   - id: "SimulationStep"
     type: "SimpleLLMNode"
+    config:
+      stream: false
     model_tier: "capable"
     inputs:
       - name: "draft_response"
@@ -50,6 +56,8 @@ nodes:
 
   - id: "RefinementStep"
     type: "SimpleLLMNode"
+    config:
+      stream: false
     model_tier: "capable"
     inputs:
       - name: "draft_response"

--- a/pipecatapp/workflows/deep_context.yaml
+++ b/pipecatapp/workflows/deep_context.yaml
@@ -9,6 +9,8 @@ nodes:
 
   - id: "PathExtractor"
     type: "SimpleLLMNode"
+    config:
+      stream: false
     model_tier: "balanced"
     inputs:
       - name: "user_text"
@@ -28,6 +30,8 @@ nodes:
 
   - id: "ComprehensionStep"
     type: "SimpleLLMNode"
+    config:
+      stream: false
     model_tier: "balanced"
     inputs:
       - name: "file_content"
@@ -41,6 +45,8 @@ nodes:
 
   - id: "ReasoningStep"
     type: "SimpleLLMNode"
+    config:
+      stream: false
     model_tier: "capable"
     inputs:
       - name: "user_text"

--- a/pipecatapp/workflows/default_agent_loop.yaml
+++ b/pipecatapp/workflows/default_agent_loop.yaml
@@ -19,6 +19,12 @@ nodes:
 
   - id: "Router"
     type: "SimpleLLMNode"
+    config:
+      stream: false
+      model: "gemma"
+      fallback_models: ["olmo"]
+      retry_on_403: true
+      timeout: 60
     model_tier: "balanced"
     inputs:
       - name: "user_text"

--- a/pipecatapp/workflows/manager.yaml
+++ b/pipecatapp/workflows/manager.yaml
@@ -35,6 +35,8 @@ nodes:
 
   - id: "ManagerReasoning"
     type: "SimpleLLMNode"
+    config:
+      stream: false
     model_tier: "capable"
     inputs:
       - name: "user_text"

--- a/pipecatapp/workflows/sandbox.yaml
+++ b/pipecatapp/workflows/sandbox.yaml
@@ -27,6 +27,8 @@ nodes:
 
   - id: "SandboxReasoning"
     type: "SimpleLLMNode"
+    config:
+      stream: false
     model_tier: "fast"
     inputs:
       - name: "user_text"

--- a/pipecatapp/workflows/tiered_agent_loop.yaml
+++ b/pipecatapp/workflows/tiered_agent_loop.yaml
@@ -6,6 +6,12 @@ nodes:
 
   - id: "Summarizer"
     type: "SimpleLLMNode"
+    config:
+      stream: false
+      model: "gemma"
+      fallback_models: ["olmo"]
+      retry_on_403: true
+      timeout: 60
     model_tier: "fast"
     system_prompt: "You are a concise summarizer. Summarize the user's input in one sentence."
     inputs:
@@ -16,6 +22,12 @@ nodes:
 
   - id: "Reasoning"
     type: "SimpleLLMNode"
+    config:
+      stream: false
+      model: "gemma"
+      fallback_models: ["olmo"]
+      retry_on_403: true
+      timeout: 60
     model_tier: "balanced"
     system_prompt: "You are a thoughtful assistant. Answer the user based on the summary provided."
     inputs:

--- a/pipecatapp/workflows/update_litellm_workflow.yaml
+++ b/pipecatapp/workflows/update_litellm_workflow.yaml
@@ -29,6 +29,8 @@ nodes:
 
   - id: "SecurityReasoning"
     type: "SimpleLLMNode"
+    config:
+      stream: false
     model_tier: "fast"
     inputs:
       - name: "user_text"


### PR DESCRIPTION
* Restored `VisionLLMNode` in `default_agent_loop.yaml.j2`
* Updated `architect.nomad.j2` to properly mount the workflows volume so `architect_loop.yaml` can be discovered.
* Pinned model fallbacks (gemma -> olmo) and explicitly disabled streaming across all `SimpleLLMNode` and `VisionLLMNode` blocks in local `pipecatapp/workflows/*.yaml` definitions and their Jinja templates.