### PR TITLE
Fix undefined ansible_memtotal_mb fact in expert Nomad template

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -16,7 +16,7 @@ variable "rpc_pool_job_name" {
 
 # --- DYNAMIC MODEL SELECTION & TPS CALCULATION ---
 {% set memory_buffer_mb = 2048 %}
-{% set available_memory_mb = (ansible_memtotal_mb | int) - memory_buffer_mb %}
+{% set available_memory_mb = (ansible_facts['memtotal_mb'] | int) - memory_buffer_mb %}
 {% set model_list = expert_models[current_expert] %}
 {% set models_with_memory = model_list | selectattr('memory_mb', 'defined') | list %}
 {% set suitable_models_unsorted = models_with_memory | selectattr('memory_mb', 'le', available_memory_mb) %}


### PR DESCRIPTION
Fixes undefined variable crash in playbook deployment by updating `ansible_memtotal_mb` to `ansible_facts['memtotal_mb']` in the Nomad job template `expert.nomad.j2`.

---
*PR created automatically by Jules for task [16356672773541859310](https://jules.google.com/task/16356672773541859310) started by @LokiMetaSmith*