### PR TITLE
feat(litegraph): implement group support for canvas workflows

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -322,7 +322,7 @@ This section tracks actionable ideas derived from the `docs/analysis/FLOWISE_ANA
 - [x] **Introduce a `PostProcessorNode`:** Implement an execution hook or a dedicated node that allows arbitrary Javascript/Python manipulation of the final output dictionary (e.g., reformatting or filtering data) before it is sent back to the client.
 - [ ] **Implement Auto-Layout:** Integrate a library like `dagre.js` to calculate node positions, then apply those `x,y` coordinates to our LiteGraph nodes.
 - [ ] **Enhance Node Metadata:** As noted in `FLOWISE_ANALYSIS.md`, we should build a strong separation between the visual card and the backend execution logic, allowing dynamic UI generation based on Python schema definitions.
-- [ ] **Group Support:** We need to explicitly build "Group" visual boundaries in LiteGraph to support the Obsidian Canvas grouping feature.
+- [x] **Group Support:** We need to explicitly build "Group" visual boundaries in LiteGraph to support the Obsidian Canvas grouping feature.
 
 ## Suggested New Items
 

--- a/pipecatapp/static/js/editor.js
+++ b/pipecatapp/static/js/editor.js
@@ -380,6 +380,28 @@ const WorkflowEditor = {
 
         // 1. Create Nodes
         yamlNodes.forEach(n => {
+            if (n.type === "scope" || n.type === "group") {
+                const group = new LiteGraph.LGraphGroup();
+                group.title = n.id || n.name || "Group";
+
+                if (n.position) {
+                    group.pos = [n.position.x || 0, n.position.y || 0];
+                } else {
+                    group.pos = [Math.random() * 800 + 100, Math.random() * 600 + 100];
+                }
+
+                if (n.dimensions) {
+                    group.size = [n.dimensions.width || 400, n.dimensions.height || 200];
+                }
+
+                if (n.style && n.style.color) {
+                    group.color = n.style.color;
+                }
+
+                this.graph.add(group);
+                return;
+            }
+
             const nodeTypeString = "agent/" + n.type;
             const node = LiteGraph.createNode(nodeTypeString);
 
@@ -405,9 +427,21 @@ const WorkflowEditor = {
                 }
             }
 
-            // Attempt to layout nodes roughly (Auto-layout would be better)
-            // For now, place them randomly or in a grid
-            node.pos = [Math.random() * 800 + 100, Math.random() * 600 + 100];
+            if (n.position) {
+                node.pos = [n.position.x || 0, n.position.y || 0];
+            } else {
+                // Attempt to layout nodes roughly (Auto-layout would be better)
+                // For now, place them randomly or in a grid
+                node.pos = [Math.random() * 800 + 100, Math.random() * 600 + 100];
+            }
+
+            if (n.dimensions) {
+                node.size = [n.dimensions.width || LiteGraph.NODE_WIDTH, n.dimensions.height || LiteGraph.NODE_SLOT_HEIGHT];
+            }
+
+            if (n.style && n.style.color) {
+                node.color = n.style.color;
+            }
 
             this.graph.add(node);
             nodesMap[n.id] = node;
@@ -529,13 +563,51 @@ const WorkflowEditor = {
 
     exportWorkflow: function() {
         const nodes = this.graph._nodes;
+        const groups = this.graph._groups || [];
         const yamlNodes = [];
+
+        // Export groups (scopes)
+        groups.forEach(group => {
+            const yamlNode = {
+                id: group.title || "Group",
+                type: "scope",
+                position: {
+                    x: group._pos[0],
+                    y: group._pos[1],
+                    z: 0
+                },
+                dimensions: {
+                    width: group._size[0],
+                    height: group._size[1],
+                    depth: 0
+                },
+                style: {
+                    color: group.color || "#cccccc",
+                    shape: "box"
+                }
+            };
+            yamlNodes.push(yamlNode);
+        });
 
         nodes.forEach(node => {
             const yamlNode = {
                 id: node.title, // Assuming title is kept as ID
-                type: node.agentNodeType.replace("agent/", "") // Strip prefix
+                type: node.agentNodeType.replace("agent/", ""), // Strip prefix
+                position: {
+                    x: node.pos[0],
+                    y: node.pos[1],
+                    z: 0
+                },
+                dimensions: {
+                    width: node.size[0],
+                    height: node.size[1],
+                    depth: 0
+                }
             };
+
+            if (node.color) {
+                yamlNode.style = { color: node.color };
+            }
 
             // Properties
             for (const key in node.properties) {

--- a/pipecatapp/static/workflow.html
+++ b/pipecatapp/static/workflow.html
@@ -158,6 +158,7 @@
             <div id="toolbar">
                 <button id="save-btn">Save / Deploy</button>
                 <button id="arrange-btn">Auto Arrange</button>
+                <button id="add-group-btn">Add Group</button>
                 <button id="vr-btn" onclick="window.location.href='/static/vr_index.html'" style="background-color: #800080;">Enter VR</button>
                 <span id="status-text" role="status" aria-live="polite">Ready</span>
             </div>
@@ -318,6 +319,27 @@
 
             document.getElementById('arrange-btn').addEventListener('click', () => {
                 WorkflowEditor.autoLayout();
+            });
+
+            document.getElementById('add-group-btn').addEventListener('click', () => {
+                if (!WorkflowEditor.graph || !WorkflowEditor.canvas) return;
+
+                const group = new LiteGraph.LGraphGroup();
+                const canvas = WorkflowEditor.canvas;
+                let x = 400;
+                let y = 300;
+
+                if (canvas.ds) {
+                    const w = canvas.bgcanvas ? canvas.bgcanvas.width : 800;
+                    const h = canvas.bgcanvas ? canvas.bgcanvas.height : 600;
+
+                    x = (-canvas.ds.offset[0] + w / 2) / canvas.ds.scale;
+                    y = (-canvas.ds.offset[1] + h / 2) / canvas.ds.scale;
+                }
+
+                group.pos = [x, y];
+                WorkflowEditor.graph.add(group);
+                showStatus('Added group', 'success');
             });
 
             // Live Polling Logic


### PR DESCRIPTION
Implements Group Support in the visual workflow editor allowing LiteGraph to support grouping.

1.  **Modify Workflow Import in `pipecatapp/static/js/editor.js` (`importWorkflow`):**
    *   Currently, all nodes from the YAML are instantiated using `LiteGraph.createNode("agent/" + n.type)`.
    *   When `n.type` is `"scope"`, we instantiate a `LiteGraph.LGraphGroup()` instead of a regular node.
    *   Set the group's properties (`title` = `n.id`, `pos` = `[n.position.x, n.position.y]`, `size` = `[n.dimensions.width, n.dimensions.height]`, `color` = `n.style.color`).
    *   Add the group to the graph using `this.graph.add(group)`.

2.  **Modify Workflow Export in `pipecatapp/static/js/editor.js` (`exportWorkflow`):**
    *   Currently, it iterates over `this.graph._nodes`. We need to also iterate over `this.graph._groups`.
    *   For each group, create a yaml node with `type: "scope"`, `id: group.title`, `position: {x: group._pos[0], y: group._pos[1], z: 0}`, `dimensions: {width: group._size[0], height: group._size[1], depth: 0}`, and `style: {color: group.color, shape: "box"}`.
    *   Add the group objects to the `yamlNodes` array.

3.  **Update `pipecatapp/static/workflow.html` to allow adding groups:**
    *   Add an "Add Group" button `<button id="add-group-btn">Add Group</button>` to the UI layout near `save-btn` and `arrange-btn`.
    *   Add an event listener for `add-group-btn` that uses `addNodeToCenter` logic to compute the `[x,y]` center of the view, creates `new LiteGraph.LGraphGroup()`, assigns it to `[x,y]`, and calls `WorkflowEditor.graph.add(group);`.

4.  **Update `TODO.md`:**
    *   Mark the item "Group Support: We need to explicitly build "Group" visual boundaries in LiteGraph to support the Obsidian Canvas grouping feature." as complete `[x]`.

---
*PR created automatically by Jules for task [104737001816048476](https://jules.google.com/task/104737001816048476) started by @LokiMetaSmith*