### PR TITLE
feat: implement ModelCapabilitiesRegistry for dynamic reasoning effort

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -164,7 +164,7 @@ These structural suggestions are targeted for a future major release to signific
   - [x] Add transparent pagination feedback (e.g. `[Showing results with pagination...]`).
   - Implement single-pass read with metadata extraction (encoding, line endings) for file editors.
   - Implement `LRUCache` for file state to optimize `RAG_Tool` and `DocumentTool`.
-  - Integrate dynamic "thinking" feature support detection based on model string.
+  - [x] Integrate dynamic "thinking" feature support detection based on model string.
 - [x] **Expand the Model Collection:** Systematically test and add the remaining LiquidAI nano models to `group_vars/models.yaml`.
 - [x] **Security Hardening:**
   - [x] **Remove passwordless sudo:** Modify the sudoers file configuration to require a password for the `target_user`.

--- a/pipecatapp/workflow/nodes/llm_nodes.py
+++ b/pipecatapp/workflow/nodes/llm_nodes.py
@@ -530,6 +530,26 @@ class DynamicRouterNode(Node):
             if route != decision:
                 self.set_output(context, route, None)
 
+
+class ModelCapabilitiesRegistry:
+    """
+    A registry mapping model families to specific capabilities and features.
+    """
+    _registry = {
+        "claude-3-7-sonnet": {"supports_reasoning_effort": True},
+        "o1": {"supports_reasoning_effort": True},
+        "o3": {"supports_reasoning_effort": True},
+        "deepseek-reasoner": {"supports_reasoning_effort": True},
+    }
+
+    @classmethod
+    def get_capabilities(cls, model_name: str) -> dict:
+        capabilities = {}
+        for key, value in cls._registry.items():
+            if key in model_name.lower():
+                capabilities.update(value)
+        return capabilities
+
 @registry.register
 class LLMRouterNode(Node):
     """
@@ -596,6 +616,11 @@ class LLMRouterNode(Node):
                             "messages": [{"role": "user", "content": query}],
                             "temperature": 0.7
                         }
+
+                        # Dynamically inject feature flags like reasoning effort
+                        caps = ModelCapabilitiesRegistry.get_capabilities(selected_model)
+                        if caps.get("supports_reasoning_effort"):
+                            payload["reasoning_effort"] = "medium"
 
                         chat_url = f"{base_url}/chat/completions"
                         llm_res = await client.post(chat_url, json=payload, timeout=120)


### PR DESCRIPTION
Implements dynamic "thinking" feature support detection based on the routed model string.

Replaces hardcoded string checks or lack of reasoning parameter injection with a cleaner `ModelCapabilitiesRegistry` pattern. `LLMRouterNode` now consults this registry before calling the LLM and injects `reasoning_effort: "medium"` if the routed model supports it.

Fixes part of the Claude Code CLI Techniques in TODO.md.

---
*PR created automatically by Jules for task [13588757313548877573](https://jules.google.com/task/13588757313548877573) started by @LokiMetaSmith*