### PR TITLE
feat: Implement Remote Ledgers peer-to-peer sync in Memory Service

### DIFF
--- a/ansible/roles/memory_service/files/app.py
+++ b/ansible/roles/memory_service/files/app.py
@@ -7,6 +7,71 @@ import uvicorn
 
 app = FastAPI()
 
+import asyncio
+import httpx
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def background_sync_task():
+    """Periodically syncs work items with remote ledgers."""
+    remote_ledgers_env = os.getenv("REMOTE_LEDGERS", "")
+    if not remote_ledgers_env:
+        return
+
+    remote_urls = [url.strip() for url in remote_ledgers_env.split(",") if url.strip()]
+    if not remote_urls:
+        return
+
+    logger.info(f"Starting background sync task with remote ledgers: {remote_urls}")
+    last_local_sync_time = 0.0
+    remote_sync_times = {url: 0.0 for url in remote_urls}
+
+    while True:
+        try:
+            # 1. Get local items updated since last sync to push out
+            local_items = await memory.get_work_items_since(last_local_sync_time)
+
+            if local_items:
+                last_local_sync_time = max(item['updated_at'] for item in local_items)
+
+            for remote_url in remote_urls:
+                # 2. Push local updates to remote
+                if local_items:
+                    try:
+                        async with httpx.AsyncClient() as client:
+                            resp = await client.post(f"{remote_url}/work_items/sync", json=local_items)
+                            resp.raise_for_status()
+                    except Exception as e:
+                        logger.error(f"Failed to push to {remote_url}: {e}")
+
+                # 3. Pull remote updates
+                try:
+                    async with httpx.AsyncClient() as client:
+                        resp = await client.get(f"{remote_url}/work_items/sync", params={"since": remote_sync_times[remote_url]})
+                        resp.raise_for_status()
+                        remote_items = resp.json()
+                        if remote_items:
+                            await memory.sync_work_items(remote_items)
+                            remote_sync_times[remote_url] = max(item['updated_at'] for item in remote_items)
+                            # Also update last_local_sync_time so we don't push these back immediately
+                            # (though pushing back is idempotent if timestamps match, it saves bandwidth)
+                            last_local_sync_time = max(last_local_sync_time, remote_sync_times[remote_url])
+                except Exception as e:
+                    logger.error(f"Failed to pull from {remote_url}: {e}")
+
+        except Exception as e:
+            logger.error(f"Error in background sync task: {e}")
+
+        await asyncio.sleep(30) # Sync every 30 seconds
+
+@app.on_event("startup")
+async def startup_event():
+    asyncio.create_task(background_sync_task())
+
+
+
 # Initialize PMMMemory with a persistent path
 # In Nomad, this should be a mounted volume
 DB_PATH = os.getenv("MEMORY_DB_PATH", "/data/pmm_memory.db")
@@ -114,6 +179,23 @@ async def update_work_item(item_id: str, update: WorkItemUpdate):
         return {"status": "success"}
     except HTTPException:
         raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/work_items/sync")
+async def get_work_items_sync(since: float = 0.0):
+    try:
+        items = await memory.get_work_items_since(since)
+        return items
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/work_items/sync")
+async def post_work_items_sync(items: List[Dict[str, Any]]):
+    try:
+        merged = await memory.sync_work_items(items)
+        return {"status": "success", "merged_count": len(merged)}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/ansible/roles/memory_service/files/pmm_memory.py
+++ b/ansible/roles/memory_service/files/pmm_memory.py
@@ -332,6 +332,68 @@ class PMMMemory:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self.list_work_items_sync, status, assignee_id, limit)
 
