### PR TITLE
Fix expert model deployment error on low memory nodes

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -18,10 +18,14 @@ variable "rpc_pool_job_name" {
 {% set memory_buffer_mb = 2048 %}
 {% set available_memory_mb = (ansible_memtotal_mb | int) - memory_buffer_mb %}
 {% set model_list = expert_models[current_expert] %}
-{% set models_with_memory = model_list | selectattr('memory_mb', 'defined') %}
+{% set models_with_memory = model_list | selectattr('memory_mb', 'defined') | list %}
 {% set suitable_models_unsorted = models_with_memory | selectattr('memory_mb', 'le', available_memory_mb) %}
 {% set suitable_models = suitable_models_unsorted | sort(attribute='memory_mb', reverse=true) | list %}
+{% if suitable_models | length > 0 %}
 {% set best_model = suitable_models[0] %}
+{% else %}
+{% set best_model = (models_with_memory | sort(attribute='memory_mb') | list)[0] %}
+{% endif %}
 {% set best_model_sanitized = best_model.filename | regex_replace('[^a-zA-Z0-9-]', '-') %}
 
 job "{{ job_name }}" {

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -273,7 +273,7 @@
         - name: Create Expert Orchestrator job files
           include_tasks:
             file: "{{ playbook_dir }}/../../ansible/tasks/create_expert_job.yaml"
-          loop: "{{ experts }}"
+          loop: "{{ verified_experts if (verified_experts is defined and verified_experts | length > 0) else experts }}"
           loop_control:
             loop_var: current_expert
           when: benchmark_results is defined
@@ -285,7 +285,7 @@
             file: "{{ playbook_dir }}/../../ansible/tasks/deploy_expert_wrapper.yaml"
           vars:
             registry_is_reachable: "{{ global_registry_check.state | default('stopped') == 'started' }}"
-          loop: "{{ experts }}"
+          loop: "{{ verified_experts if (verified_experts is defined and verified_experts | length > 0) else experts }}"
           loop_control:
             loop_var: expert_name
           when: benchmark_results is defined
@@ -304,7 +304,7 @@
             expert_health.json | map(attribute='Checks') | flatten | selectattr('Status', 'equalto', 'passing') | list | length > 0
           retries: 60
           delay: 10
-          loop: "{{ experts }}"
+          loop: "{{ verified_experts if (verified_experts is defined and verified_experts | length > 0) else experts }}"
           changed_when: false
           when: benchmark_results is defined
           tags:


### PR DESCRIPTION
Fixes a bug where `ai_experts.yaml` could fail when deploying on nodes with less memory than the models requested, resulting in a Jinja rendering error in `expert.nomad.j2` ("list object has no element 0"). 
Also fixes an issue where the playbook would try to start an orchestrator service for an unverified expert (e.g. if the benchmark failed or the model wasn't available), causing it to wait on a Consul health check for a service that never came up.

---
*PR created automatically by Jules for task [10808705918635900152](https://jules.google.com/task/10808705918635900152) started by @LokiMetaSmith*