### PR TITLE
Fix home-assistant.nomad.j2 HCL2 parsing

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -75,9 +75,9 @@ job "home-assistant" {
         # Docker logging driver options — ensures rotation if supported
         logging {
           type = "json-file"
-          config {
-            max-size = "15m"
-            max-file = "5"
+          config = {
+            "max-size" = "15m"
+            "max-file" = "5"
           }
         }
 


### PR DESCRIPTION
Fixed the Home Assistant nomad job definition to use HCL2 map assignment for the logging config, which is required when using hyphens in keys (e.g., `max-size`). Without it, parsing fails and the job cannot be submitted.

---
*PR created automatically by Jules for task [11833561268770579405](https://jules.google.com/task/11833561268770579405) started by @LokiMetaSmith*