### PR TITLE
Fix Docker-specific task execution in Ansible ai_experts playbooks

### DIFF
--- a/ansible/tasks/deploy_expert_wrapper.yaml
+++ b/ansible/tasks/deploy_expert_wrapper.yaml
@@ -4,6 +4,7 @@
       register: pipecat_image_check
       failed_when: false
       changed_when: false
+      when: pipecat_deployment_style == 'docker'
 
     - name: "Expert {{ expert_name }} : Ensure pipecatapp directory exists"
       ansible.builtin.file:
@@ -33,33 +34,36 @@
 
         - name: "Expert {{ expert_name }} : Tag {{ pipecat_image_name }}:{{ pipecat_image_tag }}"
           ansible.builtin.command: "docker tag {{ pipecat_image_name }}:{{ pipecat_image_tag }} {{ pipecat_image_name }}:{{ pipecat_image_tag }}"
-      when: pipecat_image_check.rc != 0
+      when: pipecat_deployment_style == 'docker' and (pipecat_image_check.rc | default(0)) != 0
 
-    - name: "Expert {{ expert_name }} : Refresh {{ pipecat_image_name }}:{{ pipecat_image_tag }} tag for Nomad"
-      ansible.builtin.command: "docker tag {{ pipecat_image_name }}:{{ pipecat_image_tag }} {{ pipecat_image_name }}:{{ pipecat_image_tag }}"
-      changed_when: false
+    - name: Docker-specific tags and registry checks
+      block:
+        - name: "Expert {{ expert_name }} : Refresh {{ pipecat_image_name }}:{{ pipecat_image_tag }} tag for Nomad"
+          ansible.builtin.command: "docker tag {{ pipecat_image_name }}:{{ pipecat_image_tag }} {{ pipecat_image_name }}:{{ pipecat_image_tag }}"
+          changed_when: false
 
-    - name: "Expert {{ expert_name }} : Check if local registry is reachable"
-      ansible.builtin.wait_for:
-        host: "{{ docker_registry_host }}"
-        port: "{{ docker_registry_port }}"
-        state: started
-        timeout: 5
-      register: registry_check
-      failed_when: false
-      ignore_errors: true
-      when: registry_is_reachable | default(true)
+        - name: "Expert {{ expert_name }} : Check if local registry is reachable"
+          ansible.builtin.wait_for:
+            host: "{{ docker_registry_host }}"
+            port: "{{ docker_registry_port }}"
+            state: started
+            timeout: 5
+          register: registry_check
+          failed_when: false
+          ignore_errors: true
+          when: registry_is_reachable | default(true)
 
-    - name: "Expert {{ expert_name }} : Tag and push {{ pipecat_image_name }} image to local registry"
-      community.docker.docker_image:
-        name: "{{ pipecat_image_name }}"
-        tag: "{{ pipecat_image_tag }}"
-        repository: "{{ docker_registry_host }}:{{ docker_registry_port }}/{{ pipecat_image_name }}"
-        push: true
-        source: local
-      when:
-        - registry_is_reachable | default(true)
-        - registry_check.state | default('stopped') == 'started'
+        - name: "Expert {{ expert_name }} : Tag and push {{ pipecat_image_name }} image to local registry"
+          community.docker.docker_image:
+            name: "{{ pipecat_image_name }}"
+            tag: "{{ pipecat_image_tag }}"
+            repository: "{{ docker_registry_host }}:{{ docker_registry_port }}/{{ pipecat_image_name }}"
+            push: true
+            source: local
+          when:
+            - registry_is_reachable | default(true)
+            - registry_check.state | default('stopped') == 'started'
+      when: pipecat_deployment_style == 'docker'
 
     - name: "Expert {{ expert_name }} : Ensure startup script exists (Dev Mode fallback)"
       ansible.builtin.template:

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -116,50 +116,53 @@
           tags:
             - deploy-expert
 
