### PR TITLE
fix: add empty lines before EOF in Nomad templates

### DIFF
--- a/ansible/roles/monitoring/templates/grafana.nomad.j2
+++ b/ansible/roles/monitoring/templates/grafana.nomad.j2
@@ -59,6 +59,7 @@ job "grafana" {
       template {
         data = <<-EOF
 {{ lookup('template', 'datasource.yaml.j2') }}
+
 EOF
 
         destination = "local/provisioning/datasources/datasource.yaml"
@@ -67,6 +68,7 @@ EOF
       template {
         data = <<-EOF
 {{ lookup('template', 'dashboards.yaml.j2') }}
+
 EOF
 
         destination = "local/provisioning/dashboards/dashboards.yaml"

--- a/ansible/roles/monitoring/templates/memory-audit.nomad.j2
+++ b/ansible/roles/monitoring/templates/memory-audit.nomad.j2
@@ -23,6 +23,7 @@ job "memory-audit" {
       template {
         data = <<EOH
 {{ lookup('file', inventory_dir + '/scripts/memory_audit.py') }}
+
 EOH
         destination = "local/memory_audit.py"
         env         = false

--- a/ansible/roles/monitoring/templates/prometheus.nomad.j2
+++ b/ansible/roles/monitoring/templates/prometheus.nomad.j2
@@ -41,6 +41,7 @@ job "prometheus" {
       template {
         data = <<-EOF
 {{ lookup('template', 'prometheus.yml.j2') }}
+
 EOF
 
         destination = "local/prometheus.yml"

--- a/ansible/roles/traefik/templates/traefik.nomad.j2
+++ b/ansible/roles/traefik/templates/traefik.nomad.j2
@@ -73,6 +73,7 @@ EOF
       template {
         data = <<-EOF
 {{ lookup('template', 'headscale-router.yaml.j2') }}
+
 EOF
 
         destination = "local/dynamic/headscale-router.yaml"
@@ -97,6 +98,7 @@ EOF
       template {
         data = <<-EOF
 {% raw %}{{ key "certs/mesh/tls.crt" }}{% endraw %}
+
 EOF
 
         destination = "local/certs/mesh/tls.crt"
@@ -105,6 +107,7 @@ EOF
       template {
         data = <<-EOF
 {% raw %}{{ key "certs/mesh/tls.key" }}{% endraw %}
+
 EOF
 
         destination = "local/certs/mesh/tls.key"


### PR DESCRIPTION
Fixes Nomad template syntax errors caused by Jinja2 newline stripping by adding blank lines before heredoc closing markers.

---
*PR created automatically by Jules for task [18234306713824758516](https://jules.google.com/task/18234306713824758516) started by @LokiMetaSmith*