### PR TITLE
Add tools for cluster network validation and load/stress testing

### DIFF
--- a/ansible/jobs/dummy_web_service.nomad
+++ b/ansible/jobs/dummy_web_service.nomad
@@ -1,0 +1,58 @@
+job "dummy-web-service" {
+  datacenters = ["dc1"]
+  type = "service"
+
+  group "web" {
+    count = 3 # Run multiple instances to test load balancing across nodes
+
+    network {
+      port "http" {
+        to = 8000
+      }
+    }
+
+    service {
+      name = "dummy-web"
+      port = "http"
+
+      # Register with Traefik for load balancing
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.dummy-web.rule=Host(`dummy.local.mesh`)", # Requires requests to use this Host header
+        "traefik.http.routers.dummy-web.entrypoints=web",
+        "traefik.http.services.dummy-web.loadbalancer.server.port=${NOMAD_PORT_http}"
+      ]
+
+      check {
+        type     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "python:3.9-slim"
+        # Create a simple python web server that returns the node ID it's running on
+        command = "sh"
+        args = [
+          "-c",
+          "echo \"import http.server, socketserver, os; class MyHandler(http.server.SimpleHTTPRequestHandler): def do_GET(self): self.send_response(200); self.send_header('Content-type', 'text/plain'); self.end_headers(); self.wfile.write(f'Node: {os.environ.get(\\\"node.unique.id\\\", \\\"unknown\\\")} | Alloc: {os.environ.get(\\\"NOMAD_ALLOC_ID\\\", \\\"unknown\\\")} \\n'.encode('utf-8')); httpd = socketserver.TCPServer(('', 8000), MyHandler); httpd.serve_forever()\" > server.py && python server.py"
+        ]
+        ports = ["http"]
+      }
+
+      env {
+        "node.unique.id" = "${node.unique.id}"
+      }
+
+      resources {
+        cpu    = 50 # 50 MHz
+        memory = 64 # 64 MB
+      }
+    }
+  }
+}

--- a/tests/playbooks/verify_cluster_network.yaml
+++ b/tests/playbooks/verify_cluster_network.yaml
@@ -1,0 +1,86 @@
+---
+- name: Verify Cluster Network Connectivity
+  hosts: all
+  become: yes
+  gather_facts: yes
+  tasks:
+    - name: Get primary Tailscale IP (if tailscale0 interface exists)
+      ansible.builtin.set_fact:
+        my_tailscale_ip: "{{ ansible_facts['tailscale0']['ipv4']['address'] | default(ansible_facts['default_ipv4']['address']) }}"
+      when: "'tailscale0' in ansible_facts"
+
+    - name: Get default IP if tailscale0 is missing
+      ansible.builtin.set_fact:
+        my_tailscale_ip: "{{ ansible_facts['default_ipv4']['address'] }}"
+      when: "'tailscale0' not in ansible_facts"
+
+    - name: Ping all other nodes' Tailscale IPs
+      ansible.builtin.command: ping -c 1 -W 2 {{ hostvars[item]['my_tailscale_ip'] }}
+      loop: "{{ groups['all'] }}"
+      when: hostvars[item]['my_tailscale_ip'] is defined and item != inventory_hostname
+      register: ping_results
+      ignore_errors: yes
+
+    - name: Assert Tailscale ping success
+      ansible.builtin.assert:
+        that:
+          - item.rc == 0
+        fail_msg: "Failed to ping {{ item.item }} from {{ inventory_hostname }}"
+        success_msg: "Successfully pinged {{ item.item }} from {{ inventory_hostname }}"
+      loop: "{{ ping_results.results }}"
+      when: item.skipped is not defined
+
+    - name: Verify Consul DNS resolution for local node
+      ansible.builtin.command: dig @127.0.0.1 -p 8600 consul.service.consul +short
+      register: consul_dns_result
+      ignore_errors: yes
+
+    - name: Assert Consul DNS resolution success
+      ansible.builtin.assert:
+        that:
+          - consul_dns_result.rc == 0
+          - consul_dns_result.stdout | length > 0
+        fail_msg: "Consul DNS resolution failed on {{ inventory_hostname }}"
+        success_msg: "Consul DNS resolution works on {{ inventory_hostname }}"
+
+    - name: Verify Nomad API connectivity to controller (HTTPS with mTLS)
+      ansible.builtin.uri:
+        url: "https://{{ hostvars[groups['controller_nodes'][0]]['my_tailscale_ip'] }}:4646/v1/agent/self"
+        method: GET
+        client_cert: "{{ nomad_tls_dir | default('/etc/nomad.d/tls') }}/cli.cert.pem"
+        client_key: "{{ nomad_tls_dir | default('/etc/nomad.d/tls') }}/cli.key.pem"
+        validate_certs: no # Skip verify if using self-signed
+      register: nomad_api_result
+      ignore_errors: yes
+
+    - name: Assert Nomad API connectivity
+      ansible.builtin.assert:
+        that:
+          - nomad_api_result.status == 200
+        fail_msg: "Failed to connect to Nomad API on {{ groups['controller_nodes'][0] }} from {{ inventory_hostname }}"
+        success_msg: "Successfully connected to Nomad API on {{ groups['controller_nodes'][0] }} from {{ inventory_hostname }}"
+
+    - name: Verify Traefik accessibility on port 80
+      ansible.builtin.uri:
+        url: "http://{{ my_tailscale_ip }}:80/ping" # Assuming traefik ping endpoint or default catch-all
+        method: GET
+      register: traefik_result
+      ignore_errors: yes
+      when: inventory_hostname in groups['controller_nodes'] # Usually traefik is on controllers, or we can check its service
+
+    # Let's check the Traefik dashboard/ping endpoint instead
+    - name: Check Traefik ping via Consul
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:8500/v1/health/service/traefik?passing"
+        method: GET
+      register: traefik_consul_health
+      ignore_errors: yes
+
+    - name: Assert Traefik is passing health checks in Consul
+      ansible.builtin.assert:
+        that:
+          - traefik_consul_health.status == 200
+          - traefik_consul_health.json | length > 0
+        fail_msg: "Traefik service is not passing health checks in Consul."
+        success_msg: "Traefik service is healthy in Consul."
+      when: inventory_hostname in groups['controller_nodes']

