### PR TITLE
Fix heal cluster script by adding explicit inventory file path

### DIFF
--- a/scripts/heal_cluster.sh
+++ b/scripts/heal_cluster.sh
@@ -64,7 +64,7 @@ if ! command -v ansible-playbook &> /dev/null; then
 fi
 
 # Run the playbook
-ansible-playbook "$PLAYBOOK" \
+ansible-playbook -i "$REPO_ROOT/inventory.yaml" "$PLAYBOOK" \
     -e "target_user=$TARGET_USER" \
     -e "ansible_python_interpreter=$(which python3)"
 


### PR DESCRIPTION
Fix heal cluster script by adding explicit inventory file path

---
*PR created automatically by Jules for task [7802421004829543713](https://jules.google.com/task/7802421004829543713) started by @LokiMetaSmith*