### PR TITLE
feat: add placeholder configuration for TML interaction models

### DIFF
--- a/ansible/jobs/tml-interaction.nomad.j2
+++ b/ansible/jobs/tml-interaction.nomad.j2
@@ -1,0 +1,93 @@
+job "{{ job_name | default('tml-interaction') }}" {
+  datacenters = ["dc1"]
+  namespace   = "{{ nomad_namespace | default('default') }}"
+  type        = "service"
+
+  group "interaction-group" {
+    count = 1
+
+    network {
+      # The HTTP port for configuration and control plane communication
+      port "http" {
+        to = 8000
+      }
+      # The WebRTC port for the continuous audio/video micro-turn stream
+      port "webrtc" {
+        to = 8080
+      }
+    }
+
+    service {
+      name = "tml-interaction-http"
+      port = "http"
+
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.tml-interaction.rule=Host(`interaction.{{ mesh_domain | default('local.mesh') }}`)",
+        "traefik.http.routers.tml-interaction.entrypoints=websecure",
+        "traefik.http.routers.tml-interaction.tls=true"
+      ]
+
+      check {
+        type     = "http"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    service {
+      name = "tml-interaction-stream"
+      port = "webrtc"
+
+      tags = [
+        # Traefik routing could be set up for WebRTC if desired (e.g., via UDP/TCP routers)
+        "traefik.enable=true",
+        "traefik.udp.routers.tml-stream.entrypoints=webrtc",
+        "traefik.udp.services.tml-stream.loadbalancer.server.port=8080"
+      ]
+
+      # Minimal TCP check to ensure the streaming port is bound
+      check {
+        type     = "tcp"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "tml-runtime" {
+      driver = "docker"
+
+      config {
+        # This is a placeholder for the actual TML interaction runtime image
+        image = "thinkingmachines/interaction-runtime:preview"
+
+        ports = ["http", "webrtc"]
+
+        # Ensure GPUs are passed through for real-time model inference
+        # (Assuming the model runs natively requiring GPU acceleration)
+        {% if enable_gpu | default(true) %}
+        # Experimental feature in Nomad Docker driver for GPU passthrough
+        # Some setups use `device` blocks or `gpus = "all"`
+        args = [
+          "--gpus", "all"
+        ]
+        {% endif %}
+      }
+
+      env {
+        MODEL_PATH = "{{ nomad_models_dir }}/{{ model.filename | default('tml-interaction-small.gguf') }}"
+        STREAMING_PORT = "8080"
+        HTTP_PORT = "8000"
+        # Enable multi-modal processing for micro-turns
+        ENABLE_AUDIO = "true"
+        ENABLE_VIDEO = "true"
+      }
+
+      resources {
+        # Allocate sufficient memory for a large MoE model and streaming buffers
+        memory = {{ model.memory_mb | default(16384) }}
+      }
+    }
+  }
+}

--- a/ansible/roles/tml_interaction/README.md
+++ b/ansible/roles/tml_interaction/README.md
@@ -1,0 +1,6 @@
+# TML Interaction Role
+
+This role acts as a placeholder to configure the cluster for the Thinking Machines Lab's Interaction Models research preview.
+It establishes the routing, continuous multi-modal streaming architecture, and Nomad job configurations for the multi-stream micro-turn models.
+
+Currently, it sets up the `tml-interaction` Nomad jobs using placeholder image and weights URLs.

--- a/ansible/roles/tml_interaction/tasks/main.yaml
+++ b/ansible/roles/tml_interaction/tasks/main.yaml
@@ -1,0 +1,46 @@
+---
+- name: Set job facts for TML Interaction Models
+  ansible.builtin.set_fact:
+    tml_models: "{{ interaction_models.tml | default([]) }}"
+
+- name: Stop and purge any existing tml-interaction jobs (for updates)
+  ansible.builtin.command:
+    cmd: /usr/local/bin/nomad job stop -purge "tml-interaction-{{ item.name | regex_replace('[^a-zA-Z0-9-]', '-') | lower }}"
+  loop: "{{ tml_models }}"
+  register: tml_job_stop_status
+  changed_when: "'Running' in tml_job_stop_status.stdout"
+  failed_when: false # Don't fail if the job doesn't exist
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+
+- name: Template tml-interaction nomad job for each model
+  ansible.builtin.template:
+    src: ../../jobs/tml-interaction.nomad.j2
+    dest: "/tmp/tml-interaction-{{ item.name | regex_replace('[^a-zA-Z0-9-]', '-') | lower }}.nomad"
+    mode: '0644'
+  loop: "{{ tml_models }}"
+  vars:
+    # Safely create a job name string
+    job_name: "tml-interaction-{{ item.name | regex_replace('[^a-zA-Z0-9-]', '-') | lower }}"
+    model: "{{ item }}"
+
+- name: Run tml-interaction job for each model
+  ansible.builtin.command:
+    cmd: "/usr/local/bin/nomad job run -detach /tmp/tml-interaction-{{ item.name | regex_replace('[^a-zA-Z0-9-]', '-') | lower }}.nomad"
+  loop: "{{ tml_models }}"
+  register: tml_job_run
+  changed_when: "'Eval ID' in tml_job_run.stdout"
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+
+- name: Clean up temporary job files
+  ansible.builtin.file:
+    path: "/tmp/tml-interaction-{{ item.name | regex_replace('[^a-zA-Z0-9-]', '-') | lower }}.nomad"
+    state: absent
+  loop: "{{ tml_models }}"

--- a/group_vars/models.yaml
+++ b/group_vars/models.yaml
@@ -144,3 +144,13 @@ vision_models:
   - name: "moondream2"
     repo_id: "vikhyatk/moondream2"
     # This model will be downloaded using the huggingface_hub module.
+
+# Interaction Models (Research Preview Placeholder)
+# Specialized models handling continuous audio/video micro-turns directly.
+interaction_models:
+  tml:
+    - name: "TML-Interaction-Small"
+      url: "placeholder://thinkingmachines.ai/tml-interaction-small"
+      filename: "tml-interaction-small.gguf"
+      memory_mb: 16384 # Estimate for a 12B active parameter MoE model
+      description: "Thinking Machines Lab Interaction Model (Research Preview)"

--- a/playbooks/services/core_ai_services.yaml
+++ b/playbooks/services/core_ai_services.yaml
@@ -35,3 +35,7 @@
     - role: pipecatapp
       tags:
         - pipecatapp
+    - role: tml_interaction
+      tags:
+        - tml_interaction
+        - interaction_models


### PR DESCRIPTION
This pull request introduces the infrastructure foundation for the upcoming Thinking Machines Lab Interaction Models research preview.

It configures a new Nomad job designed to handle continuous WebRTC multi-modal audio/video micro-turns, distinct from the standard text-based LLM jobs. It also registers placeholder models in the configuration so the cluster is ready to deploy them once the preview weights or runtimes become available.

---
*PR created automatically by Jules for task [13244643380845295231](https://jules.google.com/task/13244643380845295231) started by @LokiMetaSmith*