### PR TITLE
Fix: Replace incorrect 'workers' inventory group references with 'worker_nodes'

### DIFF
--- a/ansible/roles/bootstrap_agent/tasks/main.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/main.yaml
@@ -68,7 +68,7 @@
 
 - name: Set expected cluster size
   ansible.builtin.set_fact:
-    expected_cluster_size: "{{ groups['workers'] | default([]) | length }}"
+    expected_cluster_size: "{{ groups['worker_nodes'] | default([]) | length }}"
 
 - name: Force all pending handlers to run now
   meta: flush_handlers

--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -90,7 +90,7 @@
   loop:
     - "{{ nomad_config_dir }}/client.hcl"
     - "{{ nomad_config_dir }}/server.hcl"
-  when: "inventory_hostname == 'localhost' and 'controller' not in group_names and 'workers' not in group_names and ('controller_nodes' not in groups or inventory_hostname not in groups['controller_nodes'])"
+  when: "inventory_hostname == 'localhost' and 'controller' not in group_names and 'worker_nodes' not in group_names and ('controller_nodes' not in groups or inventory_hostname not in groups['controller_nodes'])"
   become: yes
   notify: Restart nomad
 
@@ -98,7 +98,7 @@
   ansible.builtin.file:
     path: "{{ nomad_config_dir }}/nomad.hcl"
     state: absent
-  when: "not (inventory_hostname == 'localhost' and 'controller' not in group_names and 'workers' not in group_names) or ('controller_nodes' in groups and inventory_hostname in groups['controller_nodes'])"
+  when: "not (inventory_hostname == 'localhost' and 'controller' not in group_names and 'worker_nodes' not in group_names) or ('controller_nodes' in groups and inventory_hostname in groups['controller_nodes'])"
   become: yes
   notify: Restart nomad
 
@@ -251,7 +251,7 @@
   ansible.builtin.template:
     src: nomad.hcl.server.j2
     dest: "{{ nomad_config_dir }}/nomad.hcl"
-  when: "inventory_hostname == 'localhost' and 'controller' not in group_names and 'workers' not in group_names and ('controller_nodes' not in groups or inventory_hostname not in groups['controller_nodes'])"
+  when: "inventory_hostname == 'localhost' and 'controller' not in group_names and 'worker_nodes' not in group_names and ('controller_nodes' not in groups or inventory_hostname not in groups['controller_nodes'])"
   notify:
     - Restart nomad
 
@@ -263,7 +263,7 @@
     group: root
     mode: "0644"
   become: yes
-  when: "'workers' in groups and inventory_hostname in groups['workers']"
+  when: "'worker_nodes' in groups and inventory_hostname in groups['worker_nodes']"
   notify:
     - Restart nomad
 

--- a/ansible/tasks/deploy_model_gpu_provider.yaml
+++ b/ansible/tasks/deploy_model_gpu_provider.yaml
@@ -42,7 +42,7 @@
     # Expert expects: "rpc-<model>-provider".
     # Therefore, we set job_name to "rpc-<model>".
     job_name: "{{ rpc_job_name }}"
-    worker_count: "{{ groups['workers'] | length if 'workers' in groups else 1 }}"
+    worker_count: "{{ groups['worker_nodes'] | length if 'worker_nodes' in groups else 1 }}"
     # model variable is passed in implicitly
 
   when: model is defined

--- a/docs/manual/MEMORIES.md
+++ b/docs/manual/MEMORIES.md
@@ -21,7 +21,7 @@ Agent memories related to the project.
 * Ansible task files should not begin with `---` as per `.yamllint` configuration.
 * For `unarchive` tasks in Ansible to succeed in check mode, the destination directory creation task must be forced to run (`check_mode: false`) or the unarchive task must be skipped.
 * The `ansible.builtin.uri` module does not support `--check` mode.
-* Provide default values for variables dependent on inventory groups (e.g., `groups['workers']`) to prevent errors in partial inventories.
+* Provide default values for variables dependent on inventory groups (e.g., `groups['worker_nodes']`) to prevent errors in partial inventories.
 * When `replace_with_git_merge_diff` fails due to context matching issues, `overwrite_file_with_block` is a reliable alternative for ensuring file correctness.
 * In Ansible, the `loop` keyword must be at the same indentation level as task attributes.
 * Use `listen: "Handler Name"` in Ansible handlers to group multiple tasks (e.g., restart service and wait for port) under a single notification name.

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -8,7 +8,7 @@ node_tier: "mid"
 # Deployment topology setting: monolith vs distributed
 deploy_topology: "distributed"
 
