### PR TITLE
Implement automated garbage collection for Docker, Nomad, and Python dependency caches

### DIFF
--- a/ansible/roles/docker/handlers/main.yaml
+++ b/ansible/roles/docker/handlers/main.yaml
@@ -5,3 +5,10 @@
     name: docker
     state: restarted
   become: true
+
+- name: Restart Docker Prune Timer
+  ansible.builtin.systemd:
+    name: docker-prune.timer
+    state: restarted
+    daemon_reload: yes
+  become: true

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -105,3 +105,26 @@
     state: started
     enabled: yes
   become: yes
+
+- name: Place the docker-prune systemd service file
+  ansible.builtin.template:
+    src: docker-prune.service.j2
+    dest: /etc/systemd/system/docker-prune.service
+    mode: '0644'
+  become: true
+
+- name: Place the docker-prune systemd timer file
+  ansible.builtin.template:
+    src: docker-prune.timer.j2
+    dest: /etc/systemd/system/docker-prune.timer
+    mode: '0644'
+  become: true
+  notify: Restart Docker Prune Timer
+
+- name: Ensure docker-prune timer is started and enabled
+  ansible.builtin.systemd:
+    name: docker-prune.timer
+    state: started
+    enabled: yes
+    daemon_reload: yes
+  become: yes

--- a/ansible/roles/docker/templates/docker-prune.service.j2
+++ b/ansible/roles/docker/templates/docker-prune.service.j2
@@ -1,0 +1,7 @@
+[Unit]
+Description=Prune Docker/Containerd unused images and containers
+Documentation=https://docs.docker.com/engine/reference/commandline/system_prune/
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker system prune -af --filter "until=168h"

--- a/ansible/roles/docker/templates/docker-prune.timer.j2
+++ b/ansible/roles/docker/templates/docker-prune.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run Docker/Containerd Prune Weekly
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -29,6 +29,10 @@ plugin "docker" {
       enabled = true
     }
     allow_caps = ["NET_RAW", "NET_ADMIN", "SETUID", "SETGID", "CHOWN", "NET_BIND_SERVICE"]
+    gc {
+      image = true
+      container = true
+    }
   }
 }
 

--- a/ansible/roles/nomad/templates/nomad.hcl.server.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.server.j2
@@ -98,6 +98,10 @@ plugin "docker" {
       enabled = true
     }
     allow_caps = ["NET_RAW", "NET_ADMIN", "SETUID", "SETGID", "CHOWN", "NET_BIND_SERVICE"]
+    gc {
+      image = true
+      container = true
+    }
   }
 }
 

--- a/ansible/roles/nomad/templates/server.hcl.j2
+++ b/ansible/roles/nomad/templates/server.hcl.j2
@@ -36,6 +36,10 @@ plugin "docker" {
       enabled = true
     }
     allow_caps = ["NET_RAW", "NET_ADMIN", "SETUID", "SETGID", "CHOWN", "NET_BIND_SERVICE"]
+    gc {
+      image = true
+      container = true
+    }
   }
 }
 

--- a/ansible/roles/python_deps/tasks/main.yaml
+++ b/ansible/roles/python_deps/tasks/main.yaml
@@ -101,6 +101,14 @@
   tags:
     - deploy_app
 
+- name: Clean up uv cache
+  ansible.builtin.command:
+    cmd: "/opt/pipecatapp/venv/bin/uv cache clean"
+  become: yes
+  become_user: "{{ target_user }}"
+  tags:
+    - deploy_app
+
 - name: Clean up pip build directory
   ansible.builtin.file:
     path: /var/tmp/ansible_pip_build


### PR DESCRIPTION
Adds garbage collection across the stack (Docker/containerd, Nomad task driver, and Python package cache via `uv cache clean`) to resolve disk bloat issues on nodes.

---
*PR created automatically by Jules for task [7274076638024303251](https://jules.google.com/task/7274076638024303251) started by @LokiMetaSmith*