### PR TITLE
Fix HCL2 parsing error in home-assistant.nomad.j2

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -61,7 +61,7 @@ job "home-assistant" {
     task "home-assistant" {
       driver = "docker"
 
-      config = {
+      config {
         image = "homeassistant/home-assistant:stable"
         {% if not use_host_network | default(false) %}
         ports = ["http"]
@@ -73,11 +73,11 @@ job "home-assistant" {
         ]
 
         # Docker logging driver options — ensures rotation if supported
-        logging = {
+        logging {
           type = "json-file"
-          config = {
-            "max-size" = "15m"
-            "max-file" = "5"
+          config {
+            max-size = "15m"
+            max-file = "5"
           }
         }
 


### PR DESCRIPTION
Fix HCL2 parsing error in home-assistant.nomad.j2

- Convert HCL1 map-assignments (`= {`) for `config` and `logging` into proper HCL2 nested blocks (`{`).
- Remove quoted argument names inside the nested Docker `logging` block configurations since Nomad HCL2 parser strictly rejects quoted keys in a block context.

---
*PR created automatically by Jules for task [5057635256576616432](https://jules.google.com/task/5057635256576616432) started by @LokiMetaSmith*