### PR TITLE
fix(consul): fix connection refused on https port

### DIFF
--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -349,6 +349,7 @@
   become: yes
   loop:
     - "{{ consul_http_port }}"
+    - "{{ consul_https_port }}"
     - "{{ consul_rpc_port }}"
   changed_when: false
   ignore_errors: yes

--- a/ansible/roles/consul/templates/consul.hcl.j2
+++ b/ansible/roles/consul/templates/consul.hcl.j2
@@ -29,6 +29,10 @@ telemetry {
   disable_hostname = true
 }
 
+addresses {
+  https = "0.0.0.0"
+}
+
 ports {
   dns = {{ consul_dns_port }}
   http = {{ consul_http_port }}


### PR DESCRIPTION
This PR resolves the `Connection refused` error encountered when querying the Consul API on the HTTPS port (`8501`) during deployment wait steps. 

It implements two missing configuration updates:
1. Adds `consul_https_port` to the allowed TCP ports handled by UFW rules.
2. Updates `consul.hcl.j2` by adding an `addresses` block that binds `https` to `0.0.0.0`, ensuring Consul's HTTPS listener is properly exposed on all interfaces, including the cluster IP (`100.64.0.1`).

---
*PR created automatically by Jules for task [6109090412435695353](https://jules.google.com/task/6109090412435695353) started by @LokiMetaSmith*