### PR TITLE
Add JulesTool to issue Jules API sessions on crash

### DIFF
--- a/pipecatapp/tools/jules_tool.py
+++ b/pipecatapp/tools/jules_tool.py
@@ -1,0 +1,78 @@
+import os
+import logging
+import httpx
+
+class JulesTool:
+    """A tool for using the Jules REST API to create coding sessions.
+
+    This class interfaces with the Jules API to automate tasks like bug fixing
+    when a crash is detected.
+
+    Attributes:
+        description (str): A brief description of the tool's purpose.
+        name (str): The name of the tool.
+    """
+    def __init__(self, api_key: str = None):
+        """Initializes the JulesTool.
+
+        Args:
+            api_key (str): The Jules API Key. Defaults to JULES_API_KEY env var.
+        """
+        self.description = "Delegate tasks and report crashes to the Jules autonomous AI coding agent."
+        self.name = "jules"
+        self.api_key = api_key or os.getenv("JULES_API_KEY")
+        self.base_url = "https://jules.googleapis.com/v1alpha"
+
+    async def run(self, prompt: str, source: str, title: str = None, automation_mode: str = None) -> str:
+        """Runs a task using the Jules agent by creating a new session.
+
+        Args:
+            prompt (str): The task description or crash logs.
+            source (str): The source context (e.g., 'sources/github/bobalover/boba').
+            title (str, optional): The title for the session.
+            automation_mode (str, optional): Automation mode (e.g., 'AUTO_CREATE_PR').
+
+        Returns:
+            str: The result of the task execution (session details or error).
+        """
+        if not self.api_key:
+             return "Error: JULES_API_KEY not configured."
+
+        url = f"{self.base_url}/sessions"
+
+        headers = {
+            "Content-Type": "application/json",
+            "x-goog-api-key": self.api_key
+        }
+
+        payload = {
+            "prompt": prompt,
+            "sourceContext": {
+                "source": source
+            }
+        }
+
+        if title:
+            payload["title"] = title
+
+        if automation_mode:
+            payload["automationMode"] = automation_mode
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(url, headers=headers, json=payload, timeout=30.0)
+                response.raise_for_status()
+
+                data = response.json()
+                session_name = data.get("name")
+                session_id = data.get("id")
+
+                logging.info(f"Created Jules session: {session_id}")
+                return f"Jules session created successfully. Session ID: {session_id}. Session Name: {session_name}"
+
+        except httpx.HTTPStatusError as e:
+            logging.error(f"HTTP error creating Jules session: {e.response.text}")
+            return f"Error creating Jules session: HTTP {e.response.status_code} - {e.response.text}"
+        except Exception as e:
+            logging.error(f"Error executing Jules task: {e}")
+            return f"Error executing Jules task: {e}"

--- a/tests/unit/test_jules_tool.py
+++ b/tests/unit/test_jules_tool.py
@@ -1,0 +1,103 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+import httpx
+
+from pipecatapp.tools.jules_tool import JulesTool
+
+class TestJulesTool(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.api_key = "test_api_key"
+        self.tool = JulesTool(api_key=self.api_key)
+        self.prompt = "Fix the crash in the main loop"
+        self.source = "sources/github/bobalover/boba"
+        self.title = "Fix crash"
+
+    async def test_run_success(self):
+        # Mock httpx.AsyncClient and its post method
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "sessions/12345",
+            "id": "12345",
+            "title": self.title,
+            "sourceContext": {
+                "source": self.source
+            },
+            "prompt": self.prompt
+        }
+        mock_response.raise_for_status.return_value = None
+
+        mock_post = AsyncMock(return_value=mock_response)
+
+        # We need to mock the context manager of AsyncClient
+        mock_client = MagicMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+
+        with patch('httpx.AsyncClient', return_value=mock_client):
+            result = await self.tool.run(self.prompt, self.source, self.title)
+
+        self.assertIn("Jules session created successfully", result)
+        self.assertIn("Session ID: 12345", result)
+        self.assertIn("Session Name: sessions/12345", result)
+
+        # Verify POST was called with correct args
+        mock_post.assert_called_once_with(
+            "https://jules.googleapis.com/v1alpha/sessions",
+            headers={
+                "Content-Type": "application/json",
+                "x-goog-api-key": self.api_key
+            },
+            json={
+                "prompt": self.prompt,
+                "sourceContext": {"source": self.source},
+                "title": self.title
+            },
+            timeout=30.0
+        )
+
+    async def test_run_missing_api_key(self):
+        # Instantiate tool without API key
+        with patch.dict(os.environ, clear=True):
+            tool = JulesTool(api_key=None)
+            result = await tool.run(self.prompt, self.source)
+            self.assertEqual(result, "Error: JULES_API_KEY not configured.")
+
+    async def test_run_http_error(self):
+        # Create a mock exception that httpx would raise
+        mock_request = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = '{"error": "Unauthorized"}'
+
+        http_error = httpx.HTTPStatusError("Unauthorized", request=mock_request, response=mock_response)
+
+        mock_post = AsyncMock(side_effect=http_error)
+
+        mock_client = MagicMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+
+        with patch('httpx.AsyncClient', return_value=mock_client):
+            result = await self.tool.run(self.prompt, self.source)
+
+        self.assertIn("Error creating Jules session: HTTP 401", result)
+        self.assertIn('{"error": "Unauthorized"}', result)
+
+    async def test_run_generic_exception(self):
+        mock_post = AsyncMock(side_effect=Exception("Network failure"))
+
+        mock_client = MagicMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+
+        with patch('httpx.AsyncClient', return_value=mock_client):
+            result = await self.tool.run(self.prompt, self.source)
+
+        self.assertEqual(result, "Error executing Jules task: Network failure")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request implements the new `JulesTool` which allows the system to autonomously issue bug fixing sessions to the Jules AI via its REST API. This handles the requirement to automatically report crashes similarly to how the `OpenCodeTool` works.

- **`pipecatapp/tools/jules_tool.py`**: A new class initialized with an optional `api_key` (defaulting to the `JULES_API_KEY` env var) containing an asynchronous `run` method to invoke `POST https://jules.googleapis.com/v1alpha/sessions`.
- **`tests/unit/test_jules_tool.py`**: Added unit tests leveraging `unittest.mock` to ensure correct HTTP requests are made and that error conditions (like missing API keys or HTTP errors) are handled securely without crashing the application.

---
*PR created automatically by Jules for task [6647809745310425423](https://jules.google.com/task/6647809745310425423) started by @LokiMetaSmith*