### PR TITLE
Deploy traefik before app services

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -9,6 +9,7 @@
 - import_playbook: playbooks/services/docker.yaml
 - import_playbook: playbooks/services/nomad.yaml
 - import_playbook: playbooks/services/registry.yaml
+- import_playbook: playbooks/app_jobs.yaml
 - import_playbook: playbooks/services/app_services.yaml
 - import_playbook: playbooks/services/monitoring.yaml
 - import_playbook: playbooks/services/model_services.yaml


### PR DESCRIPTION
Fixes a deployment orchestration issue where Traefik was not being deployed during a "Full" setup, leaving dependent application services dead or failing because they had no external routing. I added `app_jobs.yaml` to the main playbook right after the core Nomad and registry deployments.

---
*PR created automatically by Jules for task [3304195410750844337](https://jules.google.com/task/3304195410750844337) started by @LokiMetaSmith*