### PR TITLE
Fix diagnostic playbook false positive errors

### DIFF
--- a/playbooks/diagnose_home_assistant.yaml
+++ b/playbooks/diagnose_home_assistant.yaml
@@ -8,6 +8,7 @@
         cmd: "nomad job status home-assistant"
       register: job_status
       changed_when: false
+      failed_when: false
       ignore_errors: yes
       check_mode: no
 

--- a/playbooks/services/tasks/diagnose_home_assistant.yaml
+++ b/playbooks/services/tasks/diagnose_home_assistant.yaml
@@ -15,6 +15,7 @@
     NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   register: mqtt_job_status
   changed_when: false
+  failed_when: false
   ignore_errors: yes
 
 - name: Log MQTT job status
@@ -74,6 +75,7 @@
     NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
   register: job_status
   changed_when: false
+  failed_when: false
   ignore_errors: yes
 
 - name: Log job status


### PR DESCRIPTION
When checking the status of missing Nomad jobs, the `ignore_errors: yes` flag prevented Ansible from aborting but still produced red error traces that confused users and strict CI/CD wrappers. Adding `failed_when: false` properly marks the task as successful, maintaining clean logs and correct playbook flow.

---
*PR created automatically by Jules for task [11751802145885133577](https://jules.google.com/task/11751802145885133577) started by @LokiMetaSmith*