### PR TITLE
Fix Consul API health checks to use HTTPS and mTLS

### DIFF
--- a/ansible/tasks/deploy_model_gpu_provider.yaml
+++ b/ansible/tasks/deploy_model_gpu_provider.yaml
@@ -60,9 +60,12 @@
 
 - name: "Wait for GPU Provider for {{ model.name }} to become healthy in Consul"
   ansible.builtin.uri:
-    url: "http://127.0.0.1:{{ consul_http_port }}/v1/health/service/{{ rpc_service_name }}?passing"
+    url: "https://127.0.0.1:{{ consul_https_port | default(8501) }}/v1/health/service/{{ rpc_service_name }}?passing"
     headers:
       X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
     return_content: yes
   register: consul_health
   until: "consul_health.json | length >= expected_worker_count | int"

--- a/ansible/tasks/deploy_model_gpu_provider.yaml
+++ b/ansible/tasks/deploy_model_gpu_provider.yaml
@@ -60,7 +60,7 @@
 
 - name: "Wait for GPU Provider for {{ model.name }} to become healthy in Consul"
   ansible.builtin.uri:
-    url: "https://127.0.0.1:{{ consul_https_port | default(8501) }}/v1/health/service/{{ rpc_service_name }}?passing"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/health/service/{{ rpc_service_name }}?passing"
     headers:
       X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -294,9 +294,12 @@
 
         - name: Wait for the expert services to be healthy in Consul
           ansible.builtin.uri:
-            url: "http://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_http_port | default(8500) }}/v1/health/service/expert-api-{{ item }}"
+            url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/health/service/expert-api-{{ item }}"
             headers:
               X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
+            client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+            client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+            validate_certs: false
             return_content: yes
           register: expert_health
           until: >


### PR DESCRIPTION
Updates the `ansible.builtin.uri` tasks that poll the Consul API in the AI Experts and GPU Provider deployment playbooks to use the encrypted `https://` endpoint on `{{ consul_https_port | default(8501) }}`. It additionally provides the required client certificate and key to authenticate over mTLS, resolving timeout issues where the health check was attempting to communicate over plaintext HTTP on a secured cluster.

---
*PR created automatically by Jules for task [12623081745282994591](https://jules.google.com/task/12623081745282994591) started by @LokiMetaSmith*