### PR TITLE
Refactor to use a shared cached Docker build task

### DIFF
--- a/ansible/roles/semantic_router/tasks/main.yaml
+++ b/ansible/roles/semantic_router/tasks/main.yaml
@@ -15,53 +15,21 @@
   become: yes
   register: dockerfile_status
 
-- name: Get checksum of all files in semantic_router build directory
-  ansible.builtin.find:
-    paths: "{{ semantic_router_build_dir }}"
-    recurse: yes
-    get_checksum: yes
-    checksum_algorithm: sha256
-  register: build_files
-  become: yes
-
-- name: Generate build configuration hash
-  ansible.builtin.set_fact:
-    build_hash: >-
-      {{
-        build_files.files
-        | sort(attribute='path')
-        | map(attribute='path')
-        | zip(build_files.files | sort(attribute='path') | map(attribute='checksum'))
-        | map('join', ':')
-        | join(',')
-        | hash('sha256')
-      }}
-
 - name: Extract base image name
   ansible.builtin.set_fact:
-    base_image_name: "{{ semantic_router_image_name | split(':') | first }}"
+    _semantic_router_base_image: "{{ semantic_router_image_name | regex_replace(':[^/:]+$', '') }}"
 
-- name: Set versioned tag
+- name: Extract tag name
   ansible.builtin.set_fact:
-    versioned_tag: "v-{{ build_hash }}"
+    _semantic_router_tag: "{{ semantic_router_image_name | regex_search('(?<=:)[^/:]+$') | default('latest', true) }}"
 
-- name: Check if versioned image exists locally
-  ansible.builtin.command: "docker image inspect {{ base_image_name }}:{{ versioned_tag }}"
-  register: versioned_image_check
-  failed_when: false
-  changed_when: false
-  become: yes
-
-- name: Build Semantic Router Docker Image
-  ansible.builtin.command:
-    cmd: "docker build -t {{ base_image_name }}:{{ versioned_tag }} ."
-    chdir: "{{ semantic_router_build_dir }}"
-  become: yes
-  when: dockerfile_status.changed or force_rebuild | default(false) or versioned_image_check.rc != 0
-
-- name: Tag image with target tag
-  ansible.builtin.command: "docker tag {{ base_image_name }}:{{ versioned_tag }} {{ semantic_router_image_name }}"
-  become: yes
+- name: Build Semantic Router Docker Image (cached)
+  ansible.builtin.include_tasks:
+    file: "../../tasks/build_cached_image.yaml"
+  vars:
+    build_dir: "{{ semantic_router_build_dir }}"
+    image_name: "{{ _semantic_router_base_image }}"
+    image_tag: "{{ _semantic_router_tag }}"
 
 - name: Ensure Nomad jobs directory exists
   ansible.builtin.file:

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -73,51 +73,13 @@
   ansible.builtin.command: "ls -R {{ role_path }}"
   changed_when: false
 
-- name: "Tool Server : Get checksum of all files in tool_server directory"
-  ansible.builtin.find:
-    paths: "/opt/tool_server"
-    recurse: yes
-    get_checksum: yes
-    checksum_algorithm: sha256
-  register: build_files
-  become: yes
-
-- name: "Tool Server : Generate build configuration hash"
-  ansible.builtin.set_fact:
-    build_hash: >-
-      {{
-        build_files.files
-        | sort(attribute='path')
-        | map(attribute='path')
-        | zip(build_files.files | sort(attribute='path') | map(attribute='checksum'))
-        | map('join', ':')
-        | join(',')
-        | hash('sha256')
-      }}
-
-- name: "Tool Server : Set versioned tag"
-  ansible.builtin.set_fact:
-    versioned_tag: "v-{{ build_hash }}"
-
-- name: "Tool Server : Check if versioned image exists locally"
-  ansible.builtin.command: "docker image inspect tool-server:{{ versioned_tag }}"
-  register: versioned_image_check
-  failed_when: false
-  changed_when: false
-  become: yes
-
-- name: Build tool-server docker image
-  ansible.builtin.command:
-    cmd: "docker build --no-cache -t tool-server:{{ versioned_tag }} ."
-    chdir: "/opt/tool_server"
-  become: yes
-  register: tool_server_docker_build_result
-  changed_when: "'Successfully built' in tool_server_docker_build_result.stdout or 'writing image' in tool_server_docker_build_result.stdout"
-  when: versioned_image_check.rc != 0
-
-- name: "Tool Server : Tag image with local tag"
-  ansible.builtin.command: "docker tag tool-server:{{ versioned_tag }} tool-server:local"
-  become: yes
+- name: "Tool Server : Build tool-server docker image (cached)"
+  ansible.builtin.include_tasks:
+    file: "../../tasks/build_cached_image.yaml"
+  vars:
+    build_dir: "/opt/tool_server"
+    image_name: "tool-server"
+    image_tag: "local"
 
 - name: Verify tool-server image exists
   ansible.builtin.command: docker image inspect tool-server:local

