### PR TITLE
Add test-mode to bootstrap to purge app jobs and save memory

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,6 +38,7 @@ show_help() {
     echo "  --deploy-full-stack          Deploy the full application stack (AI agents, models) instead of just infrastructure."
     echo "  --deploy-partial-stack       Deploy a partial application stack (e.g. 4-8B models) for mid-tier worker nodes."
     echo "  --deploy-minimal-stack       Deploy a minimal application stack (e.g. audio, kiosk, status) for low resource nodes."
+    echo "  --test-mode                  Test mode: Purges application jobs after they are deployed to save memory during testing."
     echo "  --continue                   Resume from the last successfully completed playbook."
     echo "  --benchmark                  Run benchmark tests."
     echo "  --deploy-docker              Deploy the pipecat application using Docker (Default)."
@@ -289,6 +290,9 @@ for ((i=0; i<${#ARGS[@]}; i++)); do
             ;;
         --deploy-minimal-stack)
             PROCESSED_ARGS+=("--deploy-minimal-stack")
+            ;;
+        --test-mode)
+            PROCESSED_ARGS+=("--test-mode")
             ;;
         --clean-git|--clean) # Support legacy --clean just in case, but map to clean-git
             DO_CLEAN_GIT=true

--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -237,6 +237,34 @@ def kill_if_running(pattern):
     except Exception as e:
         print_warning(f"Failed to kill process matching '{pattern}': {e}")
 
+def purge_app_jobs_for_test_mode():
+    """Stops and purges non-critical Nomad jobs during test mode."""
+    if not shutil.which("nomad"):
+        print_warning("'nomad' command not found. Cannot purge jobs. Skipping.")
+        return
+
+    try:
+        env = get_nomad_env()
+        cmd = "nomad job status | awk 'NR>1 {print $1}'"
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, env=env)
+        job_ids = result.stdout.strip().split('\n')
+
+        found_jobs = False
+        # Do not purge core infra jobs that subsequent tests might rely on
+        excluded_jobs = ["traefik", "docker-registry", "authentik"]
+
+        for job_id in job_ids:
+            if job_id and job_id != "No" and job_id not in excluded_jobs:
+                found_jobs = True
+                print(f"Stopping and purging app job: {job_id}")
+                subprocess.run(["nomad", "job", "stop", "-purge", job_id],
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
+
+        if not found_jobs:
+            print("No running app jobs found to purge.")
+    except Exception as e:
+        print_error(f"Error purging app jobs: {e}")
+
 def purge_nomad_jobs():
     """Stops and purges all Nomad jobs."""
     if not shutil.which("nomad"):
@@ -634,6 +662,7 @@ def main():
     parser.add_argument("--leave-services-running", action="store_true", help="Don't cleanup Nomad/Consul")
     parser.add_argument("--purge-jobs", action="store_true", help="Purge Nomad jobs (handled by wrapper mostly, but var passed)")
     parser.add_argument("--only-purge", action="store_true", help="Only purge jobs and exit (requires --purge-jobs)")
+    parser.add_argument("--test-mode", action="store_true", help="Test mode: Purges application jobs after they are deployed to save memory during testing.")
     parser.add_argument("--only-status", action="store_true", help="Only print status and exit")
     parser.add_argument("--deploy-docker", action="store_true", help="Deploy via Docker")
     parser.add_argument("--run-local", action="store_true", help="Deploy via raw_exec")
@@ -828,6 +857,20 @@ def main():
         # --- Run ---
         run_playbook(pb_path, extra_vars, args.tags, verbose_level)
         executed_playbooks.append(pb_path)
+
+        # --- Test Mode Purge ---
+        if args.test_mode and os.path.basename(pb_path) in [
+            "monitoring.yaml",
+            "model_services.yaml",
+            "core_ai_services.yaml",
+            "ai_experts.yaml",
+            "training_services.yaml",
+            "distributed_compute.yaml",
+            "streaming_services.yaml",
+            "app_services.yaml"
+        ]:
+            print(f"{Colors.WARNING}🧪 Test Mode: Purging jobs after {os.path.basename(pb_path)} to save memory...{Colors.ENDC}")
+            purge_app_jobs_for_test_mode()
 
         # --- Profiling After ---
         ram_after = get_current_ram_usage()


### PR DESCRIPTION
This implements the user's request to add a feature to the cluster provisioning to run and verify tasks but shut them down immediately after so that the bootstrap can fully test the entire system without running out of memory. 

- Added `--test-mode` to `bootstrap.sh`.
- Added `--test-mode` argument to `scripts/provisioning.py`.
- Added `purge_app_jobs_for_test_mode()` logic in `scripts/provisioning.py` to stop jobs that are not core infrastructure (Traefik, Docker Registry, Authentik) when `--test-mode` is provided and the playbook is an application playbook.

---
*PR created automatically by Jules for task [10552797639595507406](https://jules.google.com/task/10552797639595507406) started by @LokiMetaSmith*