### PR TITLE
fix: Remove invalid initial_delay argument from Nomad check blocks

### DIFF
--- a/ansible/roles/paperless/templates/paperless-app.nomad.j2
+++ b/ansible/roles/paperless/templates/paperless-app.nomad.j2
@@ -24,7 +24,6 @@ job "paperless-app" {
         path     = "/"
         interval = "20s"
         timeout  = "5s"
-        initial_delay = "60s"
       }
     }
 

--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -92,7 +92,6 @@ job "{{ job_name | default('pipecat-app') }}" {
         path     = "/health"
         interval = "20s"
         timeout  = "5s"
-        initial_delay = "60s"
       }
 
       check {
@@ -101,7 +100,6 @@ job "{{ job_name | default('pipecat-app') }}" {
         path     = "/api/status"
         interval = "30s"
         timeout  = "5s"
-        initial_delay = "60s"
       }
     }
 

--- a/ansible/roles/tool_server/templates/tool_server.nomad.j2
+++ b/ansible/roles/tool_server/templates/tool_server.nomad.j2
@@ -68,7 +68,6 @@ job "tool-server" {
           type     = "http"
           path     = "/health"
           interval = "15s"
-          initial_delay = "60s"
           timeout  = "5s"
         }
       }


### PR DESCRIPTION
Removed `initial_delay` argument from Nomad check blocks because it is not supported and causes deployment parsing failures. Verified fix by checking template syntax.

---
*PR created automatically by Jules for task [13929844018295649593](https://jules.google.com/task/13929844018295649593) started by @LokiMetaSmith*