### PR TITLE
Format Pydantic validation errors for LLMs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -159,7 +159,7 @@ These structural suggestions are targeted for a future major release to signific
 - [x] **Add Pre-flight System Health Checks:** Create a new Ansible role to perform non-destructive checks at the beginning of `playbook.yaml`.
 - [x] **Investigate Advanced Power Management:** Research and prototype a more advanced version that uses Wake-on-LAN.
 - [x] **Implement Claude Code CLI Techniques:** Review `docs/analysis/CLAUDE_CODE_ANALYSIS.md` and implement the recommended techniques in `pipecatapp/tools/`:
-  - Format Zod/Pydantic validation errors for LLMs.
+  - [x] Format Zod/Pydantic validation errors for LLMs.
   - Add robust ripgrep fallback (EAGAIN handling) to `shell_tool.py`.
   - [x] Add transparent pagination feedback (e.g. `[Showing results with pagination...]`).
   - Implement single-pass read with metadata extraction (encoding, line endings) for file editors.

--- a/pipecatapp/workflow/nodes/tool_nodes.py
+++ b/pipecatapp/workflow/nodes/tool_nodes.py
@@ -4,6 +4,7 @@ from ..context import WorkflowContext
 from ..crypto_receipts import ToolExecutionSigner
 import json
 import inspect
+from pydantic import create_model, ValidationError
 
 # Global signer instance for the workflow engine
 signer = ToolExecutionSigner()
@@ -123,6 +124,42 @@ class ToolExecutorNode(Node):
             raise ValueError(f"Tool '{tool_name}' not found.")
 
         method = getattr(tool, method_name)
+
+        # Validate arguments using Pydantic
+        sig = inspect.signature(method)
+        fields = {}
+        for param_name, param in sig.parameters.items():
+            if param_name == 'self':
+                continue
+            annotation = param.annotation if param.annotation is not inspect.Parameter.empty else str
+            default = param.default if param.default is not inspect.Parameter.empty else ...
+            fields[param_name] = (annotation, default)
+
+        try:
+            DynamicModel = create_model("DynamicModel", **fields)
+            validated_args = DynamicModel(**args)
+            args = validated_args.model_dump()
+        except ValidationError as e:
+            errors = e.errors()
+            formatted_messages = []
+            for error in errors:
+                loc = ".".join(str(l) for l in error.get("loc", []))
+                msg = error.get("msg", "")
+                err_type = error.get("type", "")
+
+                if err_type == "missing":
+                    formatted_messages.append(f"The required parameter `{loc}` is missing.")
+                elif err_type == "extra_forbidden":
+                    formatted_messages.append(f"An unexpected parameter `{loc}` was provided.")
+                elif "type" in err_type:
+                    formatted_messages.append(f"The parameter `{loc}` has an invalid type: {msg}.")
+                else:
+                    formatted_messages.append(f"Validation error on `{loc}`: {msg}.")
+
+            formatted_error_str = " ".join(formatted_messages)
+            error_result = f"Tool argument validation failed: {formatted_error_str} Please verify the required tool parameters."
+            self.set_output(context, "tool_result", error_result)
+            return
 
         # Re-implement approval logic
         # Security: Enforce mandatory approval for high-risk tools

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -127,8 +127,13 @@ async def test_tool_executor_node(mocker):
     from workflow.nodes.tool_nodes import ToolExecutorNode
 
     # Create a mock tool
-    mock_tool = MagicMock()
-    mock_tool.do_something = MagicMock(return_value="it worked")
+    class MockTool:
+        def do_something(self, foo: str):
+            return "it worked"
+
+    mock_tool = MockTool()
+    # We still want to spy on the method call
+    mocker.spy(mock_tool, 'do_something')
 
     tools = {"my_tool": mock_tool}
     tool_call = {"tool": "my_tool.do_something", "args": {"foo": "bar"}}
@@ -193,8 +198,12 @@ async def test_workflow_tool_loop(mock_registry, mocker):
     runner = WorkflowRunner("dummy/path.yaml")
 
     # Mock the tool
-    mock_dummy_tool = MagicMock()
-    mock_dummy_tool.run = MagicMock(return_value="tool_output")
+    class DummyTool:
+        def run(self):
+            return "tool_output"
+
+    mock_dummy_tool = DummyTool()
+    mocker.spy(mock_dummy_tool, 'run')
 
     # Run with no initial tool result
     await runner.run(global_inputs={"tool_result": None, "tools": {"dummy": mock_dummy_tool}})


### PR DESCRIPTION
Implements a more robust way for the `ToolExecutorNode` to validate arguments using Pydantic, providing clear, LLM-friendly feedback instead of raw JSON schema errors. This solves one of the "Claude Code CLI Techniques" identified in the `TODO.md` backlog. Tests were updated to accommodate the use of `inspect.signature` which fails on bare `MagicMock` objects.

---
*PR created automatically by Jules for task [16358455768320301261](https://jules.google.com/task/16358455768320301261) started by @LokiMetaSmith*