### PR TITLE
fix: Nomad parsing errors due to unterminated heredoc strings

### DIFF
--- a/ansible/roles/monitoring/templates/grafana.nomad.j2
+++ b/ansible/roles/monitoring/templates/grafana.nomad.j2
@@ -57,16 +57,18 @@ job "grafana" {
       }
 
       template {
-        data = <<EOF
+        data = <<-EOF
 {{ lookup('template', 'datasource.yaml.j2') }}
 EOF
+
         destination = "local/provisioning/datasources/datasource.yaml"
       }
 
       template {
-        data = <<EOF
+        data = <<-EOF
 {{ lookup('template', 'dashboards.yaml.j2') }}
 EOF
+
         destination = "local/provisioning/dashboards/dashboards.yaml"
       }
 

--- a/ansible/roles/monitoring/templates/prometheus.nomad.j2
+++ b/ansible/roles/monitoring/templates/prometheus.nomad.j2
@@ -39,9 +39,10 @@ job "prometheus" {
       }
 
       template {
-        data = <<EOF
+        data = <<-EOF
 {{ lookup('template', 'prometheus.yml.j2') }}
 EOF
+
         destination = "local/prometheus.yml"
         change_mode = "restart"
       }

--- a/ansible/roles/traefik/templates/traefik.nomad.j2
+++ b/ansible/roles/traefik/templates/traefik.nomad.j2
@@ -42,7 +42,7 @@ job "traefik" {
       }
 
       template {
-        data = <<EOF
+        data = <<-EOF
 entryPoints:
   web:
     address: ":{{ traefik_http_port | default(80) }}"
@@ -66,18 +66,20 @@ providers:
     directory: "/etc/traefik/dynamic"
     watch: true
 EOF
+
         destination = "local/traefik.yml"
       }
 
       template {
-        data = <<EOF
+        data = <<-EOF
 {{ lookup('template', 'headscale-router.yaml.j2') }}
 EOF
+
         destination = "local/dynamic/headscale-router.yaml"
       }
 
       template {
-        data = <<EOF
+        data = <<-EOF
 tls:
   certificates:
     - certFile: "/etc/traefik/certs/mesh/tls.crt"
@@ -88,20 +90,23 @@ tls:
         certFile: "/etc/traefik/certs/mesh/tls.crt"
         keyFile: "/etc/traefik/certs/mesh/tls.key"
 EOF
+
         destination = "local/dynamic/tls.yml"
       }
 
       template {
-        data = <<EOF
+        data = <<-EOF
 {% raw %}{{ key "certs/mesh/tls.crt" }}{% endraw %}
 EOF
+
         destination = "local/certs/mesh/tls.crt"
       }
 
       template {
-        data = <<EOF
+        data = <<-EOF
 {% raw %}{{ key "certs/mesh/tls.key" }}{% endraw %}
 EOF
+
         destination = "local/certs/mesh/tls.key"
       }
 


### PR DESCRIPTION
This PR addresses an issue where Nomad jobs rendered via Ansible Jinja templates fail to parse with the error "Unterminated template string". This was happening because Ansible sometimes removes trailing newlines or modifies whitespace, breaking the strict parsing rules of Nomad HCL for heredocs (`<<EOF`). 

The fix involved updating the heredoc syntax to the indented form `<<-EOF` and explicitly formatting the EOF block throughout the affected `traefik`, `prometheus`, and `grafana` Nomad job templates.

---
*PR created automatically by Jules for task [8033650991720506815](https://jules.google.com/task/8033650991720506815) started by @LokiMetaSmith*