### PR TITLE
fix: remove invalid Nomad autopilot config and disable slow nmap scan

### DIFF
--- a/ansible/roles/nomad/templates/nomad.hcl.server.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.server.j2
@@ -21,13 +21,6 @@ server {
   server_join {
     retry_join = ["{{ cluster_ip }}"]
   }
-
-  autopilot {
-    cleanup_dead_servers = true
-    last_contact_threshold = "20s"
-    max_trailing_logs    = 250
-    server_stabilization_time = "10s"
-  }
 }
 
 client {

--- a/ansible/roles/nomad/templates/server.hcl.j2
+++ b/ansible/roles/nomad/templates/server.hcl.j2
@@ -18,13 +18,6 @@ advertise {
 {% if is_controller is defined and is_controller %}
 server {
   enabled = true
-
-  autopilot {
-    cleanup_dead_servers = true
-    last_contact_threshold = "20s"
-    max_trailing_logs    = 250
-    server_stabilization_time = "10s"
-  }
 }
 {% endif %}
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -123,9 +123,6 @@ find_controller() {
     local OVERLAY_FAST_PATH="100.64.0.0/24"
     # Only add OVERLAY_FAST_PATH to array if it is different from OVERLAY_SUBNET to avoid scanning same thing twice
     local SUBNETS_TO_SCAN=("$PXE_SUBNET" "$LOCAL_SUBNET" "$OVERLAY_FAST_PATH")
-    if [ "$OVERLAY_SUBNET" != "$OVERLAY_FAST_PATH" ]; then
-        SUBNETS_TO_SCAN+=("$OVERLAY_SUBNET")
-    fi
 
     spinner() {
         local pid=$1


### PR DESCRIPTION
This PR addresses two critical bootstrapping regressions:

1. **Nomad Agent Crashing:** Removed the unsupported `autopilot` HCL configuration block from the Nomad server templates (`server.hcl.j2`, `nomad.hcl.server.j2`). Recent commits incorrectly attempted to nest it within the `server` block or place it at the top level, causing Nomad to fail to start with the error `server unexpected keys autopilot`.
2. **Bootstrap Script Hanging:** Removed the scanning of the massive `100.64.0.0/10` `OVERLAY_SUBNET` from `bootstrap.sh`. Scanning over 4 million IPs was causing `nmap` to hang and timeout, significantly delaying the cluster bootstrapping process. The script now correctly depends on the `OVERLAY_FAST_PATH` (`/24`) to quickly find the controller.

---
*PR created automatically by Jules for task [3854276398554094639](https://jules.google.com/task/3854276398554094639) started by @LokiMetaSmith*