### PR TITLE
Add e2a email gateway integration

### DIFF
--- a/ansible/roles/e2a/tasks/main.yml
+++ b/ansible/roles/e2a/tasks/main.yml
@@ -1,0 +1,24 @@
+- name: Create e2a data directory
+  ansible.builtin.file:
+    path: "{{ nomad_volumes_dir }}/e2a/data"
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Template e2a Nomad job
+  ansible.builtin.template:
+    src: e2a.nomad.j2
+    dest: "{{ nomad_jobs_dir }}/e2a.nomad"
+  become: yes
+
+- name: Run e2a Nomad job
+  ansible.builtin.command: nomad job run -detach {{ nomad_jobs_dir }}/e2a.nomad
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "{{ nomad_tls_dir }}/ca.pem"
+    NOMAD_CLIENT_CERT: "{{ nomad_tls_dir }}/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "{{ nomad_tls_dir }}/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
+  register: e2a_deploy
+  changed_when: "'modified' in e2a_deploy.stdout or 'created' in e2a_deploy.stdout"
+  become: yes

--- a/ansible/roles/e2a/templates/e2a.nomad.j2
+++ b/ansible/roles/e2a/templates/e2a.nomad.j2
@@ -1,0 +1,80 @@
+job "e2a" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  # Deploy on edge tier node (as specified by the user)
+  constraint {
+    attribute = "${node.class}"
+    value     = "edge"
+  }
+
+  group "e2a" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 8080
+      }
+      port "smtp" {
+        to = 25
+      }
+    }
+
+    service {
+      name = "e2a"
+      port = "http"
+
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.e2a.rule=Host(`e2a.{{ cluster_domain | default('local.mesh') }}`)",
+        "traefik.http.routers.e2a.entrypoints=websecure",
+        "traefik.http.routers.e2a.tls=true",
+        "traefik.http.routers.e2a.tls.certresolver=local"
+      ]
+
+      check {
+        type     = "http"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    # TCP router for SMTP if needed
+    service {
+      name = "e2a-smtp"
+      port = "smtp"
+
+      tags = [
+        "traefik.enable=true",
+        "traefik.tcp.routers.e2a-smtp.rule=HostSNI(`*`)",
+        "traefik.tcp.routers.e2a-smtp.entrypoints=smtp"
+      ]
+    }
+
+    task "e2a" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/mnexa-ai/e2a:latest"
+        ports = ["http", "smtp"]
+
+        # Volumes for e2a data persistence
+        volumes = [
+          "{{ nomad_volumes_dir }}/e2a/data:/data"
+        ]
+      }
+
+      env {
+        PORT = "8080"
+        SMTP_PORT = "25"
+        # Additional required env vars for e2a can be configured here
+      }
+
+      resources {
+        cpu    = 200 # MHz
+        memory = 256 # MB
+      }
+    }
+  }
+}

--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -108,6 +108,7 @@
         - forgejo
         - paperless
         - opengist
+        - e2a
       loop_control:
         loop_var: role_name
       tags:
@@ -119,6 +120,7 @@
         - forgejo
         - paperless
         - opengist
+        - e2a
 
     - name: Run Paddler Stack
       when: enable_paddler | default(false)


### PR DESCRIPTION
Added the e2a authenticated email gateway for AI agents to the cluster. This allows agents to utilize authenticated email capabilities using an edge tier node, exposed only to the local mesh.

---
*PR created automatically by Jules for task [9880796277426589742](https://jules.google.com/task/9880796277426589742) started by @LokiMetaSmith*