### PR TITLE
fix: properly deactivate deleted venv before recreating in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -605,6 +605,14 @@ VENV_DIR="$SCRIPT_DIR/.venv"
 # shellcheck disable=SC2317
 setup_venv() {
     if [ ! -d "$VENV_DIR" ]; then
+        # If a virtual environment is active but the directory is gone, deactivate it
+        if [ -n "$VIRTUAL_ENV" ]; then
+            if type deactivate >/dev/null 2>&1; then
+                deactivate
+            fi
+            # Clear hashed executable paths (like python3)
+            hash -r 2>/dev/null || true
+        fi
         python3 -m venv "$VENV_DIR"
     fi
 }


### PR DESCRIPTION
Fixes an issue where `bootstrap.sh` fails to recreate a Python virtual environment after the repository is cleaned (e.g. via `--system-cleanup`).

When the `.venv` directory is deleted but the environment remains active in the current Bash session, the script previously failed because `python3` resolved to the deleted path due to Bash caching. This commit adds logic to `setup_venv()` to detect this state, `deactivate` the ghost environment, and run `hash -r` to clear the cache before recreating the environment.

---
*PR created automatically by Jules for task [5190531768411601265](https://jules.google.com/task/5190531768411601265) started by @LokiMetaSmith*