### PR TITLE
Fix duplicate options in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,9 +2,6 @@
 force_valid_group_names = silently
 inject_facts_as_vars = False
 deprecation_warnings = False
-force_valid_group_names = silently
-inject_facts_as_vars = False
-deprecation_warnings = False
 collections_path = /root/.ansible/collections:/usr/share/ansible/collections
 fact_caching = jsonfile
 fact_caching_connection = /tmp/ansible_facts_cache


### PR DESCRIPTION
Removes duplicate entries for configuration options from `ansible.cfg` which were causing a `configparser.DuplicateOptionError` when `ansible-core` read the file. This fixes the issue where `bootstrap.sh` fails during the "Installing Ansible collections" step.

---
*PR created automatically by Jules for task [18375375230813611844](https://jules.google.com/task/18375375230813611844) started by @LokiMetaSmith*