### PR TITLE
fix: ensure proper mTLS connections and safe until loops for Consul API in playbooks

### DIFF
--- a/ansible/roles/consul/tasks/acl.yaml
+++ b/ansible/roles/consul/tasks/acl.yaml
@@ -79,9 +79,12 @@
 
         - name: Wait for Consul API to be ready after recovery
           uri:
-            url: "http://{{ advertise_ip }}:{{ consul_http_port }}/v1/status/leader"
+            url: "https://{{ advertise_ip }}:{{ consul_https_port }}/v1/status/leader"
+            client_cert: "{{ consul_config_dir | default('/etc/consul.d') }}/cert.pem"
+            client_key: "{{ consul_config_dir | default('/etc/consul.d') }}/key.pem"
+            validate_certs: false
           register: consul_status_recovery
-          until: consul_status_recovery.status == 200
+          until: consul_status_recovery.status is defined and consul_status_recovery.status == 200
           retries: 30
           delay: 5
 

--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -14,10 +14,13 @@
 
     - name: Wait for a Consul leader to be elected
       ansible.builtin.uri:
-        url: "http://{{ cluster_ip }}:{{ consul_http_port | default(8500) }}/v1/status/leader"
+        url: "https://{{ cluster_ip }}:{{ consul_https_port | default(8501) }}/v1/status/leader"
+        client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+        client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+        validate_certs: false
         return_content: yes
       register: consul_leader_status
-      until: consul_leader_status.content != '""' and consul_leader_status.status == 200
+      until: consul_leader_status.status is defined and consul_leader_status.status == 200 and consul_leader_status.content is defined and consul_leader_status.content != '""'
       retries: 12
       delay: 5
       ignore_errors: yes

--- a/playbooks/services/final_verification.yaml
+++ b/playbooks/services/final_verification.yaml
@@ -30,10 +30,13 @@
 
           - name: Wait for a Consul leader to be elected
             ansible.builtin.uri:
-              url: "http://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_http_port | default(8500) }}/v1/status/leader"
+              url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/status/leader"
+              client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+              client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+              validate_certs: false
               return_content: yes
             register: consul_leader_status
-            until: consul_leader_status.content != '""' and consul_leader_status.status == 200
+            until: consul_leader_status.status is defined and consul_leader_status.status == 200 and consul_leader_status.content is defined and consul_leader_status.content != '""'
             retries: 12
             delay: 5
             ignore_errors: yes


### PR DESCRIPTION
Resolves an issue where the deployment script hangs indefinitely during the application and verification playbooks on the "Wait for a Consul leader to be elected" task. By enforcing mTLS settings using the `uri` module and safely checking attribute presence in `until` conditionals, the task correctly authenticates, polls, and appropriately logs/retries or handles errors gracefully rather than crashing silently.

---
*PR created automatically by Jules for task [5815332571618645433](https://jules.google.com/task/5815332571618645433) started by @LokiMetaSmith*