### PR TITLE
Fix mismatched RPC job/service name truncation logic

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -26,7 +26,7 @@ variable "rpc_pool_job_name" {
 {% else %}
 {% set best_model = (models_with_memory | sort(attribute='memory_mb') | list)[0] %}
 {% endif %}
-{% set best_model_sanitized = best_model.filename | regex_replace('[^a-zA-Z0-9-]', '-') %}
+{% set best_model_sanitized = ((best_model.filename | regex_replace('[^a-zA-Z0-9-]', '-'))[:40]) | regex_replace('-$', '') %}
 
 job "{{ job_name }}" {
   datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -180,7 +180,7 @@
 
 - name: Stop and purge any existing llamacpp-rpc jobs if llama.cpp was rebuilt
   ansible.builtin.command:
-    cmd: /usr/local/bin/nomad job stop -purge "rpc-{{ item.filename | regex_replace('\\.gguf$', '') }}"
+    cmd: /usr/local/bin/nomad job stop -purge "rpc-{{ ((item.filename | regex_replace('[^a-zA-Z0-9-]', '-'))[:40]) | regex_replace('-$', '') }}"
   loop: "{{ all_models_for_rpc }}"
   register: rpc_job_stop_status
   changed_when: "'Running' in rpc_job_stop_status.stdout"

--- a/ansible/tasks/deploy_model_gpu_provider.yaml
+++ b/ansible/tasks/deploy_model_gpu_provider.yaml
@@ -1,7 +1,7 @@
 - name: Set service name facts for {{ model.name }}
   ansible.builtin.set_fact:
-    rpc_job_name: "rpc-{{ model.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}"
-    rpc_service_name: "rpc-{{ model.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}-provider"
+    rpc_job_name: "rpc-{{ ((model.filename | regex_replace('[^a-zA-Z0-9-]', '-'))[:40]) | regex_replace('-$', '') }}"
+    rpc_service_name: "rpc-{{ ((model.filename | regex_replace('[^a-zA-Z0-9-]', '-'))[:40]) | regex_replace('-$', '') }}-provider"
 
 - name: Debug service name for {{ model.name }}
   ansible.builtin.debug:


### PR DESCRIPTION
Fix mismatched RPC job/service name truncation logic across AI expert deployment playbooks.

---
*PR created automatically by Jules for task [6530797260563455571](https://jules.google.com/task/6530797260563455571) started by @LokiMetaSmith*