### PR TITLE
fix: correct welcome message when running from installed system

### DIFF
--- a/os-image/config/includes.chroot/etc/profile.d/99-pipecat-welcome.sh
+++ b/os-image/config/includes.chroot/etc/profile.d/99-pipecat-welcome.sh
@@ -52,8 +52,12 @@ echo " System Details:"
 echo "   Hostname: $(hostname)"
 echo "   IP Address: $IP"
 echo ""
-echo " The system is running from the bootable media."
-echo " To install and configure the cluster agent or control node, run:"
+if grep -q "boot=live" /proc/cmdline; then
+    echo " The system is running from the bootable media."
+    echo " To install and configure the cluster agent or control node, run:"
+else
+    echo " To configure or update the cluster agent or control node, run:"
+fi
 echo ""
 echo "   cd /opt/pipecat-cluster && sudo ./bootstrap.sh"
 echo ""


### PR DESCRIPTION
Modified `os-image/config/includes.chroot/etc/profile.d/99-pipecat-welcome.sh` to check for `boot=live` in `/proc/cmdline` before claiming the system is running from bootable media. If it is installed, it now correctly omits the "bootable media" text and provides instructions to configure or update the node instead of to "install and configure".

---
*PR created automatically by Jules for task [2923583947833354995](https://jules.google.com/task/2923583947833354995) started by @LokiMetaSmith*