### PR TITLE
Add Python unit tests to pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -31,5 +31,14 @@ if git diff --cached --name-only | grep -q "bootstrap.sh"; then
     }
 fi
 
+# We run unit tests if any Python files are staged
+if git diff --cached --name-only | grep -q "\.py$"; then
+    echo "Python files changed. Running unit tests..."
+    ./scripts/run_tests.sh --unit || {
+        echo "Error: Unit tests failed. Please fix them before committing."
+        exit 1
+    }
+fi
+
 echo "Pre-commit safety check passed."
 exit 0


### PR DESCRIPTION
Added a check in `.githooks/pre-commit` to execute the Python test suite if any `.py` files are modified, preventing commits that break unit tests.

---
*PR created automatically by Jules for task [12402449545566998280](https://jules.google.com/task/12402449545566998280) started by @LokiMetaSmith*