### PR TITLE
Secure Traefik Ingress Configuration for Mesh Network

### DIFF
--- a/ansible/jobs/dummy_web_service.nomad
+++ b/ansible/jobs/dummy_web_service.nomad
@@ -16,12 +16,7 @@ job "dummy-web-service" {
       port = "http"
 
       # Register with Traefik for load balancing
-      tags = [
-        "traefik.enable=true",
-        "traefik.http.routers.dummy-web.rule=Host(`dummy.local.mesh`)", # Requires requests to use this Host header
-        "traefik.http.routers.dummy-web.entrypoints=web",
-        "traefik.http.services.dummy-web.loadbalancer.server.port=${NOMAD_PORT_http}"
-      ]
+      tags = []
 
       check {
         type     = "http"

--- a/ansible/jobs/e2a.nomad.j2
+++ b/ansible/jobs/e2a.nomad.j2
@@ -1,0 +1,47 @@
+job "e2a" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "web" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 8080
+      }
+    }
+
+    service {
+      name = "e2a"
+      port = "http"
+
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.e2a.rule=Host(`e2a.{{ cluster_domain | default('local.mesh') }}`)",
+        "traefik.http.routers.e2a.entrypoints=websecure",
+        "traefik.http.routers.e2a.tls=true"
+      ]
+
+      check {
+        type     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "e2a:placeholder"
+        ports = ["http"]
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+  }
+}

--- a/ansible/jobs/filebrowser.nomad.j2
+++ b/ansible/jobs/filebrowser.nomad.j2
@@ -14,10 +14,7 @@ job "filebrowser" {
     service {
       name = "filebrowser"
       port = "http"
-      tags = [
-        "traefik.enable=true",
-        "traefik.http.routers.filebrowser.rule=Host(`filebrowser.service.consul`)",
-      ]
+      tags = []
       check {
         type     = "http"
         path     = "/"

--- a/ansible/jobs/opengravity.nomad.j2
+++ b/ansible/jobs/opengravity.nomad.j2
@@ -1,0 +1,47 @@
+job "opengravity" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "web" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 3000
+      }
+    }
+
+    service {
+      name = "opengravity"
+      port = "http"
+
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.opengravity.rule=Host(`opengravity.{{ cluster_domain | default('local.mesh') }}`)",
+        "traefik.http.routers.opengravity.entrypoints=websecure",
+        "traefik.http.routers.opengravity.tls=true"
+      ]
+
+      check {
+        type     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "opengravity:placeholder"
+        ports = ["http"]
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+  }
+}

--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -185,7 +185,9 @@ EOH
         port = "http"
         tags = [
           "traefik.enable=true",
-          "traefik.http.routers.authentik.rule=Host(`authentik.service.consul`)",
+          "traefik.http.routers.authentik.rule=Host(`authentik.{{ cluster_domain | default('local.mesh') }}`)",
+          "traefik.http.routers.authentik.entrypoints=websecure",
+          "traefik.http.routers.authentik.tls=true",
           "traefik.http.services.authentik.loadbalancer.server.port={{ authentik_internal_port | default(9000) }}"
         ]
       }

