### PR TITLE
fix(bootstrap): correctly populate profile variables during status check

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -202,7 +202,7 @@ profile_system() {
     fi
 
     # Network Discovery & Role Fallback
-    if [ "$ROLE" = "worker" ] && [ -z "$CONTROLLER_IP" ]; then
+    if [ "$ROLE" = "worker" ] && [ -z "$CONTROLLER_IP" ] && [ "$DO_STATUS" != true ]; then
         if find_controller; then
             # Controller found, CONTROLLER_IP is set. Add it to PROCESSED_ARGS.
             PROCESSED_ARGS+=("--controller-ip" "$CONTROLLER_IP")
@@ -371,9 +371,9 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR" || exit 1
 
 # Run system profiling before we proceed, unless just asking for status
-if [ "$DO_STATUS" != true ]; then
-    profile_system
-fi
+
+profile_system
+
 
 LOG_FILE="bootstrap_debug.log"
 AGENT_LOG="agent_recovery.log"


### PR DESCRIPTION
Fixes an issue where `bootstrap.sh --status` incorrectly reports the configured stack profile as "Infrastructure Only" because it bypasses the system profiling step. The fix ensures `profile_system` is called to populate `PROCESSED_ARGS` but avoids the network discovery penalty by conditionally bypassing `find_controller` when running a status check.

---
*PR created automatically by Jules for task [2193116348340729189](https://jules.google.com/task/2193116348340729189) started by @LokiMetaSmith*