+
+    def sync_work_items_sync(self, remote_items: List[Dict]) -> List[Dict]:
+        """Merges remote work items into the local ledger, resolving conflicts by updated_at."""
+        cursor = self.conn.cursor()
+        merged_items = []
+
+        for r_item in remote_items:
+            cursor.execute("SELECT updated_at FROM work_items WHERE id = ?", (r_item['id'],))
+            l_row = cursor.fetchone()
+
+            should_update = False
+            if not l_row:
+                # Insert
+                should_update = True
+                cursor.execute("""
+                    INSERT INTO work_items (id, title, status, assignee_id, created_by, created_at, updated_at, parent_id, meta, validation_results)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, (
+                    r_item['id'], r_item['title'], r_item['status'], r_item.get('assignee_id'), r_item['created_by'],
+                    r_item['created_at'], r_item['updated_at'], r_item.get('parent_id'),
+                    json.dumps(r_item.get('meta', {})), json.dumps(r_item.get('validation_results', {}))
+                ))
+            elif r_item['updated_at'] > l_row[0]:
+                # Update
+                should_update = True
+                cursor.execute("""
+                    UPDATE work_items
+                    SET title = ?, status = ?, assignee_id = ?, updated_at = ?, parent_id = ?, meta = ?, validation_results = ?
+                    WHERE id = ?
+                """, (
+                    r_item['title'], r_item['status'], r_item.get('assignee_id'), r_item['updated_at'],
+                    r_item.get('parent_id'), json.dumps(r_item.get('meta', {})),
+                    json.dumps(r_item.get('validation_results', {})), r_item['id']
+                ))
+
+            if should_update:
+                merged_items.append(r_item)
+
+        self.conn.commit()
+        return merged_items
+
+    async def sync_work_items(self, remote_items: List[Dict]) -> List[Dict]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.sync_work_items_sync, remote_items)
+
+    def get_work_items_since_sync(self, since_timestamp: float) -> List[Dict]:
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM work_items WHERE updated_at > ?", (since_timestamp,))
+        rows = cursor.fetchall()
+        columns = [description[0] for description in cursor.description]
+        items = []
+        for row in rows:
+            item = dict(zip(columns, row))
+            item['meta'] = json.loads(item['meta']) if item['meta'] else {}
+            item['validation_results'] = json.loads(item['validation_results']) if item['validation_results'] else {}
+            items.append(item)
+        return items
+
+    async def get_work_items_since(self, since_timestamp: float) -> List[Dict]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.get_work_items_since_sync, since_timestamp)
+
     def get_agent_stats_sync(self, assignee_id: str) -> Dict[str, Any]:
         """Aggregates work statistics for a specific agent."""
         cursor = self.conn.cursor()

--- a/docs/manual/GASTOWN_TODO.md
+++ b/docs/manual/GASTOWN_TODO.md
@@ -31,4 +31,4 @@ This roadmap tracks the adaptation of Gas Town concepts (Work Ledger, Attributio
 
 ## Phase 5: Federation (Future)
 
-- [ ] **Remote Ledgers:** Investigate syncing work items across multiple Memory Service instances.
+- [x] **Remote Ledgers:** Investigate syncing work items across multiple Memory Service instances.

--- a/pipecatapp/pmm_memory.py
+++ b/pipecatapp/pmm_memory.py
@@ -332,6 +332,68 @@ class PMMMemory:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self.list_work_items_sync, status, assignee_id, limit)
 
+
+    def sync_work_items_sync(self, remote_items: List[Dict]) -> List[Dict]:
+        """Merges remote work items into the local ledger, resolving conflicts by updated_at."""
+        cursor = self.conn.cursor()
+        merged_items = []
+
+        for r_item in remote_items:
+            cursor.execute("SELECT updated_at FROM work_items WHERE id = ?", (r_item['id'],))
+            l_row = cursor.fetchone()
+
+            should_update = False
+            if not l_row:
+                # Insert
+                should_update = True
+                cursor.execute("""
+                    INSERT INTO work_items (id, title, status, assignee_id, created_by, created_at, updated_at, parent_id, meta, validation_results)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, (
+                    r_item['id'], r_item['title'], r_item['status'], r_item.get('assignee_id'), r_item['created_by'],
+                    r_item['created_at'], r_item['updated_at'], r_item.get('parent_id'),
+                    json.dumps(r_item.get('meta', {})), json.dumps(r_item.get('validation_results', {}))
+                ))
+            elif r_item['updated_at'] > l_row[0]:
+                # Update
+                should_update = True
+                cursor.execute("""
+                    UPDATE work_items
+                    SET title = ?, status = ?, assignee_id = ?, updated_at = ?, parent_id = ?, meta = ?, validation_results = ?
+                    WHERE id = ?
+                """, (
+                    r_item['title'], r_item['status'], r_item.get('assignee_id'), r_item['updated_at'],
+                    r_item.get('parent_id'), json.dumps(r_item.get('meta', {})),
+                    json.dumps(r_item.get('validation_results', {})), r_item['id']
+                ))
+
+            if should_update:
+                merged_items.append(r_item)
+
+        self.conn.commit()
+        return merged_items
+
+    async def sync_work_items(self, remote_items: List[Dict]) -> List[Dict]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.sync_work_items_sync, remote_items)
+
+    def get_work_items_since_sync(self, since_timestamp: float) -> List[Dict]:
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM work_items WHERE updated_at > ?", (since_timestamp,))
+        rows = cursor.fetchall()
+        columns = [description[0] for description in cursor.description]
+        items = []
+        for row in rows:
+            item = dict(zip(columns, row))
+            item['meta'] = json.loads(item['meta']) if item['meta'] else {}
+            item['validation_results'] = json.loads(item['validation_results']) if item['validation_results'] else {}
+            items.append(item)
+        return items
+
+    async def get_work_items_since(self, since_timestamp: float) -> List[Dict]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.get_work_items_since_sync, since_timestamp)
+
     def get_agent_stats_sync(self, assignee_id: str) -> Dict[str, Any]:
         """Aggregates work statistics for a specific agent."""
         cursor = self.conn.cursor()

--- a/pipecatapp/pmm_memory_client.py
+++ b/pipecatapp/pmm_memory_client.py
@@ -209,3 +209,48 @@ class PMMMemoryClient:
     def close(self):
         """No-op for HTTP client, but kept for interface compatibility."""
         pass
