### PR TITLE
Refactor to node_tier conditionals and Nomad Federation

### DIFF
--- a/ansible/jobs/evolve-prompt.nomad.j2
+++ b/ansible/jobs/evolve-prompt.nomad.j2
@@ -1,5 +1,5 @@
 job "evolve-prompt" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   namespace   = "default"
   type        = "batch"
 

--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -25,7 +25,7 @@ variable "rpc_pool_job_name" {
 {% set best_model_sanitized = best_model.filename | regex_replace('[^a-zA-Z0-9-]', '-') %}
 
 job "{{ job_name }}" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
 
   group "{{ job_name }}-group" {
     count = 1

--- a/ansible/jobs/filebrowser.nomad.j2
+++ b/ansible/jobs/filebrowser.nomad.j2
@@ -1,5 +1,5 @@
 job "filebrowser" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "filebrowser" {

--- a/ansible/jobs/health-check.nomad.j2
+++ b/ansible/jobs/health-check.nomad.j2
@@ -1,5 +1,5 @@
 job "health-check" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "batch"
 
   task "health-checker" {

--- a/ansible/jobs/llamacpp-batch.nomad.j2
+++ b/ansible/jobs/llamacpp-batch.nomad.j2
@@ -1,5 +1,5 @@
 job "llamacpp-batch" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "batch"
   namespace   = "{{ nomad_namespace | default('default') }}"
   priority    = 80

--- a/ansible/jobs/llamacpp-rpc.nomad.j2
+++ b/ansible/jobs/llamacpp-rpc.nomad.j2
@@ -25,7 +25,7 @@
 # === End Monitoring ===
 
 job "{{ job_name | default('llamacpp-rpc-pool') }}" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   namespace   = "{{ nomad_namespace | default('default') }}"
   
   meta {

--- a/ansible/jobs/router.nomad.j2
+++ b/ansible/jobs/router.nomad.j2
@@ -1,6 +1,6 @@
 # This Nomad job file runs the "router" service.
 job "router" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
   namespace   = "{{ nomad_namespace | default('default') }}"
   priority    = 50

--- a/ansible/jobs/test-runner.nomad.j2
+++ b/ansible/jobs/test-runner.nomad.j2
@@ -1,5 +1,5 @@
 job "test-runner" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "batch"
 
   group "testing" {

--- a/ansible/jobs/vllm.nomad.j2
+++ b/ansible/jobs/vllm.nomad.j2
@@ -1,5 +1,5 @@
 job "vllm-server-{{ model.name }}" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   namespace   = "{{ nomad_namespace | default('default') }}"
 
   meta {

--- a/ansible/roles/authentik/templates/authentik.nomad.j2
+++ b/ansible/roles/authentik/templates/authentik.nomad.j2
@@ -1,5 +1,5 @@
 job "authentik" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
 update {

--- a/ansible/roles/benchmark_models/templates/model-benchmark.nomad.j2
+++ b/ansible/roles/benchmark_models/templates/model-benchmark.nomad.j2
@@ -2,7 +2,7 @@
 # It is designed to be a short-lived batch job.
 
 job "model-benchmark-{{ model_filename | regex_replace('[^a-zA-Z0-9-]', '-') }}" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "batch"
   namespace   = "{{ nomad_namespace | default('default') }}"
 

--- a/ansible/roles/docker_registry/templates/docker-registry.nomad.j2
+++ b/ansible/roles/docker_registry/templates/docker-registry.nomad.j2
@@ -1,5 +1,5 @@
 job "docker-registry" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "registry" {

--- a/ansible/roles/exo/templates/exo.nomad.j2
+++ b/ansible/roles/exo/templates/exo.nomad.j2
@@ -1,5 +1,5 @@
 job "exo" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "exo" {

--- a/ansible/roles/forgejo/templates/forgejo.nomad.j2
+++ b/ansible/roles/forgejo/templates/forgejo.nomad.j2
@@ -1,5 +1,5 @@
 job "forgejo" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "forgejo" {

--- a/ansible/roles/gemini_cli/templates/gemini.nomad.j2
+++ b/ansible/roles/gemini_cli/templates/gemini.nomad.j2
@@ -1,5 +1,5 @@
 job "gemini" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "gemini" {

--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -1,5 +1,5 @@
 job "home-assistant" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "home-assistant-group" {

--- a/ansible/roles/magic_mirror/templates/magic_mirror.nomad.j2
+++ b/ansible/roles/magic_mirror/templates/magic_mirror.nomad.j2
@@ -1,5 +1,5 @@
 job "magic_mirror" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "server" {

--- a/ansible/roles/mcp_server/templates/mcp_server.nomad.j2
+++ b/ansible/roles/mcp_server/templates/mcp_server.nomad.j2
@@ -1,5 +1,5 @@
 job "mcp-server" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type = "service"
 
   group "mcp-server" {

--- a/ansible/roles/memory_graph/templates/memory-graph.nomad.j2
+++ b/ansible/roles/memory_graph/templates/memory-graph.nomad.j2
@@ -1,5 +1,5 @@
 job "memory-graph" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type = "service"
 
   group "memory" {

--- a/ansible/roles/memory_service/templates/memory_service.nomad.j2
+++ b/ansible/roles/memory_service/templates/memory_service.nomad.j2
@@ -1,5 +1,5 @@
 job "memory-service" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "memory-api" {

--- a/ansible/roles/minikeyvalue/templates/mkv.nomad.j2
+++ b/ansible/roles/minikeyvalue/templates/mkv.nomad.j2
@@ -1,5 +1,5 @@
 job "minikeyvalue" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "master" {

--- a/ansible/roles/miniray/templates/miniray.nomad.j2
+++ b/ansible/roles/miniray/templates/miniray.nomad.j2
@@ -1,5 +1,5 @@
 job "miniray" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "redis" {

--- a/ansible/roles/moe_gateway/templates/moe-gateway.nomad.j2
+++ b/ansible/roles/moe_gateway/templates/moe-gateway.nomad.j2
@@ -1,5 +1,5 @@
 job "moe-gateway" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "gateway" {

--- a/ansible/roles/monitoring/templates/beszel-agent.nomad.j2
+++ b/ansible/roles/monitoring/templates/beszel-agent.nomad.j2
@@ -1,5 +1,5 @@
 job "beszel-agent" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "system"
 
   group "beszel" {

--- a/ansible/roles/monitoring/templates/beszel-hub.nomad.j2
+++ b/ansible/roles/monitoring/templates/beszel-hub.nomad.j2
@@ -1,5 +1,5 @@
 job "beszel-hub" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "beszel-hub" {

--- a/ansible/roles/monitoring/templates/grafana.nomad.j2
+++ b/ansible/roles/monitoring/templates/grafana.nomad.j2
@@ -1,5 +1,5 @@
 job "grafana" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   # Update stanza for reliability

--- a/ansible/roles/monitoring/templates/memory-audit.nomad.j2
+++ b/ansible/roles/monitoring/templates/memory-audit.nomad.j2
@@ -1,5 +1,5 @@
 job "memory-audit" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "batch"
 
   periodic {

--- a/ansible/roles/monitoring/templates/mqtt-exporter.nomad.j2
+++ b/ansible/roles/monitoring/templates/mqtt-exporter.nomad.j2
@@ -1,5 +1,5 @@
 job "mqtt-exporter" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   # Update stanza for reliability

--- a/ansible/roles/monitoring/templates/node-exporter.nomad.j2
+++ b/ansible/roles/monitoring/templates/node-exporter.nomad.j2
@@ -1,5 +1,5 @@
 job "node-exporter" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "system"
 
   group "node-exporter" {

--- a/ansible/roles/monitoring/templates/prometheus.nomad.j2
+++ b/ansible/roles/monitoring/templates/prometheus.nomad.j2
@@ -1,5 +1,5 @@
 job "prometheus" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   # Update stanza for reliability

--- a/ansible/roles/monitoring/templates/statsping.nomad.j2
+++ b/ansible/roles/monitoring/templates/statsping.nomad.j2
@@ -1,5 +1,5 @@
 job "statsping" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "statsping" {

--- a/ansible/roles/mqtt/templates/mqtt.nomad.j2
+++ b/ansible/roles/mqtt/templates/mqtt.nomad.j2
@@ -1,5 +1,5 @@
 job "mqtt" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "mqtt-group" {

--- a/ansible/roles/nanochat/templates/nanochat.nomad.j2
+++ b/ansible/roles/nanochat/templates/nanochat.nomad.j2
@@ -1,5 +1,5 @@
 job "nanochat" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "nanochat-server" {

--- a/ansible/roles/nats/templates/nats.nomad.j2
+++ b/ansible/roles/nats/templates/nats.nomad.j2
@@ -1,5 +1,5 @@
 job "nats" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "nats" {

--- a/ansible/roles/openclaw/templates/openclaw.nomad.j2
+++ b/ansible/roles/openclaw/templates/openclaw.nomad.j2
@@ -1,5 +1,5 @@
 job "openclaw" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "gateway" {

--- a/ansible/roles/opencode/templates/opencode.nomad.j2
+++ b/ansible/roles/opencode/templates/opencode.nomad.j2
@@ -1,5 +1,5 @@
 job "opencode" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "opencode" {

--- a/ansible/roles/opengist/templates/opengist.nomad.j2
+++ b/ansible/roles/opengist/templates/opengist.nomad.j2
@@ -1,5 +1,5 @@
 job "opengist" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "opengist" {

--- a/ansible/roles/openworkers/templates/openworkers-bootstrap.nomad.j2
+++ b/ansible/roles/openworkers/templates/openworkers-bootstrap.nomad.j2
@@ -1,5 +1,5 @@
 job "openworkers-bootstrap" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "batch"
 
   group "bootstrap" {

--- a/ansible/roles/openworkers/templates/openworkers-infra.nomad.j2
+++ b/ansible/roles/openworkers/templates/openworkers-infra.nomad.j2
@@ -1,5 +1,5 @@
 job "openworkers-infra" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   # Postgate (HTTP proxy for Postgres)

--- a/ansible/roles/openworkers/templates/openworkers-runners.nomad.j2
+++ b/ansible/roles/openworkers/templates/openworkers-runners.nomad.j2
@@ -1,5 +1,5 @@
 job "openworkers-runners" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "runner" {

--- a/ansible/roles/paperless/templates/paperless.nomad.j2
+++ b/ansible/roles/paperless/templates/paperless.nomad.j2
@@ -1,5 +1,5 @@
 job "paperless" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "paperless-stack" {

--- a/ansible/roles/pds/templates/pds.nomad.j2
+++ b/ansible/roles/pds/templates/pds.nomad.j2
@@ -1,5 +1,5 @@
 job "pds" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "pds" {

--- a/ansible/roles/pipecatapp/templates/architect.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/architect.nomad.j2
@@ -1,5 +1,5 @@
 job "architect" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   meta {

--- a/ansible/roles/pipecatapp/templates/archivist.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/archivist.nomad.j2
@@ -1,5 +1,5 @@
 job "archivist" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "archivist-group" {

--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -1,5 +1,5 @@
 job "{{ job_name | default('pipecat-app') }}" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   meta {

--- a/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
@@ -1,5 +1,5 @@
 job "seed-agent" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   meta {

--- a/ansible/roles/polyphony/templates/polyphony.nomad.j2
+++ b/ansible/roles/polyphony/templates/polyphony.nomad.j2
@@ -1,5 +1,5 @@
 job "polyphony" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "polyphony" {

--- a/ansible/roles/postgres/templates/postgres.nomad.j2
+++ b/ansible/roles/postgres/templates/postgres.nomad.j2
@@ -1,5 +1,5 @@
 job "postgres" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "postgres" {

--- a/ansible/roles/semantic_router/templates/semantic-router.nomad.j2
+++ b/ansible/roles/semantic_router/templates/semantic-router.nomad.j2
@@ -1,5 +1,5 @@
 job "semantic-router" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "router" {

--- a/ansible/roles/sunshine/templates/sunshine.nomad.j2
+++ b/ansible/roles/sunshine/templates/sunshine.nomad.j2
@@ -1,5 +1,5 @@
 job "sunshine" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "sunshine" {

--- a/ansible/roles/tool_server/templates/tool_server.nomad.j2
+++ b/ansible/roles/tool_server/templates/tool_server.nomad.j2
@@ -1,5 +1,5 @@
 job "tool-server" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "tool-server-group" {

--- a/ansible/roles/traefik/templates/traefik.nomad.j2
+++ b/ansible/roles/traefik/templates/traefik.nomad.j2
@@ -1,5 +1,5 @@
 job "traefik" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "system"
 
   group "traefik" {
@@ -60,6 +60,7 @@ providers:
     exposedByDefault: false
     endpoint:
       address: "127.0.0.1:8500"
+      datacenter: "{{ (nomad_datacenters | default(['dc1']))[0] }}"
   file:
     directory: "/etc/traefik/dynamic"
     watch: true

--- a/ansible/roles/vision/templates/vision.nomad.j2
+++ b/ansible/roles/vision/templates/vision.nomad.j2
@@ -1,5 +1,5 @@
 job "vision" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "frigate" {

--- a/ansible/roles/vllm/templates/vllm-expert.nomad.j2
+++ b/ansible/roles/vllm/templates/vllm-expert.nomad.j2
@@ -1,5 +1,5 @@
 job "{{ job_name }}" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "vllm" {

--- a/ansible/roles/world_model_service/templates/world_model.nomad.j2
+++ b/ansible/roles/world_model_service/templates/world_model.nomad.j2
@@ -1,5 +1,5 @@
 job "world-model-service" {
-  datacenters = ["dc1"]
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
   type        = "service"
 
   group "world-model" {

--- a/playbooks/services/model_services.yaml
+++ b/playbooks/services/model_services.yaml
@@ -1,5 +1,5 @@
 - name: Deploy Model Services
-  hosts: hw_tier_high,hw_tier_mid
+  hosts: all
   vars_files:
     - "../../group_vars/models.yaml"
     - "../../group_vars/external_experts.yaml"
@@ -14,6 +14,7 @@
       include_role:
         name: config_manager
       run_once: true
+      when: node_tier in ['mid', 'core']
       tags:
         - config_manager
 
@@ -28,7 +29,7 @@
         - exo
       loop_control:
         loop_var: role_name
-      when: not external_model_server
+      when: not external_model_server and node_tier in ['mid', 'core']
       tags:
         - download_models
         - llama_cpp


### PR DESCRIPTION
Refactored Ansible playbooks to remove strict `&hw_tier_` host intersections to fix provisioning skipped executions. Added dynamic `node_tier` evaluation blocks, implemented multi-region datacenter parameters via JSON list filtering in Nomad job templates, and prioritized local service discovery in Traefik. Note: IPFS is designated as the future stateless architecture backend.

---
*PR created automatically by Jules for task [8016086646644980962](https://jules.google.com/task/8016086646644980962) started by @LokiMetaSmith*