### PR TITLE
Fix bootstrap status stack profile detection

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -202,7 +202,7 @@ profile_system() {
     fi
 
     # Network Discovery & Role Fallback
-    if [ "$ROLE" = "worker" ] && [ -z "$CONTROLLER_IP" ]; then
+    if [ "$ROLE" = "worker" ] && [ -z "$CONTROLLER_IP" ] && [ "$DO_STATUS" != true ]; then
         if find_controller; then
             # Controller found, CONTROLLER_IP is set. Add it to PROCESSED_ARGS.
             PROCESSED_ARGS+=("--controller-ip" "$CONTROLLER_IP")
@@ -371,7 +371,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR" || exit 1
 
 # Run system profiling before we proceed, unless just asking for status
-if [ "$DO_STATUS" != true ]; then
+if true; then
     profile_system
 fi
 
@@ -649,7 +649,7 @@ perform_git_clean() {
 if [ "$DO_STATUS" = true ]; then
     echo -e "${BOLD}=== Cluster Status ===${NC}"
     ensure_python_environment
-    python3 scripts/provisioning.py --only-status
+    python3 scripts/provisioning.py --only-status "${PROCESSED_ARGS[@]}"
     exit $?
 fi
 


### PR DESCRIPTION
Ensures the cluster's stack profile and roles are correctly detected and printed when querying the environment via `--status` flag without incurring a long network discovery timeout.

---
*PR created automatically by Jules for task [17985986708587514601](https://jules.google.com/task/17985986708587514601) started by @LokiMetaSmith*