### PR TITLE
Fix synchronous wait in llxprt_code

### DIFF
--- a/ansible/roles/llxprt_code/tasks/main.yaml
+++ b/ansible/roles/llxprt_code/tasks/main.yaml
@@ -57,7 +57,7 @@
 
 - name: Discover tool-server-api address
   ansible.builtin.uri:
-    url: "http://localhost:{{ consul_http_port }}/v1/health/service/tool-server-api?passing"
+    url: "http://{{ advertise_ip }}:{{ consul_http_port }}/v1/health/service/tool-server-api?passing"
     headers:
       X-Consul-Token: "{{ consul_bootstrap_token }}"
     return_content: yes


### PR DESCRIPTION
Fixed `llxprt_code` to query `advertise_ip` instead of `localhost` so the Consul health check evaluates properly without hanging in the runner.

---
*PR created automatically by Jules for task [7996026016125252671](https://jules.google.com/task/7996026016125252671) started by @LokiMetaSmith*