### PR TITLE
fix: Prevent recursive root ownership assignment in nomad volumes dir…

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -169,7 +169,7 @@
     owner: "root"
     group: "root"
     mode: '0755'
-    recurse: yes
+    recurse: no
   become: yes
 
 - name: Create subdirectories for Nomad volumes


### PR DESCRIPTION
…ectory

The `Create Nomad volumes directory before service setup` task in the `nomad` role was previously set to `recurse: yes` when creating the `/opt/nomad/volumes` directory as `root:root`. This was continuously overwriting the ownership of all subdirectories, including `ha-config` (which needs `568:568`) and `mqtt-data` (which needs `1883:1883`), every time the playbook was run.

This commit updates the task to `recurse: no` to ensure it only manages the top-level `/opt/nomad/volumes` directory, allowing individual service roles to manage their own subdirectory permissions.