### PR TITLE
Fix AI Experts fallback timeout in deployment loop

### DIFF
--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -80,7 +80,7 @@
 
         - name: Set deployment candidates based on verification
           ansible.builtin.set_fact:
-            deployment_candidates: "{{ (unique_models | selectattr('filename', 'in', successful_models) | list) if (successful_models is defined and successful_models | length > 0) else unique_models }}"
+            deployment_candidates: "{{ (unique_models | selectattr('filename', 'in', successful_models) | list) if (successful_models is defined and successful_models | length > 0) else [] }}"
           tags:
             - benchmark
             - deploy-gpu-provider


### PR DESCRIPTION
Fixes the issue where the `ai_experts.yaml` playbook times out trying to deploy unverified models by defaulting the fallback array to an empty list instead of the full unfiltered model array.

---
*PR created automatically by Jules for task [16131127739416818332](https://jules.google.com/task/16131127739416818332) started by @LokiMetaSmith*