### PR TITLE
Fix pipecat_image_id undefined error in expert.nomad.j2

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -168,7 +168,7 @@ EOH
       }
 
       config {
-        image = "{{ pipecat_image_id }}"
+        image = "{{ pipecat_image_id | default('pipecatapp:' ~ (pipecat_image_tag | default('local'))) }}"
         force_pull = false
         ports = ["http"]
         command = "/bin/bash"


### PR DESCRIPTION
Added a default fallback to `pipecat_image_id` inside the `ansible/jobs/expert.nomad.j2` template to resolve undefined variable errors.

---
*PR created automatically by Jules for task [7868203453317707856](https://jules.google.com/task/7868203453317707856) started by @LokiMetaSmith*