### PR TITLE
Fix: add mTLS variables to nomad job execution in ansible handlers/tasks

### DIFF
--- a/ansible/roles/benchmark_models/tasks/benchmark_loop.yaml
+++ b/ansible/roles/benchmark_models/tasks/benchmark_loop.yaml
@@ -9,12 +9,24 @@
 - name: "Run benchmark job for model {{ model.name }}"
   ansible.builtin.command:
     cmd: "nomad job run -detach /tmp/model-benchmark-{{ model.filename }}.nomad"
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   register: benchmark_models_job_run_result
   changed_when: "'job registration' in benchmark_models_job_run_result.stdout"
 
 - name: "Wait for benchmark job to complete for model {{ model.name }}"
   ansible.builtin.command:
     cmd: "nomad job status -json model-benchmark-{{ model.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}"
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   register: benchmark_models_job_status_result
   until: "((benchmark_models_job_status_result.stdout | from_json).Status == 'dead') and ((benchmark_models_job_status_result.stdout | from_json).JobSummary.Summary.Complete == 1)"
   retries: 60 # 5 minutes (60 * 5s)
@@ -24,12 +36,24 @@
 - name: "Get allocation ID for model {{ model.name }}"
   ansible.builtin.command:
     cmd: "nomad job allocs -json model-benchmark-{{ model.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}"
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   register: benchmark_models_job_allocs_result
   changed_when: false
 
 - name: "Capture benchmark logs for model {{ model.name }}"
   ansible.builtin.command:
     cmd: "nomad alloc logs {{ (benchmark_models_job_allocs_result.stdout | from_json)[0].ID }} benchmark-task"
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   register: benchmark_models_benchmark_logs
   changed_when: false
 
@@ -48,6 +72,12 @@
     - name: "Purge benchmark job for model {{ model.name }}"
       ansible.builtin.command:
         cmd: "nomad job stop -purge model-benchmark-{{ model.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}"
+      environment:
+        NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+        NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+        NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+        NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+        NOMAD_TLS_SKIP_VERIFY: "1"
       changed_when: false
 
     - name: "Remove temporary job file for model {{ model.name }}"

--- a/ansible/roles/exo/tasks/main.yaml
+++ b/ansible/roles/exo/tasks/main.yaml
@@ -88,6 +88,10 @@
     cmd: "/usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/exo.nomad"
   environment:
     NOMAD_ADDR: "https://{{ advertise_ip }}:{{ nomad_http_port }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   register: exo_job_run
   changed_when: "'Eval ID' in exo_job_run.stdout"
   when: exo_enable

--- a/ansible/roles/magic_mirror/handlers/main.yaml
+++ b/ansible/roles/magic_mirror/handlers/main.yaml
@@ -1,4 +1,10 @@
 - name: Run Magic Mirror Job
   ansible.builtin.command:
     cmd: nomad job run -detach /opt/nomad/jobs/magic_mirror.nomad
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   listen: "Run Magic Mirror Job"

--- a/ansible/roles/mcp_server/handlers/main.yaml
+++ b/ansible/roles/mcp_server/handlers/main.yaml
@@ -1,3 +1,9 @@
 - name: Run mcp server job
   ansible.builtin.command: nomad job run -detach {{ nomad_jobs_dir }}/mcp_server.nomad
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   changed_when: true

--- a/ansible/roles/polyphony/handlers/main.yaml
+++ b/ansible/roles/polyphony/handlers/main.yaml
@@ -2,4 +2,8 @@
   ansible.builtin.command: nomad job run -detach /opt/nomad/jobs/polyphony.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   changed_when: true

--- a/ansible/roles/sunshine/handlers/main.yaml
+++ b/ansible/roles/sunshine/handlers/main.yaml
@@ -1,4 +1,10 @@
 - name: Run Sunshine Job
   ansible.builtin.command:
     cmd: nomad job run -detach /opt/nomad/jobs/sunshine.nomad
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
   listen: "Run Sunshine Job"


### PR DESCRIPTION
This pull request fixes an issue where Nomad CLI commands executed via Ansible tasks and handlers were failing with TLS certificate verification errors (`x509: certificate signed by unknown authority`).

The missing mTLS environment variables have been added to the following roles:
- polyphony
- magic_mirror
- sunshine
- benchmark_models (for all `job run`, `job status`, `job allocs`, `alloc logs`, and `job stop` tasks)
- mcp_server
- exo

---
*PR created automatically by Jules for task [12727967407471617984](https://jules.google.com/task/12727967407471617984) started by @LokiMetaSmith*