### PR TITLE
fix(ansible): prevent playbook crashes when uri module responses lack json attribute

### DIFF
--- a/ansible/roles/bootstrap_agent/tasks/main.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/main.yaml
@@ -40,7 +40,7 @@
         client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
         client_key: "{{ nomad_tls_dir }}/cli.key.pem"
       register: nomad_peers
-      until: nomad_peers.json | length >= 1
+      until: nomad_peers.json is defined and nomad_peers.json | length >= 1
       retries: 20
       delay: 6
       changed_when: false

--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -235,7 +235,7 @@
         return_content: yes
         status_code: 200
       register: consul_check
-      until: consul_check.json | length > 0
+      until: consul_check.json is defined and consul_check.json | length > 0
       retries: 30
       delay: 2
   rescue:

--- a/ansible/tasks/deploy_model_gpu_provider.yaml
+++ b/ansible/tasks/deploy_model_gpu_provider.yaml
@@ -68,6 +68,6 @@
     validate_certs: false
     return_content: yes
   register: consul_health
-  until: "consul_health.json | length >= expected_worker_count | int"
+  until: "consul_health.json is defined and consul_health.json | length >= expected_worker_count | int"
   retries: 30
   delay: 10

--- a/tests/playbooks/verify_cluster_network.yaml
+++ b/tests/playbooks/verify_cluster_network.yaml
@@ -80,7 +80,7 @@
       ansible.builtin.assert:
         that:
           - traefik_consul_health.status == 200
-          - traefik_consul_health.json | length > 0
+          - traefik_consul_health.json is defined and traefik_consul_health.json | length > 0
         fail_msg: "Traefik service is not passing health checks in Consul."
         success_msg: "Traefik service is healthy in Consul."
       when: inventory_hostname in groups['controller_nodes']


### PR DESCRIPTION
Fixes an Ansible playbook failure where `until` loops relying on `.json` contents from `uri` module tasks would immediately crash instead of retrying when the service was unreachable. This is resolved by leveraging Jinja2 short-circuiting to check if `.json is defined` before checking its length.

---
*PR created automatically by Jules for task [588411802794707548](https://jules.google.com/task/588411802794707548) started by @LokiMetaSmith*