### PR TITLE
Fix Nomad HCL parsing error for home-assistant logging config

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -75,9 +75,9 @@ job "home-assistant" {
         # Docker logging driver options — ensures rotation if supported
         logging {
           type = "json-file"
-          config {
-            max-size = "15m"
-            max-file = "5"
+          config = {
+            "max-size" = "15m"
+            "max-file" = "5"
           }
         }
 


### PR DESCRIPTION
Fixes the `Invalid argument name; Argument names must not be quoted.` error during the home-assistant Nomad job execution. By changing the `logging` object's `config` to be a map assignment with an equals sign instead of a raw block, HCL correctly parses the quoted, hyphenated keys like `"max-size"`.

---
*PR created automatically by Jules for task [2496762511320521158](https://jules.google.com/task/2496762511320521158) started by @LokiMetaSmith*