-        - name: Explicitly tag pipecatapp:expert to refresh metadata
-          ansible.builtin.command: "docker tag {{ pipecat_image_name }}:{{ pipecat_image_tag }} {{ pipecat_image_name }}:{{ pipecat_image_tag }}"
-          changed_when: false
-          tags:
-            - deploy-expert
+        - name: Docker-specific tasks
+          block:
+            - name: Explicitly tag pipecatapp:expert to refresh metadata
+              ansible.builtin.command: "docker tag {{ pipecat_image_name }}:{{ pipecat_image_tag }} {{ pipecat_image_name }}:{{ pipecat_image_tag }}"
+              changed_when: false
+              tags:
+                - deploy-expert
 
-        - name: Verify pipecatapp Docker image exists
-          ansible.builtin.command: "docker image inspect {{ pipecat_image_name }}:{{ pipecat_image_tag }}"
-          changed_when: false
-          register: pipecat_image_info
-          tags:
-            - deploy-expert
+            - name: Verify pipecatapp Docker image exists
+              ansible.builtin.command: "docker image inspect {{ pipecat_image_name }}:{{ pipecat_image_tag }}"
+              changed_when: false
+              register: pipecat_image_info
+              tags:
+                - deploy-expert
 
-        - name: Verify pipecatapp Docker image is runnable
-          ansible.builtin.command: "docker run --rm --entrypoint /bin/true {{ pipecat_image_name }}:{{ pipecat_image_tag }}"
-          changed_when: false
-          tags:
-            - deploy-expert
+            - name: Verify pipecatapp Docker image is runnable
+              ansible.builtin.command: "docker run --rm --entrypoint /bin/true {{ pipecat_image_name }}:{{ pipecat_image_tag }}"
+              changed_when: false
+              tags:
+                - deploy-expert
 
-        - name: Check if local registry is reachable (Global)
-          ansible.builtin.wait_for:
-            host: "{{ docker_registry_host }}"
-            port: "{{ docker_registry_port }}"
-            state: started
-            timeout: 5
-          register: global_registry_check
-          failed_when: false
-          ignore_errors: true
-          tags:
-            - deploy-expert
+            - name: Check if local registry is reachable (Global)
+              ansible.builtin.wait_for:
+                host: "{{ docker_registry_host }}"
+                port: "{{ docker_registry_port }}"
+                state: started
+                timeout: 5
+              register: global_registry_check
+              failed_when: false
+              ignore_errors: true
+              tags:
+                - deploy-expert
 
-        - name: Set pipecat_image_id fact (Registry)
-          ansible.builtin.set_fact:
-            pipecat_image_id: "{{ docker_registry_host }}:{{ docker_registry_port }}/{{ pipecat_image_name }}:{{ pipecat_image_tag }}"
-          when: global_registry_check.state | default('stopped') == 'started'
-          tags:
-            - deploy-expert
+            - name: Set pipecat_image_id fact (Registry)
+              ansible.builtin.set_fact:
+                pipecat_image_id: "{{ docker_registry_host }}:{{ docker_registry_port }}/{{ pipecat_image_name }}:{{ pipecat_image_tag }}"
+              when: global_registry_check.state | default('stopped') == 'started'
+              tags:
+                - deploy-expert
 
-        - name: Set pipecat_image_id fact (Local Fallback)
-          ansible.builtin.set_fact:
-            pipecat_image_id: "{{ (pipecat_image_info.stdout | from_json)[0].Id }}"
-          when: global_registry_check.state | default('stopped') != 'started'
-          tags:
-            - deploy-expert
+            - name: Set pipecat_image_id fact (Local Fallback)
+              ansible.builtin.set_fact:
+                pipecat_image_id: "{{ (pipecat_image_info.stdout | from_json)[0].Id }}"
+              when: global_registry_check.state | default('stopped') != 'started'
+              tags:
+                - deploy-expert
+          when: pipecat_deployment_style == 'docker'
 
         - name: Deploy and run the GPU Provider Pool job for verified models
           include_tasks:


### PR DESCRIPTION
Fix pipeline failures caused by unconditional Docker command executions during Ansible setups that utilize `raw_exec` instead of `docker` for their deployment styles.

---
*PR created automatically by Jules for task [9588197846186649259](https://jules.google.com/task/9588197846186649259) started by @LokiMetaSmith*