### PR TITLE
fix(ansible): add missing expert model categories to download_models role

### DIFF
--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -29,9 +29,16 @@
     - coding
     - math
     - extract
+    - rag
+    - tool
+    - thinking
+    - instruct
     - router
     - qwen
     - cynic
+    - gpt-oss
+    - qwen3-5
+    - orthrus
     - vllm_expert_models
     - piper_voice_files
     - embedding_models
@@ -45,7 +52,7 @@
 
 - name: Set model facts from Consul KV
   ansible.builtin.set_fact:
-    llm_models_to_download: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'in', ['main', 'coding', 'math', 'extract', 'router', 'qwen', 'cynic']) | map(attribute='content') | map('from_json') | sum(start=[]) }}"
+    llm_models_to_download: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'in', ['main', 'coding', 'math', 'extract', 'rag', 'tool', 'thinking', 'instruct', 'router', 'qwen', 'cynic', 'gpt-oss', 'qwen3-5', 'orthrus']) | map(attribute='content') | map('from_json') | sum(start=[]) }}"
     vllm_expert_models: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'vllm_expert_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
     piper_voice_files: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'piper_voice_files') | map(attribute='content') | map('from_json') | first | default([]) }}"
     embedding_models: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'embedding_models') | map(attribute='content') | map('from_json') | first | default([]) }}"


### PR DESCRIPTION
The download_models ansible role was missing several expert model categories (rag, tool, thinking, instruct, gpt-oss, qwen3-5, orthrus) from both its initial Consul KV query loop and the `llm_models_to_download` fact filter.

This caused these specific `.gguf` files to silently fail downloading during cluster upbringing, leading to cascading inference and orchestration failures because llama.cpp couldn't locate the required weights. This commit ensures all categories defined in `group_vars/models.yaml` are correctly fetched and installed.

---
*PR created automatically by Jules for task [13686070972333605352](https://jules.google.com/task/13686070972333605352) started by @LokiMetaSmith*