### PR TITLE
Fix Docker inspect failure in raw_exec deployments

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -402,31 +402,34 @@
   ansible.builtin.include_tasks:
     file: "{{ inventory_dir }}/ansible/tasks/build_pipecatapp_image.yaml"
 
-- name: Inspect pipecatapp:local image
-  ansible.builtin.command: docker image inspect pipecatapp:local
-  register: pipecatapp_local_image_info
-  changed_when: false
-  become: yes
+- name: Handle docker specific tasks for pipecatapp
+  block:
+    - name: Inspect pipecatapp:local image
+      ansible.builtin.command: docker image inspect pipecatapp:local
+      register: pipecatapp_local_image_info
+      changed_when: false
+      become: yes
 
-- name: Check if local registry is reachable (Pipecat App)
-  ansible.builtin.wait_for:
-    host: "{{ docker_registry_host }}"
-    port: "{{ docker_registry_port }}"
-    state: started
-    timeout: 1
-  register: pipecatapp_registry_check
-  failed_when: false
-  ignore_errors: true
+    - name: Check if local registry is reachable (Pipecat App)
+      ansible.builtin.wait_for:
+        host: "{{ docker_registry_host }}"
+        port: "{{ docker_registry_port }}"
+        state: started
+        timeout: 1
+      register: pipecatapp_registry_check
+      failed_when: false
+      ignore_errors: true
 
-- name: Set pipecatapp_image_ref (Registry)
-  ansible.builtin.set_fact:
-    pipecatapp_image_ref: "{{ docker_registry_host }}:{{ docker_registry_port }}/pipecatapp:local"
-  when: pipecatapp_registry_check.state | default('stopped') == 'started'
+    - name: Set pipecatapp_image_ref (Registry)
+      ansible.builtin.set_fact:
+        pipecatapp_image_ref: "{{ docker_registry_host }}:{{ docker_registry_port }}/pipecatapp:local"
+      when: pipecatapp_registry_check.state | default('stopped') == 'started'
 
-- name: Set pipecatapp_image_ref (Local Fallback)
-  ansible.builtin.set_fact:
-    pipecatapp_image_ref: "pipecatapp:local"
-  when: pipecatapp_registry_check.state | default('stopped') != 'started'
+    - name: Set pipecatapp_image_ref (Local Fallback)
+      ansible.builtin.set_fact:
+        pipecatapp_image_ref: "pipecatapp:local"
+      when: pipecatapp_registry_check.state | default('stopped') != 'started'
+  when: pipecat_deployment_style == 'docker'
 
 - name: Ensure Nomad jobs directory exists
   ansible.builtin.file:


### PR DESCRIPTION
Fixed a playbook failure where `docker image inspect` would fail in environments deployed with `raw_exec` because the Docker build steps were skipped. Wrapped the image inspection and registry checking tasks inside a block that only runs when `pipecat_deployment_style == 'docker'`.

---
*PR created automatically by Jules for task [10512937724281889172](https://jules.google.com/task/10512937724281889172) started by @LokiMetaSmith*