### PR TITLE
fix: Remove ha-config from root ownership loop in nomad role

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -182,7 +182,6 @@
     recurse: yes
   loop:
     - mqtt-data
-    - ha-config
     - world_model_storage
     - postgres_data
     - memory-data


### PR DESCRIPTION
The `ha-config` directory was previously being created in a generic volume creation loop within the `nomad` role which set the ownership to `root:root` and permissions to `0755`. This overwrote the permissions set by the `home_assistant` role (`568:568` and `0775`), causing the Home Assistant container to fail to start because it couldn't write to its own config directory.

This commit removes `ha-config` from the `nomad` role's loop, allowing the `home_assistant` role to have exclusive control over its permissions.

---
*PR created automatically by Jules for task [5453020596853509077](https://jules.google.com/task/5453020596853509077) started by @LokiMetaSmith*