### PR TITLE
Fix HCL2 formatting error in home_assistant.nomad.j2

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -75,7 +75,7 @@ job "home-assistant" {
         # Docker logging driver options — ensures rotation if supported
         logging {
           type = "json-file"
-          config {
+          config = {
             "max-size" = "15m"
             "max-file" = "5"
           }


### PR DESCRIPTION
Fix HCL2 formatting error in home_assistant.nomad.j2

Changed the `config { ... }` block inside the Docker `logging` configuration to use map assignment `config = { ... }`.
This fixes the Nomad deployment error "Argument names must not be quoted" which occurred because HCL2 block attributes cannot use quoted keys with hyphens, such as `"max-size"` and `"max-file"`.

---
*PR created automatically by Jules for task [5608520555786664343](https://jules.google.com/task/5608520555786664343) started by @LokiMetaSmith*