### PR TITLE
Fix MQTT Exporter deployment job check failure and correct cert paths

### DIFF
--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -238,12 +238,13 @@
         cmd: /usr/local/bin/nomad job status mqtt-exporter
       register: pre_mqtt_exporter_job_status
       ignore_errors: yes
+      failed_when: false
       changed_when: false
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
 
     - name: Purge failing MQTT Exporter deployment
       ansible.builtin.command:
@@ -252,8 +253,8 @@
       environment:
         NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
-        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cert.pem"
-        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/key.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
 
     - name: Template mqtt-exporter job
       ansible.builtin.template:


### PR DESCRIPTION
This PR fixes a deployment failure for the MQTT Exporter job. The Nomad API command checking if the job exists before purging returned a non-zero exit code because the job was naturally not present. Adding `failed_when: false` ensures the process continues cleanly instead of aborting the playbook with a fatal error. Additionally, updated the `NOMAD_CLIENT_CERT` and `NOMAD_CLIENT_KEY` environment variables to accurately point to `cli.cert.pem` and `cli.key.pem`, matching the cluster's client certificate conventions.

---
*PR created automatically by Jules for task [13846707966492176074](https://jules.google.com/task/13846707966492176074) started by @LokiMetaSmith*