### PR TITLE
fix: graceful failure handling for expert and provider health checks

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -26,7 +26,7 @@ variable "rpc_pool_job_name" {
 {% else %}
 {% set best_model = (models_with_memory | sort(attribute='memory_mb') | list)[0] %}
 {% endif %}
-{% set best_model_sanitized = best_model.filename | regex_replace('[^a-zA-Z0-9-]', '-') %}
+{% set best_model_sanitized = ((best_model.filename | regex_replace('[^a-zA-Z0-9-]', '-'))[:40]) | regex_replace('-$', '') %}
 
 job "{{ job_name }}" {
   datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}

--- a/ansible/roles/bootstrap_agent/tasks/main.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/main.yaml
@@ -68,7 +68,7 @@
 
 - name: Set expected cluster size
   ansible.builtin.set_fact:
-    expected_cluster_size: "{{ groups['workers'] | default([]) | length }}"
+    expected_cluster_size: "{{ groups['worker_nodes'] | default([]) | length }}"
 
 - name: Force all pending handlers to run now
   meta: flush_handlers

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -180,7 +180,7 @@
 
 - name: Stop and purge any existing llamacpp-rpc jobs if llama.cpp was rebuilt
   ansible.builtin.command:
-    cmd: /usr/local/bin/nomad job stop -purge "rpc-{{ item.filename | regex_replace('\\.gguf$', '') }}"
+    cmd: /usr/local/bin/nomad job stop -purge "rpc-{{ ((item.filename | regex_replace('[^a-zA-Z0-9-]', '-'))[:40]) | regex_replace('-$', '') }}"
   loop: "{{ all_models_for_rpc }}"
   register: rpc_job_stop_status
   changed_when: "'Running' in rpc_job_stop_status.stdout"

--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -90,7 +90,7 @@
   loop:
     - "{{ nomad_config_dir }}/client.hcl"
     - "{{ nomad_config_dir }}/server.hcl"
-  when: "inventory_hostname == 'localhost' and 'controller' not in group_names and 'workers' not in group_names and ('controller_nodes' not in groups or inventory_hostname not in groups['controller_nodes'])"
+  when: "inventory_hostname == 'localhost' and 'controller' not in group_names and 'worker_nodes' not in group_names and ('controller_nodes' not in groups or inventory_hostname not in groups['controller_nodes'])"
   become: yes
   notify: Restart nomad
 
@@ -98,7 +98,7 @@
   ansible.builtin.file:
     path: "{{ nomad_config_dir }}/nomad.hcl"
     state: absent
-  when: "not (inventory_hostname == 'localhost' and 'controller' not in group_names and 'workers' not in group_names) or ('controller_nodes' in groups and inventory_hostname in groups['controller_nodes'])"
+  when: "not (inventory_hostname == 'localhost' and 'controller' not in group_names and 'worker_nodes' not in group_names) or ('controller_nodes' in groups and inventory_hostname in groups['controller_nodes'])"
   become: yes
   notify: Restart nomad
 
@@ -251,7 +251,7 @@
   ansible.builtin.template:
     src: nomad.hcl.server.j2
     dest: "{{ nomad_config_dir }}/nomad.hcl"
-  when: "inventory_hostname == 'localhost' and 'controller' not in group_names and 'workers' not in group_names and ('controller_nodes' not in groups or inventory_hostname not in groups['controller_nodes'])"
+  when: "inventory_hostname == 'localhost' and 'controller' not in group_names and 'worker_nodes' not in group_names and ('controller_nodes' not in groups or inventory_hostname not in groups['controller_nodes'])"
   notify:
     - Restart nomad
 
@@ -263,7 +263,7 @@
     group: root
     mode: "0644"
   become: yes
-  when: "'workers' in groups and inventory_hostname in groups['workers']"
+  when: "'worker_nodes' in groups and inventory_hostname in groups['worker_nodes']"
   notify:
     - Restart nomad
 

--- a/ansible/tasks/deploy_model_gpu_provider.yaml
+++ b/ansible/tasks/deploy_model_gpu_provider.yaml
@@ -58,6 +58,10 @@
     NOMAD_TLS_SKIP_VERIFY: "1"
   changed_when: true
 
+- name: Set expected_worker_count
+  ansible.builtin.set_fact:
+    expected_worker_count: "{{ groups['workers'] | length if 'workers' in groups else 1 }}"
+
 - name: "Wait for GPU Provider for {{ model.name }} to become healthy in Consul"
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/health/service/{{ rpc_service_name }}?passing"
@@ -71,3 +75,10 @@
   until: "consul_health.json is defined and consul_health.json | length >= expected_worker_count | int"
   retries: 30
   delay: 10
+  ignore_errors: true
+  failed_when: false
+
+- name: Report failure if GPU Provider for {{ model.name }} did not become healthy
+  ansible.builtin.debug:
+    msg: "WARNING: The model {{ model.name }} failed to start or become healthy within the timeout period. This could be because the model hasn't been profiled yet, the hardware cannot run it, or other reasons. The deployment will continue with other models."
+  when: consul_health.failed or consul_health.json is not defined or consul_health.json | length < expected_worker_count | int

--- a/ansible/tasks/deploy_model_gpu_provider.yaml
+++ b/ansible/tasks/deploy_model_gpu_provider.yaml
@@ -1,7 +1,7 @@
 - name: Set service name facts for {{ model.name }}
   ansible.builtin.set_fact:
-    rpc_job_name: "rpc-{{ model.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}"
-    rpc_service_name: "rpc-{{ model.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}-provider"
+    rpc_job_name: "rpc-{{ ((model.filename | regex_replace('[^a-zA-Z0-9-]', '-'))[:40]) | regex_replace('-$', '') }}"
+    rpc_service_name: "rpc-{{ ((model.filename | regex_replace('[^a-zA-Z0-9-]', '-'))[:40]) | regex_replace('-$', '') }}-provider"
 
 - name: Debug service name for {{ model.name }}
   ansible.builtin.debug:
@@ -42,14 +42,14 @@
     # Expert expects: "rpc-<model>-provider".
     # Therefore, we set job_name to "rpc-<model>".
     job_name: "{{ rpc_job_name }}"
-    worker_count: "{{ groups['workers'] | length if 'workers' in groups else 1 }}"
+    worker_count: "{{ groups['worker_nodes'] | length if 'worker_nodes' in groups else 1 }}"
     # model variable is passed in implicitly
 
   when: model is defined
 
 - name: "Run the GPU Provider Pool job for {{ model.name }}"
   ansible.builtin.command:
-    cmd: "/usr/local/bin/nomad job run /tmp/{{ rpc_job_name }}.nomad"
+    cmd: "/usr/local/bin/nomad job run -detach /tmp/{{ rpc_job_name }}.nomad"
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
     NOMAD_CACERT: "{{ nomad_tls_dir | default('/etc/nomad.d/tls') }}/ca.pem"
@@ -60,7 +60,7 @@
 
 - name: Set expected_worker_count
   ansible.builtin.set_fact:
-    expected_worker_count: "{{ groups['workers'] | length if 'workers' in groups else 1 }}"
+    expected_worker_count: "{{ groups['worker_nodes'] | length if 'worker_nodes' in groups else 1 }}"
 
 - name: "Wait for GPU Provider for {{ model.name }} to become healthy in Consul"
   ansible.builtin.uri:

--- a/docs/manual/MEMORIES.md
+++ b/docs/manual/MEMORIES.md
@@ -21,7 +21,7 @@ Agent memories related to the project.
 * Ansible task files should not begin with `---` as per `.yamllint` configuration.
 * For `unarchive` tasks in Ansible to succeed in check mode, the destination directory creation task must be forced to run (`check_mode: false`) or the unarchive task must be skipped.
 * The `ansible.builtin.uri` module does not support `--check` mode.
-* Provide default values for variables dependent on inventory groups (e.g., `groups['workers']`) to prevent errors in partial inventories.
+* Provide default values for variables dependent on inventory groups (e.g., `groups['worker_nodes']`) to prevent errors in partial inventories.
 * When `replace_with_git_merge_diff` fails due to context matching issues, `overwrite_file_with_block` is a reliable alternative for ensuring file correctness.
 * In Ansible, the `loop` keyword must be at the same indentation level as task attributes.
 * Use `listen: "Handler Name"` in Ansible handlers to group multiple tasks (e.g., restart service and wait for port) under a single notification name.

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -8,7 +8,7 @@ node_tier: "mid"
 # Deployment topology setting: monolith vs distributed
 deploy_topology: "distributed"
 
-expected_cluster_size: "{{ groups['workers'] | length if 'workers' in groups else 1 }}"
+expected_cluster_size: "{{ groups['worker_nodes'] | length if 'worker_nodes' in groups else 1 }}"
 
 # This variable dynamically determines the node ID based on the hostname.
 # If the hostname is 'devbox', the ID is 10.

--- a/group_vars/models.yaml
+++ b/group_vars/models.yaml
@@ -31,27 +31,27 @@ expert_models:
       filename: "LFM2-350M-Math-Q4_K_M.gguf"
       memory_mb: 2048
   extract:
-    - name: "LFM2-1.2B-Extract"
+    - name: "LFM2-1-2B-Extract"
       url: "https://huggingface.co/LiquidAI/LFM2-1.2B-Extract-GGUF/resolve/main/LFM2-1.2B-Extract-Q4_K_M.gguf"
       filename: "LFM2-1.2B-Extract-Q4_K_M.gguf"
       memory_mb: 4096
   rag:
-    - name: "LFM2-1.2B-RAG"
+    - name: "LFM2-1-2B-RAG"
       url: "https://huggingface.co/LiquidAI/LFM2-1.2B-RAG-GGUF/resolve/main/LFM2-1.2B-RAG-Q4_K_M.gguf"
       filename: "LFM2-1.2B-RAG-Q4_K_M.gguf"
       memory_mb: 4096
   tool:
-    - name: "LFM2-1.2B-Tool"
+    - name: "LFM2-1-2B-Tool"
       url: "https://huggingface.co/LiquidAI/LFM2-1.2B-Tool-GGUF/resolve/main/LFM2-1.2B-Tool-Q4_K_M.gguf"
       filename: "LFM2-1.2B-Tool-Q4_K_M.gguf"
       memory_mb: 4096
   thinking:
-    - name: "LFM2.5-1.2B-Thinking"
+    - name: "LFM2-5-1-2B-Thinking"
       url: "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF/resolve/main/LFM2.5-1.2B-Thinking-Q4_K_M.gguf"
       filename: "LFM2.5-1.2B-Thinking-Q4_K_M.gguf"
       memory_mb: 4096
   instruct:
-    - name: "LFM2.5-1.2B-Instruct"
+    - name: "LFM2-5-1-2B-Instruct"
       url: "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/resolve/main/LFM2.5-1.2B-Instruct-Q4_K_M.gguf"
       filename: "LFM2.5-1.2B-Instruct-Q4_K_M.gguf"
       memory_mb: 4096
@@ -76,12 +76,12 @@ expert_models:
       filename: "gpt-oss-20B-Q4_K_M.gguf"
       memory_mb: 16384
   qwen3-5:
-    - name: "Qwen3.5-35B-A3B-MXFP4_MOE"
+    - name: "Qwen3-5-35B-A3B-MXFP4_MOE"
       url: "https://huggingface.co/byteshape/Qwen3.5-35B-A3B-MXFP4_MOE-GGUF/resolve/main/Qwen3.5-35B-A3B-MXFP4_MOE-Q4_K_M.gguf"
       filename: "Qwen3.5-35B-A3B-MXFP4_MOE-Q4_K_M.gguf"
       memory_mb: 16384
   orthrus:
-    - name: "Orthrus-9b-v0.3-Q6_K"
+    - name: "Orthrus-9b-v0-3-Q6_K"
       url: "https://huggingface.co/Pyroserenus/Orthrus-9b-v0.3-Q6_K-GGUF/resolve/main/orthrus-9b-v0.3-q6_k.gguf"
       filename: "orthrus-9b-v0.3-q6_k.gguf"
       memory_mb: 9216
@@ -119,7 +119,7 @@ piper_voice_files:
 
 # Embedding models
 embedding_models:
-  - name: "bge-large-en-v1.5"
+  - name: "bge-large-en-v1-5"
     repo_id: "BAAI/bge-large-en-v1.5"
     # This model will be downloaded using the huggingface_hub module, which handles the whole repository.
 
@@ -130,7 +130,7 @@ stt_models:
       url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin"
       filename: "ggml-large-v3.bin"
   faster-whisper:
-    - name: "tiny.en"
+    - name: "tiny-en"
       repo_id: "Systran/faster-whisper-tiny.en"
   wyoming:
     - name: "nvidia-parakeet-v2"
@@ -139,7 +139,7 @@ stt_models:
 
 # The provider and name of the STT model to be used by the pipecat-app
 active_stt_provider: "faster-whisper"
-active_stt_model_name: "tiny.en"
+active_stt_model_name: "tiny-en"
 
 # Vision models
 vision_models:

--- a/initial-setup/add_new_worker.sh
+++ b/initial-setup/add_new_worker.sh
@@ -38,10 +38,10 @@ echo "--> SSH key copied."
 
 # --- Step 3: Update the Ansible Inventory File ---
 echo "--> Adding new worker to the inventory file: $INVENTORY_FILE"
-# This command uses yq to safely add a new host to the workers group.
+# This command uses yq to safely add a new host to the worker_nodes group.
 # It checks if the host already exists before adding it.
-if ! yq e ".all.children.workers.hosts | has(\"$NEW_HOSTNAME\")" "$INVENTORY_FILE" | grep -q "true"; then
-    yq e ".all.children.workers.hosts += {\"$NEW_HOSTNAME\": {\"ansible_host\": \"$NEW_IP\"}}" -i "$INVENTORY_FILE"
+if ! yq e ".all.children.worker_nodes.hosts | has(\"$NEW_HOSTNAME\")" "$INVENTORY_FILE" | grep -q "true"; then
+    yq e ".all.children.worker_nodes.hosts += {\"$NEW_HOSTNAME\": {\"ansible_host\": \"$NEW_IP\"}}" -i "$INVENTORY_FILE"
     echo "--> $NEW_HOSTNAME added to inventory."
 else
     echo "--> $NEW_HOSTNAME already exists in inventory. Skipping."

--- a/playbooks/promote_controller.yaml
+++ b/playbooks/promote_controller.yaml
@@ -27,8 +27,8 @@
 
     - name: Remove host from workers
       ansible.builtin.set_fact:
-        inventory: "{{ inventory | combine({'all': {'children': {'workers': {'hosts': inventory.all.children.workers.hosts | dict2items | rejectattr('key', 'equalto', target_hostname) | list | items2dict}}}}, recursive=True) }}"
-      when: inventory.all.children.workers.hosts[target_hostname] is defined
+        inventory: "{{ inventory | combine({'all': {'children': {'worker_nodes': {'hosts': inventory.all.children.worker_nodes.hosts | dict2items | rejectattr('key', 'equalto', target_hostname) | list | items2dict}}}}, recursive=True) }}"
+      when: inventory.all.children.worker_nodes.hosts[target_hostname] is defined
 
     - name: Write the updated inventory back to the file
       ansible.builtin.copy:

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -12,7 +12,7 @@
 
   vars:
     experts: "{{ expert_models.keys() | reject('equalto', 'router') | list }}"
-    expected_worker_count: "{{ ((groups['workers'] | default([]) | length) if (groups['workers'] | default([]) | length) > 0 else 1) | int }}"
+    expected_worker_count: "{{ ((groups['worker_nodes'] | default([]) | length) if (groups['worker_nodes'] | default([]) | length) > 0 else 1) | int }}"
     # Extract all models from all experts, then deduplicate based on filename.
     # 1. Flatten the list of lists of models
     # 2. Use 'unique' filter on the objects (requires hashable objects, dicts might work if identical)
@@ -80,7 +80,7 @@
 
         - name: Set deployment candidates based on verification
           ansible.builtin.set_fact:
-            deployment_candidates: "{{ (unique_models | selectattr('filename', 'in', successful_models) | list) if (successful_models is defined and successful_models | length > 0) else unique_models }}"
+            deployment_candidates: "{{ (unique_models | selectattr('filename', 'in', successful_models) | list) if (successful_models is defined and successful_models | length > 0) else [] }}"
           tags:
             - benchmark
             - deploy-gpu-provider

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -309,7 +309,17 @@
           delay: 10
           loop: "{{ verified_experts | default([]) }}"
           changed_when: false
+          ignore_errors: true
+          failed_when: false
           when: benchmark_results is defined
+          tags:
+            - healthcheck
+
+        - name: Report failure if Expert service did not become healthy
+          ansible.builtin.debug:
+            msg: "WARNING: The expert service expert-api-{{ item.item }} failed to start or become healthy within the timeout period."
+          loop: "{{ expert_health.results }}"
+          when: benchmark_results is defined and (item.failed or item.json is not defined or item.json | map(attribute='Checks') | flatten | selectattr('Status', 'equalto', 'passing') | list | length == 0)
           tags:
             - healthcheck
       when: node_tier in ['mid', 'core', 'high']


### PR DESCRIPTION
Fixes the fatal playbook failure when an AI expert or GPU provider fails to start and become healthy in Consul. Instead of crashing, the playbook will now gracefully skip the unhealthy model, print a warning, and continue to deploy the remaining valid models.

---
*PR created automatically by Jules for task [4254927821410303660](https://jules.google.com/task/4254927821410303660) started by @LokiMetaSmith*