### PR TITLE
Fix Pipecat and Home Assistant startup

### DIFF
--- a/ansible/roles/home_assistant/tasks/main.yaml
+++ b/ansible/roles/home_assistant/tasks/main.yaml
@@ -86,6 +86,22 @@
     msg: "Token length: {{ (home_assistant_consul_token.content | b64decode | trim) | length }}"
   when: home_assistant_consul_token.content is defined
 
+- name: Wait for MQTT service to be healthy in Consul before running home-assistant
+  ansible.builtin.uri:
+    url: "https://{{ cluster_ip }}:{{ consul_https_port }}/v1/health/service/mqtt?passing"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
+    method: GET
+    headers:
+      X-Consul-Token: "{{ consul_bootstrap_token | default('') }}"
+    return_content: yes
+    status_code: 200
+  register: mqtt_consul_check
+  until: mqtt_consul_check.json is defined and mqtt_consul_check.json | length > 0
+  retries: 30
+  delay: 2
+
 - name: Run home-assistant job asynchronously
   ansible.builtin.command:
     cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/home-assistant.nomad

--- a/ansible/roles/mqtt/handlers/main.yaml
+++ b/ansible/roles/mqtt/handlers/main.yaml
@@ -1,6 +1,6 @@
 - name: Restart Home Assistant
   ansible.builtin.command:
-    cmd: nomad job run -detach {{ nomad_jobs_dir }}/home-assistant.nomad
+    cmd: /usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/home-assistant.nomad
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
     NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"

--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -230,7 +230,7 @@
         NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
       changed_when: true
       register: mqtt_job_run
-      #  notify: Restart Home Assistant
+      notify: Restart Home Assistant
 
     - name: Wait for MQTT service to be healthy in Consul
       ansible.builtin.uri:

--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -118,10 +118,9 @@ job "{{ job_name | default('pipecat-app') }}" {
         force_pull = false
         ports = ["http"]
         # Mount volumes for models and config. Models are read-only.
-        # Assumes /app is the WORKDIR in the container, where pipecat_config.json will be placed.
+        # Assumes /app is the WORKDIR in the container.
         volumes = [
           "/opt/nomad/models:/opt/nomad/models:ro",
-          "/opt/pipecatapp/pipecat_config.json:/app/pipecat_config.json:ro",
           "/opt/pipecatapp:/opt/pipecatapp",
           "/opt/pipecatapp/chromadb:/app/chromadb_storage",
         ]

--- a/tests/unit/test_home_assistant_template.py
+++ b/tests/unit/test_home_assistant_template.py
@@ -14,7 +14,9 @@ def test_home_assistant_template():
         # Fallback if running from tests directory
         template_dir = '../../ansible/roles/home_assistant/templates'
 
+    import json
     j2_env = Environment(loader=FileSystemLoader(template_dir), trim_blocks=True)
+    j2_env.filters['to_json'] = lambda value: json.dumps(value)
     template = j2_env.get_template('home_assistant.nomad.j2')
 
     # Mock context variables


### PR DESCRIPTION
Fixes an issue where both `pipecat-app` and `home-assistant` would fail to start. This includes:

1. Modifying the `pipecatapp.nomad.j2` file to remove a broken volume mount mapping to a non-existent `pipecat_config.json` that was failing container startup.
2. In the `home_assistant` Ansible role, a new task was added to wait for the `mqtt` service to be actively registered and passing in Consul before deploying the Home Assistant Nomad job. 
3. Corrected a missing `nomad` absolute path in `mqtt/handlers/main.yaml` that was breaking the handler and uncommented the trigger.
4. Addressed a jinja2 unit test error by injecting a lambda `to_json` mock to `test_home_assistant_template.py`.

---
*PR created automatically by Jules for task [13086467284174308200](https://jules.google.com/task/13086467284174308200) started by @LokiMetaSmith*