### PR TITLE
fix: Resolve home assistant parsing and permission issues

### DIFF
--- a/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
+++ b/ansible/roles/home_assistant/templates/home_assistant.nomad.j2
@@ -72,15 +72,6 @@ job "home-assistant" {
           "/etc/localtime:/etc/localtime:ro",
         ]
 
-        # Docker logging driver options — ensures rotation if supported
-        logging {
-          type = "json-file"
-          config {
-            max_size = "15m"
-            max_file = "5"
-          }
-        }
-
         # Keep container capabilities required for some network features (as you had)
         cap_add = ["NET_RAW", "NET_ADMIN"]
       }


### PR DESCRIPTION
1. Removed the redundant `logging` block entirely from `home_assistant.nomad.j2` because Docker is configured with log-opts globally anyway, preventing infinite HCL parsing headaches.
2. Updated the `Create Nomad volumes directory before service setup` task in `ansible/roles/nomad/tasks/main.yaml` to `recurse: no` so it doesn't repeatedly overwrite the ownership of `/opt/nomad/volumes/ha-config` back to `root:root`.