### PR TITLE
test: enforce strict caching in RAG ops and update TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -165,7 +165,7 @@ These structural suggestions are targeted for a future major release to signific
   - [x] Add transparent pagination feedback (e.g. `[Showing results with pagination...]`).
   - [x] Implement single-pass read with metadata extraction (encoding, line endings) for file editors.
   - [x] Implement `LRUCache` for file state to optimize `RAG_Tool` and `DocumentTool`.
-  - [ ] Evaluate and create a unit test to enforce strict caching across the board to save on disk reads during RAG operations.
+  - [x] Evaluate and create a unit test to enforce strict caching across the board to save on disk reads during RAG operations.
   - [x] Integrate dynamic "thinking" feature support detection based on model string.
 - [x] **Expand the Model Collection:** Systematically test and add the remaining LiquidAI nano models to `group_vars/models.yaml`.
 - [x] **Security Hardening:**

--- a/tests/unit/test_rag_caching.py
+++ b/tests/unit/test_rag_caching.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+
+# Add the path to the pipecatapp directory to resolve imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../pipecatapp')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../pipecatapp/tools')))
+
+from rag_tool import load_document_cached
+import rag_tool
+
+def test_strict_caching():
+    # We want to patch TextLoader in rag_tool namespace so it returns our mock
+    mock_loader_instance = MagicMock()
+    mock_loader_instance.load.return_value = ["mock_doc"]
+
+    mock_loader_class = MagicMock(return_value=mock_loader_instance)
+
+    # We also need to patch os.path.getmtime
+    with patch('rag_tool.os.path.getmtime', return_value=12345.0) as mock_mtime:
+        # We need to monkeypatch the internal TextLoader import since it's imported inside the function
+        import langchain_community.document_loaders
+        with patch('langchain_community.document_loaders.TextLoader', new=mock_loader_class):
+
+            # Clear the LRU cache before starting
+            rag_tool._load_document_cached_internal.cache_clear()
+
+            # First call
+            doc1 = load_document_cached('dummy.txt')
+            assert doc1 == ["mock_doc"]
+            mock_loader_class.assert_called_once_with('dummy.txt', encoding='utf-8')
+
+            # Second call, mtime unchanged
+            doc2 = load_document_cached('dummy.txt')
+            assert doc2 == ["mock_doc"]
+            assert mock_loader_class.call_count == 1 # Should not be called again
+
+            # Third call, mtime changed
+            mock_mtime.return_value = 54321.0
+            doc3 = load_document_cached('dummy.txt')
+            assert doc3 == ["mock_doc"]
+            assert mock_loader_class.call_count == 2 # Called again because mtime changed


### PR DESCRIPTION
This change addresses an item on the `TODO.md` checklist: `[ ] Evaluate and create a unit test to enforce strict caching across the board to save on disk reads during RAG operations.`

It adds `tests/unit/test_rag_caching.py` which mocks the `TextLoader` and `os.path.getmtime` to test the internal `@functools.lru_cache` wrapping the `load_document_cached` method. The test verifies that repeated reads of unchanged files pull from the cache instead of hitting the disk loader, and that files are re-loaded if the modification time updates.

The `TODO.md` file was also updated to reflect the completion of this item.

---
*PR created automatically by Jules for task [1286998539509027060](https://jules.google.com/task/1286998539509027060) started by @LokiMetaSmith*