### PR TITLE
Fix file editor pagination feedback

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -161,7 +161,7 @@ These structural suggestions are targeted for a future major release to signific
 - [x] **Implement Claude Code CLI Techniques:** Review `docs/analysis/CLAUDE_CODE_ANALYSIS.md` and implement the recommended techniques in `pipecatapp/tools/`:
   - Format Zod/Pydantic validation errors for LLMs.
   - Add robust ripgrep fallback (EAGAIN handling) to `shell_tool.py`.
-  - Add transparent pagination feedback (e.g. `[Showing results with pagination...]`).
+  - [x] Add transparent pagination feedback (e.g. `[Showing results with pagination...]`).
   - Implement single-pass read with metadata extraction (encoding, line endings) for file editors.
   - Implement `LRUCache` for file state to optimize `RAG_Tool` and `DocumentTool`.
   - Integrate dynamic "thinking" feature support detection based on model string.

--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -75,9 +75,9 @@ job "home-assistant" {
         # Docker logging driver options — ensures rotation if supported
         logging {
           type = "json-file"
-          config = {
-            "max-size" = "15m"
-            "max-file" = "5"
+          config {
+            max-size = "15m"
+            max-file = "5"
           }
         }
 

--- a/pipecatapp/tools/file_editor_tool.py
+++ b/pipecatapp/tools/file_editor_tool.py
@@ -262,7 +262,7 @@ class FileEditorTool:
 
             # Transparent Pagination Feedback
             if view_range and isinstance(view_range, list) and len(view_range) == 2:
-                if end_idx < len(lines):
+                if end_idx < len(lines) or start_idx > 0:
                      result_str += f"\n[Showing results with pagination = limit: {end_idx - start_idx}, offset: {start_idx}]"
 
             return result_str

--- a/tests/unit/test_file_editor_tool.py
+++ b/tests/unit/test_file_editor_tool.py
@@ -19,6 +19,15 @@ class TestFileEditorTool(unittest.TestCase):
         content = self.tool.read_file("test.txt")
         self.assertEqual(content, "Hello\nWorld")
 
+    def test_read_file_pagination(self):
+        self.tool.write_file("test_pag.txt", "1\n2\n3\n4\n5")
+        content1 = self.tool.read_file("test_pag.txt", view_range=[2, 4])
+        self.assertIn("Showing results with pagination", content1)
+        content2 = self.tool.read_file("test_pag.txt", view_range=[1, 4])
+        self.assertIn("Showing results with pagination", content2)
+        content3 = self.tool.read_file("test_pag.txt", view_range=[2, 5])
+        self.assertIn("Showing results with pagination", content3)
+
     def test_write_file(self):
         result = self.tool.write_file("new.txt", "New Content")
         self.assertIn("Successfully wrote", result)


### PR DESCRIPTION
- Fixed file editor pagination feedback to trigger when `start_idx > 0` or `end_idx < len(lines)`.
- Added unit tests for file editor pagination.
- Checked off the "Add transparent pagination feedback" task in `TODO.md`.
- Fixed an HCL2 parsing error in `ansible/roles/home_assistant/templates/home_assistant.nomad.j2` caused by quoted keys inside a block.

---
*PR created automatically by Jules for task [1695146020733137517](https://jules.google.com/task/1695146020733137517) started by @LokiMetaSmith*