--- a/ansible/roles/docker_registry/templates/docker-registry.nomad.j2
+++ b/ansible/roles/docker_registry/templates/docker-registry.nomad.j2
@@ -19,10 +19,7 @@ job "docker-registry" {
     service {
       name = "docker-registry"
       port = "http"
-      tags = [
-        "traefik.enable=true",
-        "traefik.http.routers.registry.rule=Host(`registry.service.consul`)",
-      ]
+      tags = []
       check {
         type     = "tcp"
         interval = "10s"

--- a/ansible/roles/monitoring/templates/beszel-hub.nomad.j2
+++ b/ansible/roles/monitoring/templates/beszel-hub.nomad.j2
@@ -23,10 +23,7 @@ job "beszel-hub" {
       service {
         name = "beszel-hub"
         port = "http"
-        tags = [
-          "traefik.enable=true",
-          "traefik.http.routers.beszel.rule=Host(`beszel.service.consul`)"
-        ]
+        tags = []
         check {
           name     = "alive"
           type     = "tcp"

--- a/ansible/roles/monitoring/templates/statsping.nomad.j2
+++ b/ansible/roles/monitoring/templates/statsping.nomad.j2
@@ -29,10 +29,7 @@ job "statsping" {
       service {
         name = "statsping"
         port = "http"
-        tags = [
-          "traefik.enable=true",
-          "traefik.http.routers.statsping.rule=Host(`statsping.service.consul`)"
-        ]
+        tags = []
         check {
           name     = "alive"
           type     = "http"

--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -81,10 +81,9 @@ job "{{ job_name | default('pipecat-app') }}" {
         "ai-agent",
         "version=1.0",
         "traefik.enable=true",
-        "traefik.http.routers.pipecatapp.rule=Host(`pipecatapp.{{ cluster_domain | default('local.mesh') }}`) || Host(`localhost`) || Host(`127.0.0.1`)",
+        "traefik.http.routers.pipecatapp.rule=Host(`pipecatapp.{{ cluster_domain | default('local.mesh') }}`)",
         "traefik.http.routers.pipecatapp.entrypoints=websecure",
-        "traefik.http.routers.pipecatapp.tls=true",
-        "traefik.http.routers.pipecatapp.tls.certresolver=local"
+        "traefik.http.routers.pipecatapp.tls=true"
       ]
 
       check {

--- a/ansible/roles/traefik/templates/headscale-router.yaml.j2
+++ b/ansible/roles/traefik/templates/headscale-router.yaml.j2
@@ -5,8 +5,7 @@ http:
       service: headscale
       entryPoints:
         - websecure
-      tls:
-        certResolver: local  # Assumes you have a local cert resolver defined in Traefik
+      tls: {}
 
   services:
     headscale:

--- a/ansible/roles/traefik/templates/traefik.nomad.j2
+++ b/ansible/roles/traefik/templates/traefik.nomad.j2
@@ -37,6 +37,7 @@ job "traefik" {
         volumes = [
           "local/traefik.yml:/etc/traefik/traefik.yml",
           "local/dynamic:/etc/traefik/dynamic",
+          "local/certs:/etc/traefik/certs",
         ]
       }
 
@@ -72,6 +73,35 @@ EOF
 {{ lookup('template', 'headscale-router.yaml.j2') }}
 EOF
         destination = "local/dynamic/headscale-router.yaml"
+      }
+
+      template {
+        data = <<EOF
+tls:
+  certificates:
+    - certFile: "/etc/traefik/certs/mesh/tls.crt"
+      keyFile: "/etc/traefik/certs/mesh/tls.key"
+  stores:
+    default:
+      defaultCertificate:
+        certFile: "/etc/traefik/certs/mesh/tls.crt"
+        keyFile: "/etc/traefik/certs/mesh/tls.key"
+EOF
+        destination = "local/dynamic/tls.yml"
+      }
+
+      template {
+        data = <<EOF
+{{ key "certs/mesh/tls.crt" }}
+EOF
+        destination = "local/certs/mesh/tls.crt"
+      }
+
+      template {
+        data = <<EOF
+{{ key "certs/mesh/tls.key" }}
+EOF
+        destination = "local/certs/mesh/tls.key"
       }
 
       resources {

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,37 @@
+# Plan to update Traefik configuration
+
+1.  **Remove Traefik tags from internal services**
+    *   `ansible/jobs/filebrowser.nomad.j2`
+    *   `ansible/roles/docker_registry/templates/docker-registry.nomad.j2`
+    *   `ansible/roles/monitoring/templates/beszel-hub.nomad.j2`
+    *   `ansible/roles/monitoring/templates/statsping.nomad.j2`
+    *   Remove `traefik.enable=true` and all related tags from these files so they are not exposed externally.
+
+2.  **Update `pipecatapp` to use internal CA**
+    *   Modify `ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2`
+    *   Keep `traefik.enable=true`, `entrypoints=websecure`, and `tls=true`.
+    *   Remove `tls.certresolver=local`.
+    *   Strictly restrict host routing to `Host(\`pipecatapp.{{ cluster_domain | default('local.mesh') }}\`)` (remove `localhost` and `127.0.0.1`).
+
+3.  **Update `authentik` to use internal CA**
+    *   Modify `ansible/roles/authentik/templates/authentik.nomad.j2`
+    *   Keep `traefik.enable=true`.
+    *   Add `traefik.http.routers.authentik.entrypoints=websecure` and `traefik.http.routers.authentik.tls=true` tags if not present.
+
+4.  **Update `tml-interaction` to use internal CA**
+    *   Modify `ansible/jobs/tml-interaction.nomad.j2`
+    *   Ensure `tls=true` and `entrypoints=websecure` are present. (They already are). Remove any `certresolver` if present.
+
+5.  **Create placeholder templates for `opengravity` and `e2a`**
+    *   Create `ansible/jobs/opengravity.nomad.j2` and `ansible/jobs/e2a.nomad.j2` (already created via bash). Ensure their configurations include `traefik.enable=true`, `tls=true`, `entrypoints=websecure`, and routing based on Host.
+    *   Format them assuming a stateless architecture designed for future IPFS-backed storage deployments.
+
+6.  **Configure Traefik dynamic file provider for internal certificates**
+    *   Modify `ansible/roles/traefik/templates/traefik.nomad.j2` to add a dynamic file provider configuration that loads TLS certificates dynamically.
+    *   We will provide placeholder paths like `certs/mesh/tls.crt` and `certs/mesh/tls.key` within a generated `tls.yml` file.
+
+7.  **Pre-commit checks**
+    *   Run `pre_commit_instructions` tool and complete all required checks.
+
+8.  **Submit changes**
+    *   Commit changes and submit for approval.


### PR DESCRIPTION
Updates the cluster Traefik routing configuration to align with the Headscale mesh network strategy. User/agent-facing services (`pipecatapp`, `authentik`, `tml-interaction`, plus placeholders for `opengravity` and `e2a`) are now exposed securely via HTTPS using dynamically loaded internal CA certificates. Internal services and infrastructure UIs have had their ingress tags removed so they remain inaccessible externally.

---
*PR created automatically by Jules for task [12288888914655607265](https://jules.google.com/task/12288888914655607265) started by @LokiMetaSmith*