### PR TITLE
feat(prompts): teach model to use batch tools

### DIFF
--- a/ansible/roles/pipecatapp/templates/prompts/router.txt.j2
+++ b/ansible/roles/pipecatapp/templates/prompts/router.txt.j2
@@ -6,7 +6,7 @@ You are a sophisticated router agent managing a complex ecosystem. Your primary 
 2.  **Complex Task Orchestration:** For resource-intensive or long-running tasks, use the `orchestrator` tool to dispatch a batch job. This is ideal for tasks that require significant CPU, memory, or GPU resources.
 3.  **Software Engineering:** For tasks involving modifying the application's source code, creating features, or fixing bugs:
     *   **PLAN FIRST:** Use the `planner` tool to analyze the request and map the codebase.
-    *   **EDIT:** Use the `file_editor` tool to read and modify files.
+    *   **EDIT:** Use the `file_editor` tool or `ast_editor` tool to modify files. **Crucially, for multi-file operations, always use the `batch_hash_replace` (file_editor) or `batch_edit` (ast_editor) actions to group edits across multiple files in a single tool call to save tokens.**
     *   **VERIFY:** Use the `shell` tool to run tests (`pytest`) or verify changes.
     *   **REFLECT:** If tests fail, analyze the output and retry.
 4.  **Computational and Logical Tasks:** For tasks that involve multi-step logic, calculations, data processing, or generating code *outside* the codebase, use the **`smol_agent_computer`** tool.

--- a/docs/DIRAC_TODO.md
+++ b/docs/DIRAC_TODO.md
@@ -49,7 +49,7 @@ The goal of Phase 2 is to build Dirac's token-saving techniques natively into ou
 
 ### Step 3: Multi-file Batching
 - [x] **Update Tool Schemas:** Modify the new `hash_replace` and `ast_editor` commands to accept lists of operations across multiple files in a single JSON payload.
-- [ ] **Refactor Prompt:** Update the system prompt to explicitly teach the model how to batch these commands to save tokens.
+- [x] **Refactor Prompt:** Update the system prompt to explicitly teach the model how to batch these commands to save tokens.
 
 ### Step 4: Transition
 - [ ] **Benchmarking:** Run our native tools through our internal TerminalBench suite. Compare token usage and success rate against the Node.js `dirac_tool`.

--- a/pipecatapp/prompts/router.txt
+++ b/pipecatapp/prompts/router.txt
@@ -7,7 +7,7 @@ You are a sophisticated router agent managing a complex ecosystem. Your primary 
 3.  **Computational and Logical Tasks:** For tasks that involve multi-step logic, calculations, data processing, or generating code, use the **`smol_agent_computer`** tool. This tool is a powerful code-generating agent that can handle complex instructions.
 4.  **General Tool Usage:** You have access to a wide range of other tools for tasks such as cluster management, desktop automation, and web browsing. Select the most appropriate tool for the job.
 5.  **Direct Response:** If a query does not fit any of the above categories, handle it yourself with a helpful, general-purpose response.
-6.  **Codebase Refactoring & Complex Edits:** For tasks involving complex, multi-file edits or robust refactoring, use the `dirac` tool instead of the `file_editor` tool, as it supports hash-anchored edits and token-saving operations.
+6.  **Codebase Refactoring & Complex Edits:** For tasks involving complex, multi-file edits or robust refactoring, use the `dirac` tool instead of the `file_editor` tool. Alternatively, use the `file_editor` tool with the `batch_hash_replace` action or the `ast_editor` tool with the `batch_edit` action to group edits across multiple files in a single tool call to save tokens.
 
 **Quality Control:**
 


### PR DESCRIPTION
Updated `router.txt` and `router.txt.j2` to explicitly instruct the LLM on using `batch_hash_replace` and `batch_edit` actions to group multi-file edits into a single tool call to save tokens. This completes the 'Refactor Prompt' step in `docs/DIRAC_TODO.md`.