### PR TITLE
Fix HCL syntax error in home-assistant Nomad job definition

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -61,7 +61,7 @@ job "home-assistant" {
     task "home-assistant" {
       driver = "docker"
 
-      config {
+      config = {
         image = "homeassistant/home-assistant:stable"
         {% if not use_host_network | default(false) %}
         ports = ["http"]
@@ -73,7 +73,7 @@ job "home-assistant" {
         ]
 
         # Docker logging driver options — ensures rotation if supported
-        logging {
+        logging = {
           type = "json-file"
           config = {
             "max-size" = "15m"


### PR DESCRIPTION
- Change `config {` to `config = {` and `logging {` to `logging = {` in `ansible/roles/home_assistant/templates/home_assistant.nomad.j2` to comply with Nomad HCL2 requirements for nested structures that use quoted argument names.