+
+
+    def get_work_items_since_sync(self, since: float = 0.0) -> List[Dict]:
+        url = f"{self.base_url}/work_items/sync"
+        try:
+            with httpx.Client() as client:
+                resp = client.get(url, params={"since": since})
+                resp.raise_for_status()
+                return resp.json()
+        except Exception as e:
+            self.logger.error(f"Failed to fetch work items since {since}: {e}")
+            return []
+
+    async def get_work_items_since(self, since: float = 0.0) -> List[Dict]:
+        url = f"{self.base_url}/work_items/sync"
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(url, params={"since": since})
+                resp.raise_for_status()
+                return resp.json()
+        except Exception as e:
+            self.logger.error(f"Failed to fetch work items since {since}: {e}")
+            return []
+
+    def push_work_items_sync(self, items: List[Dict]) -> bool:
+        url = f"{self.base_url}/work_items/sync"
+        try:
+            with httpx.Client() as client:
+                resp = client.post(url, json=items)
+                resp.raise_for_status()
+                return True
+        except Exception as e:
+            self.logger.error(f"Failed to push work items: {e}")
+            return False
+
+    async def push_work_items(self, items: List[Dict]) -> bool:
+        url = f"{self.base_url}/work_items/sync"
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(url, json=items)
+                resp.raise_for_status()
+                return True
+        except Exception as e:
+            self.logger.error(f"Failed to push work items: {e}")
+            return False

--- a/tests/unit/test_remote_ledgers.py
+++ b/tests/unit/test_remote_ledgers.py
@@ -1,0 +1,107 @@
+import pytest
+import time
+import json
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
+
+# Assuming pipecatapp is in PYTHONPATH
+from pipecatapp.pmm_memory import PMMMemory
+from pipecatapp.pmm_memory_client import PMMMemoryClient
+
+@pytest.fixture
+def memory_db(tmp_path):
+    db_path = tmp_path / "test_memory.db"
+    mem = PMMMemory(db_path=str(db_path))
+    yield mem
+    mem.close()
+
+def test_merge_logic(memory_db):
+    """Test the PMMMemory.sync_work_items_sync logic"""
+    # 1. Create a local item
+    t1 = time.time()
+    local_id = memory_db.create_work_item_sync(title="Local Item", created_by="user1")
+
+    local_item = memory_db.get_work_item_sync(local_id)
+    assert local_item is not None
+
+    # 2. Sync a remote item that is NEW
+    t2 = t1 + 10
+    remote_new_item = {
+        "id": "remote_id_1",
+        "title": "Remote Item",
+        "status": "open",
+        "assignee_id": None,
+        "created_by": "user2",
+        "created_at": t2,
+        "updated_at": t2,
+        "parent_id": None,
+        "meta": {"remote": True},
+        "validation_results": {}
+    }
+
+    merged = memory_db.sync_work_items_sync([remote_new_item])
+    assert len(merged) == 1
+
+    fetched_remote = memory_db.get_work_item_sync("remote_id_1")
+    assert fetched_remote is not None
+    assert fetched_remote["title"] == "Remote Item"
+
+    # 3. Sync an update to the local item
+    t3 = t1 + 20
+    remote_update_local = dict(local_item)
+    remote_update_local["status"] = "in_progress"
+    remote_update_local["updated_at"] = t3
+
+    merged = memory_db.sync_work_items_sync([remote_update_local])
+    assert len(merged) == 1
+
+    fetched_local = memory_db.get_work_item_sync(local_id)
+    assert fetched_local["status"] == "in_progress"
+    assert fetched_local["updated_at"] == t3
+
+    # 4. Sync an OLDER update to the local item (should be ignored)
+    t4 = t1 + 5
+    stale_update = dict(local_item)
+    stale_update["status"] = "done"
+    stale_update["updated_at"] = t4
+
+    merged = memory_db.sync_work_items_sync([stale_update])
+    assert len(merged) == 0  # Should not be updated
+
+    fetched_local_again = memory_db.get_work_item_sync(local_id)
+    assert fetched_local_again["status"] == "in_progress"  # Still in progress
+
+
+
+
+
+from unittest.mock import AsyncMock
+
+@pytest.mark.asyncio
+async def test_client_push_pull():
+    client = PMMMemoryClient(base_url="http://fake-url:8000")
+
+    with patch("httpx.AsyncClient") as MockClient:
+        mock_client_instance = MockClient.return_value
+        mock_client_instance.__aenter__.return_value = mock_client_instance
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [{"id": "item1"}]
+        mock_resp.raise_for_status.return_value = None
+
+        async def mock_get(*args, **kwargs):
+            return mock_resp
+
+        mock_client_instance.get = mock_get
+
+        items = await client.get_work_items_since(0.0)
+        assert len(items) == 1
+        assert items[0]["id"] == "item1"
+
+        async def mock_post(*args, **kwargs):
+            return mock_resp
+
+        mock_client_instance.post = mock_post
+
+        success = await client.push_work_items([{"id": "item1"}])
+        assert success is True


### PR DESCRIPTION
This PR implements the "Remote Ledgers" TODO item from Gas Town by adding peer-to-peer synchronization capabilities to the Memory Service. Work items are now synced symmetrically across multiple instances utilizing their `updated_at` timestamps for conflict resolution.

---
*PR created automatically by Jules for task [8732359532087793738](https://jules.google.com/task/8732359532087793738) started by @LokiMetaSmith*