### PR TITLE
fix: resolve 401 Unauthorized error during model download

### DIFF
--- a/group_vars/models.yaml
+++ b/group_vars/models.yaml
@@ -83,7 +83,7 @@ expert_models:
 
 vllm_expert_models:
   - name: "vllm-main"
-    repo_id: "meta-llama/Llama-2-7b-hf"
+    repo_id: "NousResearch/Llama-2-7b-hf"
     memory_mb: 8192
 
 # A list of voices for the PiperTTSService to use, in order of preference.


### PR DESCRIPTION
Updates `group_vars/models.yaml` to use the non-gated version `NousResearch/Llama-2-7b-hf` for the `vllm-main` model to resolve the 401 Client Error during bootstrap.

---
*PR created automatically by Jules for task [849308398130132420](https://jules.google.com/task/849308398130132420) started by @LokiMetaSmith*