### PR TITLE
Fix unterminated template string error in traefik.nomad.j2

### DIFF
--- a/ansible/roles/traefik/templates/traefik.nomad.j2
+++ b/ansible/roles/traefik/templates/traefik.nomad.j2
@@ -72,6 +72,7 @@ EOF
       template {
         data = <<EOF
 {{ lookup('template', 'headscale-router.yaml.j2') }}
+
 EOF
         destination = "local/dynamic/headscale-router.yaml"
       }


### PR DESCRIPTION
Fix unterminated template string error in traefik.nomad.j2

Added a newline after the lookup of `headscale-router.yaml.j2` inside
the template heredoc block to ensure the closing `EOF` string ends up on
its own line. When `headscale-router.yaml.j2` did not end in a newline,
the `EOF` marker was getting appended to the last line of that file
during Jinja templating, causing Nomad's HCL parser to throw an
`Unterminated template string` error.

---
*PR created automatically by Jules for task [1075190485223647773](https://jules.google.com/task/1075190485223647773) started by @LokiMetaSmith*