-expected_cluster_size: "{{ groups['workers'] | length if 'workers' in groups else 1 }}"
+expected_cluster_size: "{{ groups['worker_nodes'] | length if 'worker_nodes' in groups else 1 }}"
 
 # This variable dynamically determines the node ID based on the hostname.
 # If the hostname is 'devbox', the ID is 10.

--- a/initial-setup/add_new_worker.sh
+++ b/initial-setup/add_new_worker.sh
@@ -38,10 +38,10 @@ echo "--> SSH key copied."
 
 # --- Step 3: Update the Ansible Inventory File ---
 echo "--> Adding new worker to the inventory file: $INVENTORY_FILE"
-# This command uses yq to safely add a new host to the workers group.
+# This command uses yq to safely add a new host to the worker_nodes group.
 # It checks if the host already exists before adding it.
-if ! yq e ".all.children.workers.hosts | has(\"$NEW_HOSTNAME\")" "$INVENTORY_FILE" | grep -q "true"; then
-    yq e ".all.children.workers.hosts += {\"$NEW_HOSTNAME\": {\"ansible_host\": \"$NEW_IP\"}}" -i "$INVENTORY_FILE"
+if ! yq e ".all.children.worker_nodes.hosts | has(\"$NEW_HOSTNAME\")" "$INVENTORY_FILE" | grep -q "true"; then
+    yq e ".all.children.worker_nodes.hosts += {\"$NEW_HOSTNAME\": {\"ansible_host\": \"$NEW_IP\"}}" -i "$INVENTORY_FILE"
     echo "--> $NEW_HOSTNAME added to inventory."
 else
     echo "--> $NEW_HOSTNAME already exists in inventory. Skipping."

--- a/playbooks/promote_controller.yaml
+++ b/playbooks/promote_controller.yaml
@@ -27,8 +27,8 @@
 
     - name: Remove host from workers
       ansible.builtin.set_fact:
-        inventory: "{{ inventory | combine({'all': {'children': {'workers': {'hosts': inventory.all.children.workers.hosts | dict2items | rejectattr('key', 'equalto', target_hostname) | list | items2dict}}}}, recursive=True) }}"
-      when: inventory.all.children.workers.hosts[target_hostname] is defined
+        inventory: "{{ inventory | combine({'all': {'children': {'worker_nodes': {'hosts': inventory.all.children.worker_nodes.hosts | dict2items | rejectattr('key', 'equalto', target_hostname) | list | items2dict}}}}, recursive=True) }}"
+      when: inventory.all.children.worker_nodes.hosts[target_hostname] is defined
 
     - name: Write the updated inventory back to the file
       ansible.builtin.copy:

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -12,7 +12,7 @@
 
   vars:
     experts: "{{ expert_models.keys() | reject('equalto', 'router') | list }}"
-    expected_worker_count: "{{ ((groups['workers'] | default([]) | length) if (groups['workers'] | default([]) | length) > 0 else 1) | int }}"
+    expected_worker_count: "{{ ((groups['worker_nodes'] | default([]) | length) if (groups['worker_nodes'] | default([]) | length) > 0 else 1) | int }}"
     # Extract all models from all experts, then deduplicate based on filename.
     # 1. Flatten the list of lists of models
     # 2. Use 'unique' filter on the objects (requires hashable objects, dicts might work if identical)


### PR DESCRIPTION
This PR fixes a pervasive naming discrepancy where multiple playbooks and templates referenced the `workers` Ansible group instead of the correct `worker_nodes` group.

This caused the `client.hcl` config to not deploy to worker nodes, preventing them from registering as clients, and subsequently leading to failures when the `llamacpp-rpc` GPU providers failed to schedule and did not become healthy in Consul.

---
*PR created automatically by Jules for task [5301833729440569012](https://jules.google.com/task/5301833729440569012) started by @LokiMetaSmith*