### PR TITLE
Optimize Docker image builds using source hashing

### DIFF
--- a/ansible/roles/semantic_router/tasks/main.yaml
+++ b/ansible/roles/semantic_router/tasks/main.yaml
@@ -15,12 +15,53 @@
   become: yes
   register: dockerfile_status
 
+- name: Get checksum of all files in semantic_router build directory
+  ansible.builtin.find:
+    paths: "{{ semantic_router_build_dir }}"
+    recurse: yes
+    get_checksum: yes
+    checksum_algorithm: sha256
+  register: build_files
+  become: yes
+
+- name: Generate build configuration hash
+  ansible.builtin.set_fact:
+    build_hash: >-
+      {{
+        build_files.files
+        | sort(attribute='path')
+        | map(attribute='path')
+        | zip(build_files.files | sort(attribute='path') | map(attribute='checksum'))
+        | map('join', ':')
+        | join(',')
+        | hash('sha256')
+      }}
+
+- name: Extract base image name
+  ansible.builtin.set_fact:
+    base_image_name: "{{ semantic_router_image_name | split(':') | first }}"
+
+- name: Set versioned tag
+  ansible.builtin.set_fact:
+    versioned_tag: "v-{{ build_hash }}"
+
+- name: Check if versioned image exists locally
+  ansible.builtin.command: "docker image inspect {{ base_image_name }}:{{ versioned_tag }}"
+  register: versioned_image_check
+  failed_when: false
+  changed_when: false
+  become: yes
+
 - name: Build Semantic Router Docker Image
   ansible.builtin.command:
-    cmd: "docker build -t {{ semantic_router_image_name }} ."
+    cmd: "docker build -t {{ base_image_name }}:{{ versioned_tag }} ."
     chdir: "{{ semantic_router_build_dir }}"
   become: yes
-  when: dockerfile_status.changed or force_rebuild | default(false)
+  when: dockerfile_status.changed or force_rebuild | default(false) or versioned_image_check.rc != 0
+
+- name: Tag image with target tag
+  ansible.builtin.command: "docker tag {{ base_image_name }}:{{ versioned_tag }} {{ semantic_router_image_name }}"
+  become: yes
 
 - name: Ensure Nomad jobs directory exists
   ansible.builtin.file:

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -73,13 +73,51 @@
   ansible.builtin.command: "ls -R {{ role_path }}"
   changed_when: false
 
+- name: "Tool Server : Get checksum of all files in tool_server directory"
+  ansible.builtin.find:
+    paths: "/opt/tool_server"
+    recurse: yes
+    get_checksum: yes
+    checksum_algorithm: sha256
+  register: build_files
+  become: yes
+
+- name: "Tool Server : Generate build configuration hash"
+  ansible.builtin.set_fact:
+    build_hash: >-
+      {{
+        build_files.files
+        | sort(attribute='path')
+        | map(attribute='path')
+        | zip(build_files.files | sort(attribute='path') | map(attribute='checksum'))
+        | map('join', ':')
+        | join(',')
+        | hash('sha256')
+      }}
+
+- name: "Tool Server : Set versioned tag"
+  ansible.builtin.set_fact:
+    versioned_tag: "v-{{ build_hash }}"
+
+- name: "Tool Server : Check if versioned image exists locally"
+  ansible.builtin.command: "docker image inspect tool-server:{{ versioned_tag }}"
+  register: versioned_image_check
+  failed_when: false
+  changed_when: false
+  become: yes
+
 - name: Build tool-server docker image
   ansible.builtin.command:
-    cmd: "docker build --no-cache -t tool-server:local ."
+    cmd: "docker build --no-cache -t tool-server:{{ versioned_tag }} ."
     chdir: "/opt/tool_server"
   become: yes
   register: tool_server_docker_build_result
   changed_when: "'Successfully built' in tool_server_docker_build_result.stdout or 'writing image' in tool_server_docker_build_result.stdout"
+  when: versioned_image_check.rc != 0
+
+- name: "Tool Server : Tag image with local tag"
+  ansible.builtin.command: "docker tag tool-server:{{ versioned_tag }} tool-server:local"
+  become: yes
 
 - name: Verify tool-server image exists
   ansible.builtin.command: docker image inspect tool-server:local

--- a/ansible/roles/world_model_service/tasks/main.yaml
+++ b/ansible/roles/world_model_service/tasks/main.yaml
@@ -28,15 +28,63 @@
     - "Dockerfile"
   become: true
 
+- name: "World Model Service : Get checksum of all files in world_model_service directory"
+  tags:
+    - world_model_service
+  ansible.builtin.find:
+    paths: "/opt/world_model_service"
+    recurse: yes
+    get_checksum: yes
+    checksum_algorithm: sha256
+  register: build_files
+  become: yes
+
+- name: "World Model Service : Generate build configuration hash"
+  tags:
+    - world_model_service
+  ansible.builtin.set_fact:
+    build_hash: >-
+      {{
+        build_files.files
+        | sort(attribute='path')
+        | map(attribute='path')
+        | zip(build_files.files | sort(attribute='path') | map(attribute='checksum'))
+        | map('join', ':')
+        | join(',')
+        | hash('sha256')
+      }}
+
+- name: "World Model Service : Set versioned tag"
+  tags:
+    - world_model_service
+  ansible.builtin.set_fact:
+    versioned_tag: "v-{{ build_hash }}"
+
+- name: "World Model Service : Check if versioned image exists locally"
+  tags:
+    - world_model_service
+  ansible.builtin.command: "docker image inspect world-model-service:{{ versioned_tag }}"
+  register: versioned_image_check
+  failed_when: false
+  changed_when: false
+  become: yes
+
 - name: "World Model Service : Build the docker image"
   tags:
     - world_model_service
   ansible.builtin.command:
-    cmd: "docker build --no-cache -t world-model-service:local ."
+    cmd: "docker build --no-cache -t world-model-service:{{ versioned_tag }} ."
     chdir: "/opt/world_model_service/"
   register: docker_build_result
   changed_when: "'Successfully built' in docker_build_result.stdout or 'writing image' in docker_build_result.stdout"
   become: true
+  when: versioned_image_check.rc != 0
+
+- name: "World Model Service : Tag image with local tag"
+  tags:
+    - world_model_service
+  ansible.builtin.command: "docker tag world-model-service:{{ versioned_tag }} world-model-service:local"
+  become: yes
 
 - name: "World Model Service : Copy debug script"
   tags:


### PR DESCRIPTION
Implemented an optimized build pattern across tool_server, world_model_service, and semantic_router to dramatically speed up consecutive runs of the deployment playbook when source files for these Docker images haven't changed. The playbooks now deterministically compute a hash of the build directory and use it to skip redundant `docker build` executions.

---
*PR created automatically by Jules for task [15898617194560648335](https://jules.google.com/task/15898617194560648335) started by @LokiMetaSmith*