### PR TITLE
Fix Nomad TLS environment variables across all Ansible roles

### DIFF
--- a/ansible/roles/forgejo/handlers/main.yaml
+++ b/ansible/roles/forgejo/handlers/main.yaml
@@ -2,4 +2,8 @@
   ansible.builtin.command: nomad job run -detach /opt/nomad/jobs/forgejo.nomad
   become: yes
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"

--- a/ansible/roles/gemini_cli/handlers/main.yaml
+++ b/ansible/roles/gemini_cli/handlers/main.yaml
@@ -2,4 +2,8 @@
   ansible.builtin.command: nomad job run -detach /opt/nomad/jobs/gemini.nomad
   become: yes
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"

--- a/ansible/roles/llama_cpp/handlers/main.yaml
+++ b/ansible/roles/llama_cpp/handlers/main.yaml
@@ -3,7 +3,11 @@
     cmd: /usr/local/bin/nomad job run -detach "/tmp/rpc-{{ item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
   loop: "{{ all_models_for_rpc }}"
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip }}:4646"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   loop_control:
     label: "{{ item.filename }}"
   become: yes

--- a/ansible/roles/memory_service/handlers/main.yaml
+++ b/ansible/roles/memory_service/handlers/main.yaml
@@ -2,4 +2,8 @@
   ansible.builtin.command:
     cmd: nomad job run -detach /opt/nomad/jobs/memory_service.nomad
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"

--- a/ansible/roles/nanochat/handlers/main.yaml
+++ b/ansible/roles/nanochat/handlers/main.yaml
@@ -2,5 +2,9 @@
   ansible.builtin.command:
     cmd: "nomad job run -detach {{ nomad_jobs_dir }}/nanochat.nomad"
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   become: yes

--- a/ansible/roles/openclaw/tasks/main.yaml
+++ b/ansible/roles/openclaw/tasks/main.yaml
@@ -67,6 +67,10 @@
   ansible.builtin.command:
     cmd: "/usr/local/bin/nomad job run -detach {{ nomad_jobs_dir | default('/opt/nomad/jobs') }}/openclaw.nomad"
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip | default('localhost') }}:4646"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   register: openclaw_job_run
   changed_when: true

--- a/ansible/roles/opencode/handlers/main.yaml
+++ b/ansible/roles/opencode/handlers/main.yaml
@@ -2,4 +2,8 @@
   ansible.builtin.command: nomad job run -detach /opt/nomad/jobs/opencode.nomad
   become: yes
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"

--- a/ansible/roles/opengist/handlers/main.yaml
+++ b/ansible/roles/opengist/handlers/main.yaml
@@ -2,4 +2,8 @@
   ansible.builtin.command: nomad job run -detach /opt/nomad/jobs/opengist.nomad
   become: yes
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"

--- a/ansible/roles/paperless/handlers/main.yaml
+++ b/ansible/roles/paperless/handlers/main.yaml
@@ -1,5 +1,9 @@
 - name: Run Paperless Job
   command: nomad job run -detach /opt/nomad/jobs/paperless.nomad
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   become: yes

--- a/ansible/roles/pds/tasks/main.yaml
+++ b/ansible/roles/pds/tasks/main.yaml
@@ -20,7 +20,11 @@
   ansible.builtin.command:
     cmd: "/usr/local/bin/nomad job run -detach {{ nomad_jobs_dir | default('/opt/nomad/jobs') }}/pds.nomad"
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip | default('localhost') }}:4646"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   register: pds_job_run
   changed_when: true
   when: pds_enabled | default(false) | bool

--- a/ansible/roles/semantic_router/tasks/main.yaml
+++ b/ansible/roles/semantic_router/tasks/main.yaml
@@ -41,7 +41,11 @@
   ansible.builtin.command:
     cmd: /usr/local/bin/nomad job run -detach "{{ nomad_jobs_dir }}/semantic-router.nomad"
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip }}:4646"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   register: nomad_job_run_result
   changed_when: "'Job registration successful' in nomad_job_run_result.stdout"
   failed_when: nomad_job_run_result.rc != 0 and 'Job registration successful' not in nomad_job_run_result.stdout

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -125,7 +125,11 @@
       ansible.builtin.command:
         cmd: "/usr/local/bin/nomad job stop -purge tool-server"
       environment:
