### PR TITLE
Add TODO tracking for Orthrus integration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -328,3 +328,7 @@ This section tracks actionable ideas derived from the `docs/analysis/POLLEN_COMP
 ## Test failures
 
 - [x] Investigate and fix `test_load_playbooks_from_manifest` failure in `tests/unit/test_provisioning.py` caused by `yaml` mocking issues.
+
+## Future Model Integrations
+
+- [ ] **Orthrus Integration:** Track upstream support in `llama.cpp` or native `vLLM` for "Orthrus" (dual-view diffusion decoding model, e.g., `chiennv/Orthrus-Qwen3-8B`). Once supported by our core inference engines, integrate it into `group_vars/models.yaml` to take advantage of its memory-efficient parallel token generation for complex reasoning tasks.


### PR DESCRIPTION
As discussed, instead of building a whole new inference engine using `transformers` just for this new experimental tech demo model, we are tracking the intent to integrate it into `group_vars/models.yaml` once upstream support gets added to `llama.cpp` or `vLLM`. I've added this to the `TODO.md`.

---
*PR created automatically by Jules for task [17216817119581934006](https://jules.google.com/task/17216817119581934006) started by @LokiMetaSmith*