### PR TITLE
Fix Nomad RFC 1123 validation and Python VisionImageRawFrame import

### DIFF
--- a/group_vars/models.yaml
+++ b/group_vars/models.yaml
@@ -75,7 +75,7 @@ expert_models:
       url: "https://huggingface.co/bartowski/gpt-oss-20B-GGUF/resolve/main/gpt-oss-20B-Q4_K_M.gguf"
       filename: "gpt-oss-20B-Q4_K_M.gguf"
       memory_mb: 16384
-  qwen3.5:
+  qwen3-5:
     - name: "Qwen3.5-35B-A3B-MXFP4_MOE"
       url: "https://huggingface.co/byteshape/Qwen3.5-35B-A3B-MXFP4_MOE-GGUF/resolve/main/Qwen3.5-35B-A3B-MXFP4_MOE-Q4_K_M.gguf"
       filename: "Qwen3.5-35B-A3B-MXFP4_MOE-Q4_K_M.gguf"

--- a/pipecatapp/services/gemma_e2b_service.py
+++ b/pipecatapp/services/gemma_e2b_service.py
@@ -18,7 +18,7 @@ from pipecat.frames.frames import (
     Frame,
     CancelFrame,
     UserImageRawFrame,
-    VisionImageRawFrame,
+    UserImageRawFrame as VisionImageRawFrame,
     StartFrame,
     EndFrame,
     UserStoppedSpeakingFrame


### PR DESCRIPTION
This pull request resolves a cluster uprising failure related to core AI services:
1. **Nomad RFC 1123 Error**: It sanitizes the `qwen3.5` key to `qwen3-5` in `group_vars/models.yaml` so the generated service name `expert-api-qwen3-5` passes validation.
2. **Python Import Error**: It resolves `ImportError: cannot import name 'VisionImageRawFrame'` in `gemma_e2b_service.py` by aliasing `UserImageRawFrame`.

---
*PR created automatically by Jules for task [18280250422176090869](https://jules.google.com/task/18280250422176090869) started by @LokiMetaSmith*