--- a/tests/scripts/stress_test_cluster.py
+++ b/tests/scripts/stress_test_cluster.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+import asyncio
+import aiohttp
+import argparse
+import time
+from collections import Counter
+import sys
+
+async def fetch(session, url, headers):
+    try:
+        async with session.get(url, headers=headers, timeout=5) as response:
+            text = await response.text()
+            if response.status == 200:
+                return text.strip()
+            else:
+                return f"Error: HTTP {response.status}"
+    except Exception as e:
+        return f"Exception: {type(e).__name__}"
+
+async def main(target_url, num_requests, concurrency, host_header):
+    print(f"Starting stress test against {target_url}...")
+    print(f"Requests: {num_requests}, Concurrency: {concurrency}")
+    if host_header:
+        print(f"Host Header: {host_header}")
+
+    headers = {"Host": host_header} if host_header else {}
+    start_time = time.time()
+
+    responses = []
+
+    connector = aiohttp.TCPConnector(limit=concurrency)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        tasks = []
+        for _ in range(num_requests):
+            tasks.append(asyncio.ensure_future(fetch(session, target_url, headers)))
+
+        responses = await asyncio.gather(*tasks)
+
+    duration = time.time() - start_time
+
+    # Parse results
+    successes = 0
+    failures = 0
+    nodes = Counter()
+    allocations = Counter()
+    errors = Counter()
+
+    for r in responses:
+        if r.startswith("Node:"):
+            successes += 1
+            # Expected format: "Node: <node_id> | Alloc: <alloc_id>"
+            parts = r.split("|")
+            if len(parts) == 2:
+                node_part = parts[0].replace("Node:", "").strip()
+                alloc_part = parts[1].replace("Alloc:", "").strip()
+                nodes[node_part] += 1
+                allocations[alloc_part] += 1
+            else:
+                nodes["unknown_format"] += 1
+        else:
+            failures += 1
+            errors[r] += 1
+
+    print("\n" + "="*40)
+    print("STRESS TEST RESULTS")
+    print("="*40)
+    print(f"Total Requests:      {num_requests}")
+    print(f"Concurrency:         {concurrency}")
+    print(f"Duration:            {duration:.2f} seconds")
+    print(f"Requests/sec:        {num_requests/duration:.2f}")
+    print(f"Successful Requests: {successes}")
+    print(f"Failed Requests:     {failures}")
+
+    print("\nLoad Distribution by Node:")
+    print("-" * 25)
+    for node, count in nodes.most_common():
+        percentage = (count / successes * 100) if successes > 0 else 0
+        print(f"{node:<20} {count:>5} ({percentage:>5.1f}%)")
+
+    print("\nLoad Distribution by Allocation (Container):")
+    print("-" * 40)
+    for alloc, count in allocations.most_common():
+        percentage = (count / successes * 100) if successes > 0 else 0
+        print(f"{alloc:<36} {count:>5} ({percentage:>5.1f}%)")
+
+    if failures > 0:
+        print("\nErrors encountered:")
+        print("-" * 25)
+        for err, count in errors.most_common():
+            print(f"{err}: {count}")
+
+    # Exit with error code if we had high failure rate or no distribution
+    if successes == 0:
+        print("\nTest failed: 0 successful requests.")
+        sys.exit(1)
+    if failures / num_requests > 0.1:
+        print("\nWarning: > 10% failure rate.")
+        sys.exit(1)
+    if len(nodes) < 2 and successes > 10:
+        print("\nWarning: All traffic went to a single node. Load balancing may not be working across nodes.")
+
+    if len(allocations) < 2 and successes > 10:
+        print("\nWarning: All traffic went to a single container allocation. Load balancing may not be working.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Stress test Traefik/Nomad load balancing")
+    parser.add_argument("--url", default="http://localhost", help="Target URL (default: http://localhost)")
+    parser.add_argument("-n", "--requests", type=int, default=1000, help="Total number of requests to send")
+    parser.add_argument("-c", "--concurrency", type=int, default=50, help="Number of concurrent requests")
+    parser.add_argument("--host", default="dummy.local.mesh", help="Host header to pass for Traefik routing (default: dummy.local.mesh)")
+
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(main(args.url, args.requests, args.concurrency, args.host))
+    except KeyboardInterrupt:
+        print("\nTest interrupted by user.")
+        sys.exit(1)


### PR DESCRIPTION
This PR adds a suite of test tools to validate network routing and test cluster load balancing specifically around the upcoming multi-node swarm deployment. It features a dummy Nomad web job to balance across, an async Python stress tester to verify request distribution, and an Ansible playbook to check Tailscale, Consul, Nomad, and Traefik health.

---
*PR created automatically by Jules for task [6929426216163331264](https://jules.google.com/task/6929426216163331264) started by @LokiMetaSmith*