### PR TITLE
fix(nomad): add traceway and authentik directories to nomad volumes loop

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -186,6 +186,11 @@
     - world_model_storage
     - postgres_data
     - memory-data
+    - traceway
+    - authentik/postgres
+    - authentik/media
+    - authentik/templates
+    - authentik/certs
   become: yes
 
 - name: Include Nomad TLS tasks


### PR DESCRIPTION
This fixes an issue where the Nomad agent fails to start during provisioning because it cannot validate the host volume path `/opt/nomad/volumes/traceway` (as well as `/opt/nomad/volumes/authentik/*`), returning `stat /opt/nomad/volumes/traceway: no such file or directory`. 

I've added these missing directories to the task loop in `ansible/roles/nomad/tasks/main.yaml` that creates the required Nomad subdirectories.

---
*PR created automatically by Jules for task [4341491511679027561](https://jules.google.com/task/4341491511679027561) started by @LokiMetaSmith*