### PR TITLE
fix: use vfs storage driver to fix home assistant overlayfs issue

### DIFF
--- a/ansible/roles/docker/templates/daemon.json.j2
+++ b/ansible/roles/docker/templates/daemon.json.j2
@@ -7,5 +7,6 @@
   "insecure-registries": [
     "localhost:{{ docker_registry_port | default(5001) }}",
     "{{ docker_registry_host }}:{{ docker_registry_port | default(5001) }}"
-  ]
+  ],
+  "storage-driver": "vfs"
 }

--- a/playbooks/diagnose_and_log_home_assistant.yaml
+++ b/playbooks/diagnose_and_log_home_assistant.yaml
@@ -8,7 +8,7 @@
       ansible.builtin.lineinfile:
         create: yes
         path: "{{ log_file }}"
-        line: "--- Diagnostic run for Home Assistant at {{ ansible_facts['date_time']['iso8661'] }} ---"
+        line: "--- Diagnostic run for Home Assistant at {{ ansible_facts['date_time']['iso8601'] }} ---"
         mode: '0644'
 
     - name: Check Nomad job status


### PR DESCRIPTION
Fixes the deployment failure of the Home Assistant docker container where it could not start due to an `operation not permitted` extraction error on whiteout files. This was caused by Docker's new `overlayfs` driver on certain kernels failing to extract the HA image layers. The fix explicitly configures Docker to use the `vfs` storage driver.

---
*PR created automatically by Jules for task [1807145739209436983](https://jules.google.com/task/1807145739209436983) started by @LokiMetaSmith*