### PR TITLE
Fix `nomad_tls_dir` undefined error in `moe_gateway` role

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -43,6 +43,7 @@ nomad_version: "1.7.7"
 nomad_namespace: "default"
 nomad_jobs_dir: "/opt/nomad/jobs"
 nomad_volumes_dir: "/opt/nomad/volumes"
+nomad_tls_dir: "/etc/nomad.d/tls"
 nomad_models_dir: "/opt/nomad/models"
 
 # Standard Ports


### PR DESCRIPTION
This commit addresses a downstream bootstrap failure in the `moe_gateway` role where the playbook crashed because the variable `nomad_tls_dir` was undefined during a `ansible.builtin.uri` API call to Nomad. It adds the standard `/etc/nomad.d/tls` path to the global `group_vars/all.yaml` configuration to make it available to all roles requiring Nomad TLS authentication.