-        NOMAD_ADDR: "https://{{ cluster_ip }}:4646"
+        NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+        NOMAD_TLS_SKIP_VERIFY: "1"
       ignore_errors: yes
       failed_when: false
       changed_when: true
@@ -135,7 +139,11 @@
       ansible.builtin.command:
         cmd: "/usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/tool_server.nomad"
       environment:
-        NOMAD_ADDR: "https://{{ cluster_ip }}:4646"
+        NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+        NOMAD_TLS_SKIP_VERIFY: "1"
       changed_when: true
       become: no
       register: tool_server_job_run
@@ -145,7 +153,11 @@
       ansible.builtin.command:
         cmd: /usr/local/bin/nomad job status -verbose tool-server
       environment:
-        NOMAD_ADDR: "https://{{ cluster_ip }}:4646"
+        NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+        NOMAD_TLS_SKIP_VERIFY: "1"
       register: ts_job_status
       ignore_errors: yes
       become: no
@@ -158,7 +170,11 @@
       ansible.builtin.command:
         cmd: /usr/local/bin/nomad job allocs -json tool-server
       environment:
-        NOMAD_ADDR: "https://{{ cluster_ip }}:4646"
+        NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+        NOMAD_TLS_SKIP_VERIFY: "1"
       register: ts_allocs
       ignore_errors: yes
       become: no
@@ -177,7 +193,11 @@
       ansible.builtin.command:
         cmd: "/usr/local/bin/nomad alloc logs {{ ts_alloc_id.stdout }}"
       environment:
-        NOMAD_ADDR: "https://{{ cluster_ip }}:4646"
+        NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+        NOMAD_TLS_SKIP_VERIFY: "1"
       register: ts_logs_stdout
       ignore_errors: yes
       become: no
@@ -192,7 +212,11 @@
       ansible.builtin.command:
         cmd: "/usr/local/bin/nomad alloc logs -stderr {{ ts_alloc_id.stdout }}"
       environment:
-        NOMAD_ADDR: "https://{{ cluster_ip }}:4646"
+        NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+        NOMAD_TLS_SKIP_VERIFY: "1"
       register: ts_logs_stderr
       ignore_errors: yes
       become: no
@@ -207,7 +231,11 @@
       ansible.builtin.command:
         cmd: "/usr/local/bin/nomad alloc status -verbose {{ ts_alloc_id.stdout }}"
       environment:
-        NOMAD_ADDR: "https://{{ cluster_ip }}:4646"
+        NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+        NOMAD_TLS_SKIP_VERIFY: "1"
       register: ts_alloc_status
       ignore_errors: yes
       become: no

--- a/ansible/roles/vision/handlers/main.yaml
+++ b/ansible/roles/vision/handlers/main.yaml
@@ -2,5 +2,9 @@
   ansible.builtin.command:
     cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/vision.nomad
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   changed_when: true

--- a/ansible/roles/vision/tasks/main.yaml
+++ b/ansible/roles/vision/tasks/main.yaml
@@ -44,5 +44,9 @@
   ansible.builtin.command:
     cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/vision.nomad
   environment:
-    NOMAD_ADDR: "https://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   changed_when: true


### PR DESCRIPTION
Globally updated the environment blocks for all `ansible.builtin.command` tasks that interact with the `nomad` CLI to include required mTLS certificates (`NOMAD_CACERT`, `NOMAD_CLIENT_CERT`, `NOMAD_CLIENT_KEY`, `NOMAD_TLS_SKIP_VERIFY`). This resolves connection timeouts and failures when deploying jobs (e.g. World Model Service, Tool Server) to secure clusters.