--- a/ansible/roles/world_model_service/tasks/main.yaml
+++ b/ansible/roles/world_model_service/tasks/main.yaml
@@ -28,63 +28,15 @@
     - "Dockerfile"
   become: true
 
-- name: "World Model Service : Get checksum of all files in world_model_service directory"
+- name: "World Model Service : Build the docker image (cached)"
   tags:
     - world_model_service
-  ansible.builtin.find:
-    paths: "/opt/world_model_service"
-    recurse: yes
-    get_checksum: yes
-    checksum_algorithm: sha256
-  register: build_files
-  become: yes
-
-- name: "World Model Service : Generate build configuration hash"
-  tags:
-    - world_model_service
-  ansible.builtin.set_fact:
-    build_hash: >-
-      {{
-        build_files.files
-        | sort(attribute='path')
-        | map(attribute='path')
-        | zip(build_files.files | sort(attribute='path') | map(attribute='checksum'))
-        | map('join', ':')
-        | join(',')
-        | hash('sha256')
-      }}
-
-- name: "World Model Service : Set versioned tag"
-  tags:
-    - world_model_service
-  ansible.builtin.set_fact:
-    versioned_tag: "v-{{ build_hash }}"
-
-- name: "World Model Service : Check if versioned image exists locally"
-  tags:
-    - world_model_service
-  ansible.builtin.command: "docker image inspect world-model-service:{{ versioned_tag }}"
-  register: versioned_image_check
-  failed_when: false
-  changed_when: false
-  become: yes
-
-- name: "World Model Service : Build the docker image"
-  tags:
-    - world_model_service
-  ansible.builtin.command:
-    cmd: "docker build --no-cache -t world-model-service:{{ versioned_tag }} ."
-    chdir: "/opt/world_model_service/"
-  register: docker_build_result
-  changed_when: "'Successfully built' in docker_build_result.stdout or 'writing image' in docker_build_result.stdout"
-  become: true
-  when: versioned_image_check.rc != 0
-
-- name: "World Model Service : Tag image with local tag"
-  tags:
-    - world_model_service
-  ansible.builtin.command: "docker tag world-model-service:{{ versioned_tag }} world-model-service:local"
-  become: yes
+  ansible.builtin.include_tasks:
+    file: "../../tasks/build_cached_image.yaml"
+  vars:
+    build_dir: "/opt/world_model_service"
+    image_name: "world-model-service"
+    image_tag: "local"
 
 - name: "World Model Service : Copy debug script"
   tags:

--- a/ansible/tasks/build_cached_image.yaml
+++ b/ansible/tasks/build_cached_image.yaml
@@ -1,0 +1,45 @@
+- name: "Build Cached Image : Get checksum of all files in {{ build_dir }}"
+  ansible.builtin.find:
+    paths: "{{ build_dir }}"
+    recurse: yes
+    get_checksum: yes
+    checksum_algorithm: sha256
+  register: _build_files
+  become: yes
+
+- name: "Build Cached Image : Generate build configuration hash"
+  ansible.builtin.set_fact:
+    _build_hash: >-
+      {{
+        _build_files.files
+        | sort(attribute='path')
+        | map(attribute='path')
+        | zip(_build_files.files | sort(attribute='path') | map(attribute='checksum'))
+        | map('join', ':')
+        | join(',')
+        | hash('sha256')
+      }}
+
+- name: "Build Cached Image : Set versioned tag"
+  ansible.builtin.set_fact:
+    _versioned_tag: "v-{{ _build_hash }}"
+
+- name: "Build Cached Image : Check if versioned image exists locally"
+  ansible.builtin.command: "docker image inspect {{ image_name }}:{{ _versioned_tag }}"
+  register: _versioned_image_check
+  failed_when: false
+  changed_when: false
+  become: yes
+
+- name: "Build Cached Image : Build the docker image"
+  ansible.builtin.command:
+    cmd: "docker build --no-cache -t {{ image_name }}:{{ _versioned_tag }} ."
+    chdir: "{{ build_dir }}"
+  register: _docker_build_result
+  changed_when: "_docker_build_result.stdout is defined and ('Successfully built' in _docker_build_result.stdout or 'writing image' in _docker_build_result.stdout)"
+  become: yes
+  when: _versioned_image_check.rc != 0 or (force_rebuild | default(false) | bool)
+
+- name: "Build Cached Image : Tag image with target tag"
+  ansible.builtin.command: "docker tag {{ image_name }}:{{ _versioned_tag }} {{ image_name }}:{{ image_tag | default('latest') }}"
+  become: yes


### PR DESCRIPTION
Refactored `tool_server`, `world_model_service`, and `semantic_router` playbooks to use a generic caching task file (`ansible/tasks/build_cached_image.yaml`) to centralize the implementation of the hashed directory fallback mechanism that prevents unchanged Docker builds. Fixed regex string parsing to handle Docker registry configurations in image strings.