### PR TITLE
Fix deployment fallback for unverified ai experts

### DIFF
--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -80,7 +80,7 @@
 
         - name: Set deployment candidates based on verification
           ansible.builtin.set_fact:
-            deployment_candidates: "{{ (unique_models | selectattr('filename', 'in', successful_models) | list) if (successful_models is defined and successful_models | length > 0) else unique_models }}"
+            deployment_candidates: "{{ (unique_models | selectattr('filename', 'in', successful_models) | list) if (successful_models is defined and successful_models | length > 0) else [] }}"
           tags:
             - benchmark
             - deploy-gpu-provider


### PR DESCRIPTION
Update `playbooks/services/ai_experts.yaml` so `deployment_candidates` defaults to an empty list `[]` instead of `unique_models` when `successful_models` is undefined or empty. This will fix the issue where the playbook attempts to deploy unverified models, which then timeout waiting to become healthy.

---
*PR created automatically by Jules for task [8130130943773225365](https://jules.google.com/task/8130130943773225365) started by @LokiMetaSmith*