### PR TITLE
Refactor: Extend IPFS distribution to models, static assets, and refe…

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -166,14 +166,14 @@ EOH
       }
 
       artifact {
-        source      = "http://127.0.0.1:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
-        destination = "local/image.tar"
+        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
+        destination = "local/pipecatapp.tar"
         mode        = "file"
       }
 
       config {
         command = "docker"
-        args    = ["load", "-i", "local/image.tar"]
+        args    = ["load", "-i", "local/pipecatapp.tar"]
       }
     }
 

--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -159,6 +159,24 @@ EOH
     }
 
     {% if pipecat_deployment_style | default('docker') == 'docker' %}
+    task "load-image" {
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
+      }
+
+      artifact {
+        source      = "http://127.0.0.1:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
+        destination = "local/image.tar"
+        mode        = "file"
+      }
+
+      config {
+        command = "docker"
+        args    = ["load", "-i", "local/image.tar"]
+      }
+    }
+
     task "{{ job_name }}" {
       driver = "docker"
 
@@ -168,7 +186,7 @@ EOH
       }
 
       config {
-        image = "{{ pipecat_image_id | default('pipecatapp:' ~ (pipecat_image_tag | default('local'))) }}"
+        image = "{{ pipecatapp_image_name | default('pipecatapp') }}:{{ pipecat_versioned_tag | default('local') }}"
         force_pull = false
         ports = ["http"]
         command = "/bin/bash"

--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -166,7 +166,7 @@ EOH
       }
 
       artifact {
-        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
+        source      = "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ pipecatapp_ipfs_cid }}"
         destination = "local/pipecatapp.tar"
         mode        = "file"
       }

--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -1,20 +1,38 @@
-# tasks file for download_models
+---
+# tasks file for download_models (acts as IPFS Consumer on all nodes)
 
-- name: Read Consul management token
+- name: Get Consul token from file
   ansible.builtin.slurp:
-    src: "{{ consul_config_dir | default('/etc/consul.d') }}/management_token"
-  register: consul_token_file
-  become: yes
-  ignore_errors: yes
+    src: /etc/consul.d/management_token
+  register: consul_token_slurp
+  failed_when: false
 
-- name: Set consul_token fact
+- name: Set Consul token fact
   ansible.builtin.set_fact:
-    consul_token: "{{ consul_token_file.content | b64decode | trim }}"
-  when: consul_token_file.content is defined
+    consul_token: "{{ consul_token_slurp.content | b64decode | trim }}"
+  when: consul_token_slurp.content is defined
 
-- name: Query Consul for all model configurations
+- name: Ensure all model directories exist
+  ansible.builtin.file:
+    path: "{{ nomad_models_dir }}/{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+    - llm
+    - vllm
+    - stt
+    - stt/whisper-cpp
+    - stt/faster-whisper
+    - stt/wyoming
+    - tts
+    - vision
+    - embedding
+    - reference_data
+  become: yes
+
+- name: Fetch all IPFS CIDs from Consul KV
   ansible.builtin.uri:
-    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port }}/v1/kv/config/models/{{ item }}?raw=true"
+    url: "http://127.0.0.1:8500/v1/kv/models/ipfs?keys"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
     validate_certs: false
@@ -24,253 +42,36 @@
     status_code: [200, 404]
     return_content: true
   check_mode: no
-  loop:
-    - main
-    - coding
-    - math
-    - extract
-    - rag
-    - tool
-    - thinking
-    - instruct
-    - router
-    - qwen
-    - cynic
-    - gpt-oss
-    - qwen3-5
-    - orthrus
-    - vllm_expert_models
-    - piper_voice_files
-    - embedding_models
-    - stt_models
-    - vision_models
-  register: consul_models
-  until: consul_models.status in [200, 404]
+  register: consul_ipfs_keys
+  until: consul_ipfs_keys.status in [200, 404]
   retries: 5
   delay: 2
   failed_when: false
 
-- name: Set model facts from Consul KV
-  ansible.builtin.set_fact:
-    llm_models_to_download: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'in', ['main', 'coding', 'math', 'extract', 'rag', 'tool', 'thinking', 'instruct', 'router', 'qwen', 'cynic', 'gpt-oss', 'qwen3-5', 'orthrus']) | map(attribute='content') | map('from_json') | sum(start=[]) }}"
-    vllm_expert_models: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'vllm_expert_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
-    piper_voice_files: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'piper_voice_files') | map(attribute='content') | map('from_json') | first | default([]) }}"
-    embedding_models: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'embedding_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
-    stt_models: "{{ ((consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'stt_models') | first).content | default('{}')) | from_json }}"
-    vision_models: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'vision_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
+- name: Process and fetch each model from IPFS if keys exist
+  block:
+    - name: Fetch CID values for all model keys
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:8500/v1/kv/{{ item }}?raw=true"
+        client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+        client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+        validate_certs: false
+        method: GET
+        headers:
+          X-Consul-Token: "{{ consul_token }}"
+        return_content: true
+      loop: "{{ consul_ipfs_keys.json | default([]) }}"
+      register: cid_values
+      when: consul_ipfs_keys.status == 200
 
-
-# ---------------------------------------------------------------------------- #
-#                                  LLM Models                                  #
-# ---------------------------------------------------------------------------- #
-- name: Ensure LLM model directory exists
-  ansible.builtin.file:
-    path: "{{ nomad_models_dir }}/llm"
-    state: directory
-    mode: '0755'
-  become: yes
-
-- name: Check for existing LLM models
-  ansible.builtin.stat:
-    path: "{{ nomad_models_dir }}/llm/{{ item.filename }}"
-  loop: "{{ llm_models_to_download | selectattr('filename', 'defined') | list | unique(attribute='filename') }}"
-  register: llm_model_files
-  become: yes
-
-- name: Download all LLM models if they do not exist
-  ansible.builtin.get_url:
-    url: "{{ item.item.url }}"
-    dest: "{{ nomad_models_dir }}/llm/{{ item.item.filename }}"
-    mode: '0644'
-    timeout: 3600
-  loop: "{{ llm_model_files.results }}"
-  when: not (item.stat.exists | default(false))
-  become: yes
-  loop_control:
-    loop_var: item
-
-- name: Ensure vLLM model directory exists
-  ansible.builtin.file:
-    path: "{{ nomad_models_dir }}/vllm"
-    state: directory
-    mode: '0755'
-  become: yes
-
-- name: Check for existing vLLM models (Hub-based)
-  ansible.builtin.stat:
-    path: "{{ nomad_models_dir }}/vllm/{{ item.repo_id.split('/')[-1] }}" # Basic assumption for folder name
-  loop: "{{ vllm_expert_models | selectattr('repo_id', 'defined') | list }}"
-  register: vllm_model_files_hub
-  become: yes
-
-- name: Download all vLLM models (Hub-based) if they do not exist
-  ansible.builtin.command:
-    cmd: >
-      /opt/pipecatapp/venv/bin/python3
-      {{ role_path }}/files/download_hf_repo.py
-      "{{ item.item.repo_id }}"
-      "{{ nomad_models_dir }}/vllm/{{ item.item.repo_id.split('/')[-1] }}"
-  environment:
-    HF_TOKEN: "{{ hf_token }}"
-  loop: "{{ vllm_model_files_hub.results }}"
-  when: not item.stat.exists
-  become: yes
-  loop_control:
-    loop_var: item
-
-# ---------------------------------------------------------------------------- #
-#                                  STT Models                                  #
-# ---------------------------------------------------------------------------- #
-- name: Create provider-specific STT model directories
-  ansible.builtin.file:
-    path: "{{ nomad_models_dir }}/stt/{{ item.key }}"
-    state: directory
-    mode: '0755'
-  loop: "{{ stt_models | dict2items }}"
-  become: yes
-
-- name: Check for existing STT models (URL-based)
-  ansible.builtin.stat:
-    path: "{{ nomad_models_dir }}/stt/{{ item[0].key }}/{{ item[1].filename }}"
-  loop: "{{ stt_models | dict2items | subelements('value') | selectattr(1, 'match', 'url') | list }}"
-  register: stt_model_files_url
-  become: yes
-
-- name: Check for existing STT models (Hub-based)
-  ansible.builtin.stat:
-    path: "{{ nomad_models_dir }}/stt/{{ item[0].key }}/{{ item[1].name }}"
-  loop: "{{ stt_models | dict2items | subelements('value') | selectattr(1, 'match', 'repo_id') | list }}"
-  register: stt_model_files_hub
-  become: yes
-
-- name: Download all STT models (URL-based) if they do not exist
-  ansible.builtin.get_url:
-    url: "{{ item.item[1].url }}"
-    dest: "{{ nomad_models_dir }}/stt/{{ item.item[0].key }}/{{ item.item[1].filename }}"
-    mode: '0644'
-  loop: "{{ stt_model_files_url.results }}"
-  when: not item.stat.exists
-  become: yes
-  loop_control:
-    loop_var: item
-
-- name: Download all STT models (Hub-based) if they do not exist
-  ansible.builtin.command:
-    cmd: >
-      /opt/pipecatapp/venv/bin/python3
-      {{ role_path }}/files/download_hf_repo.py
-      "{{ item.item[1].repo_id }}"
-      "{{ nomad_models_dir }}/stt/{{ item.item[0].key }}/{{ item.item[1].name }}"
-  environment:
-    HF_TOKEN: "{{ hf_token }}"
-  loop: "{{ stt_model_files_hub.results }}"
-  when: not item.stat.exists
-  become: yes
-  loop_control:
-    loop_var: item
-# ---------------------------------------------------------------------------- #
-#                                  TTS Models                                  #
-# ---------------------------------------------------------------------------- #
-- name: Ensure TTS model directory exists
-  ansible.builtin.file:
-    path: "{{ nomad_models_dir }}/tts"
-    state: directory
-    mode: '0755'
-  become: yes
-
-- name: Check for existing TTS model files
-  ansible.builtin.stat:
-    path: "{{ nomad_models_dir }}/tts/{{ item.filename }}"
-  loop: "{{ piper_voice_files }}"
-  register: tts_model_files
-  become: yes
-
-- name: Download all Text-to-Speech model files if they do not exist
-  ansible.builtin.get_url:
-    url: "{{ item.item.url }}"
-    dest: "{{ nomad_models_dir }}/tts/{{ item.item.filename }}"
-    mode: '0644'
-  loop: "{{ tts_model_files.results }}"
-  when: not item.stat.exists
-  become: yes
-  loop_control:
-    loop_var: item
-# ---------------------------------------------------------------------------- #
-#                                 Vision Models                                #
-# ---------------------------------------------------------------------------- #
-- name: Ensure Vision model directory exists
-  ansible.builtin.file:
-    path: "{{ nomad_models_dir }}/vision"
-    state: directory
-    mode: '0755'
-  become: yes
-
-- name: Check for existing Vision models (URL-based)
-  ansible.builtin.stat:
-    path: "{{ nomad_models_dir }}/vision/{{ item.filename }}"
-  loop: "{{ vision_models | selectattr('filename', 'defined') | list }}"
-  register: vision_model_files_url
-  become: yes
-
-- name: Check for existing Vision models (Hub-based)
-  ansible.builtin.stat:
-    path: "{{ nomad_models_dir }}/vision/{{ item.name }}"
-  loop: "{{ vision_models | selectattr('repo_id', 'defined') | list }}"
-  register: vision_model_files_hub
-  become: yes
-
-- name: Download all Vision models (URL-based) if they do not exist
-  ansible.builtin.get_url:
-    url: "{{ item.item.url }}"
-    dest: "{{ nomad_models_dir }}/vision/{{ item.item.filename }}"
-    mode: '0644'
-  loop: "{{ vision_model_files_url.results }}"
-  when: not item.stat.exists
-  become: yes
-  loop_control:
-    loop_var: item
-- name: Download all Vision models (Hub-based) if they do not exist
-  ansible.builtin.command:
-    cmd: >
-      /opt/pipecatapp/venv/bin/python3
-      {{ role_path }}/files/download_hf_repo.py
-      "{{ item.item.repo_id }}"
-      "{{ nomad_models_dir }}/vision/{{ item.item.name }}"
-  environment:
-    HF_TOKEN: "{{ hf_token }}"
-  loop: "{{ vision_model_files_hub.results }}"
-  when: not item.stat.exists
-  become: yes
-  loop_control:
-    loop_var: item
-# ---------------------------------------------------------------------------- #
-#                               Embedding Models                               #
-# ---------------------------------------------------------------------------- #
-- name: Ensure Embedding model directory exists
-  ansible.builtin.file:
-    path: "{{ nomad_models_dir }}/embedding"
-    state: directory
-    mode: '0755'
-  become: yes
-
-- name: Check for existing Embedding models (Hub-based)
-  ansible.builtin.stat:
-    path: "{{ nomad_models_dir }}/embedding/{{ item.name }}"
-  loop: "{{ embedding_models | selectattr('repo_id', 'defined') | list }}"
-  register: embedding_model_files_hub
-  become: yes
-
-- name: Download all Embedding models (Hub-based) if they do not exist
-  ansible.builtin.command:
-    cmd: >
-      /opt/pipecatapp/venv/bin/python3
-      {{ role_path }}/files/download_hf_repo.py
-      "{{ item.item.repo_id }}"
-      "{{ nomad_models_dir }}/embedding/{{ item.item.name }}"
-  environment:
-    HF_TOKEN: "{{ hf_token }}"
-  loop: "{{ embedding_model_files_hub.results }}"
-  when: not item.stat.exists
-  become: yes
-  loop_control:
-    loop_var: item
+    - name: Get model from IPFS
+      ansible.builtin.command:
+        cmd: "ipfs get {{ item.content }} -o {{ nomad_models_dir }}/{{ item.item | replace('models/ipfs/', '') }}"
+      environment:
+        IPFS_PATH: "{{ nomad_volumes_dir | default('/opt/cluster-infra/data') }}/ipfs"
+      args:
+        creates: "{{ nomad_models_dir }}/{{ item.item | replace('models/ipfs/', '') }}"
+      loop: "{{ cid_values.results }}"
+      when: item.content is defined
+      become: yes
+  when: consul_ipfs_keys.status == 200

--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -32,7 +32,7 @@
 
 - name: Fetch all IPFS CIDs from Consul KV
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/kv/models/ipfs?keys"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs?keys"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
     validate_certs: false
@@ -52,7 +52,7 @@
   block:
     - name: Fetch CID values for all model keys
       ansible.builtin.uri:
-        url: "http://127.0.0.1:8500/v1/kv/{{ item }}?raw=true"
+        url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/{{ item }}?raw=true"
         client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
         client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
         validate_certs: false

--- a/ansible/roles/exo/templates/exo.nomad.j2
+++ b/ansible/roles/exo/templates/exo.nomad.j2
@@ -19,7 +19,7 @@ job "exo" {
       }
 
       artifact {
-        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ exo_ipfs_cid }}"
+        source      = "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ exo_ipfs_cid }}"
         destination = "local/exo.tar"
         mode        = "file"
       }

--- a/ansible/roles/exo/templates/exo.nomad.j2
+++ b/ansible/roles/exo/templates/exo.nomad.j2
@@ -19,14 +19,14 @@ job "exo" {
       }
 
       artifact {
-        source      = "http://127.0.0.1:8080/ipfs/{{ exo_ipfs_cid }}"
-        destination = "local/image.tar"
+        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ exo_ipfs_cid }}"
+        destination = "local/exo.tar"
         mode        = "file"
       }
 
       config {
         command = "docker"
-        args    = ["load", "-i", "local/image.tar"]
+        args    = ["load", "-i", "local/exo.tar"]
       }
     }
 

--- a/ansible/roles/ipfs/tasks/main.yaml
+++ b/ansible/roles/ipfs/tasks/main.yaml
@@ -39,7 +39,7 @@
 
 - name: Wait for IPFS API to be ready
   ansible.builtin.wait_for:
-    host: "127.0.0.1"
+    host: "{{ cluster_ip | default('127.0.0.1') }}"
     port: 5001
     delay: 5
     timeout: 300

--- a/ansible/roles/ipfs/tasks/main.yaml
+++ b/ansible/roles/ipfs/tasks/main.yaml
@@ -30,9 +30,9 @@
 - name: Allow IPFS ports in UFW
   ansible.builtin.command: ufw allow {{ item }}/tcp
   loop:
-    - 4001
-    - 5001
-    - 8080
+    - "{{ ipfs_swarm_port | default(4001) }}"
+    - "{{ ipfs_api_port | default(5001) }}"
+    - "{{ ipfs_gateway_port | default(8080) }}"
   become: yes
   changed_when: false
   ignore_errors: yes
@@ -40,7 +40,7 @@
 - name: Wait for IPFS API to be ready
   ansible.builtin.wait_for:
     host: "{{ cluster_ip | default('127.0.0.1') }}"
-    port: 5001
+    port: "{{ ipfs_api_port | default(5001) }}"
     delay: 5
     timeout: 300
     state: started

--- a/ansible/roles/ipfs/templates/ipfs.nomad.j2
+++ b/ansible/roles/ipfs/templates/ipfs.nomad.j2
@@ -5,13 +5,13 @@ job "ipfs" {
   group "ipfs" {
     network {
       port "swarm" {
-        static = 4001
+        static = {{ ipfs_swarm_port | default(4001) }}
       }
       port "api" {
-        static = 5001
+        static = {{ ipfs_api_port | default(5001) }}
       }
       port "gateway" {
-        static = 8080
+        static = {{ ipfs_gateway_port | default(8080) }}
       }
     }
 
@@ -29,8 +29,8 @@ job "ipfs" {
       env {
         IPFS_PROFILE = "server"
         # Bind to 0.0.0.0 so that Nomad prestart tasks using cluster_ip or 127.0.0.1 can reach it
-        IPFS_CONFIG_Addresses_Gateway = "/ip4/0.0.0.0/tcp/8080"
-        IPFS_CONFIG_Addresses_API = "/ip4/0.0.0.0/tcp/5001"
+        IPFS_CONFIG_Addresses_Gateway = "/ip4/0.0.0.0/tcp/{{ ipfs_gateway_port | default(8080) }}"
+        IPFS_CONFIG_Addresses_API = "/ip4/0.0.0.0/tcp/{{ ipfs_api_port | default(5001) }}"
       }
 
       resources {

--- a/ansible/roles/ipfs/templates/ipfs.nomad.j2
+++ b/ansible/roles/ipfs/templates/ipfs.nomad.j2
@@ -28,6 +28,9 @@ job "ipfs" {
 
       env {
         IPFS_PROFILE = "server"
+        # Bind to 0.0.0.0 so that Nomad prestart tasks using cluster_ip or 127.0.0.1 can reach it
+        IPFS_CONFIG_Addresses_Gateway = "/ip4/0.0.0.0/tcp/8080"
+        IPFS_CONFIG_Addresses_API = "/ip4/0.0.0.0/tcp/5001"
       }
 
       resources {

--- a/ansible/roles/memory_graph/templates/memory-graph.nomad.j2
+++ b/ansible/roles/memory_graph/templates/memory-graph.nomad.j2
@@ -14,14 +14,14 @@ job "memory-graph" {
       }
 
       artifact {
-        source      = "http://127.0.0.1:8080/ipfs/{{ memory_graph_ipfs_cid }}"
-        destination = "local/image.tar"
+        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ memory_graph_ipfs_cid }}"
+        destination = "local/memory_graph.tar"
         mode        = "file"
       }
 
       config {
         command = "docker"
-        args    = ["load", "-i", "local/image.tar"]
+        args    = ["load", "-i", "local/memory_graph.tar"]
       }
     }
 

--- a/ansible/roles/memory_graph/templates/memory-graph.nomad.j2
+++ b/ansible/roles/memory_graph/templates/memory-graph.nomad.j2
@@ -14,7 +14,7 @@ job "memory-graph" {
       }
 
       artifact {
-        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ memory_graph_ipfs_cid }}"
+        source      = "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ memory_graph_ipfs_cid }}"
         destination = "local/memory_graph.tar"
         mode        = "file"
       }

--- a/ansible/roles/memory_service/templates/memory_service.nomad.j2
+++ b/ansible/roles/memory_service/templates/memory_service.nomad.j2
@@ -28,14 +28,14 @@ job "memory-service" {
       }
 
       artifact {
-        source      = "http://127.0.0.1:8080/ipfs/{{ memory_service_ipfs_cid }}"
-        destination = "local/image.tar"
+        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ memory_service_ipfs_cid }}"
+        destination = "local/memory_service.tar"
         mode        = "file"
       }
 
       config {
         command = "docker"
-        args    = ["load", "-i", "local/image.tar"]
+        args    = ["load", "-i", "local/memory_service.tar"]
       }
     }
 

--- a/ansible/roles/memory_service/templates/memory_service.nomad.j2
+++ b/ansible/roles/memory_service/templates/memory_service.nomad.j2
@@ -28,7 +28,7 @@ job "memory-service" {
       }
 
       artifact {
-        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ memory_service_ipfs_cid }}"
+        source      = "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ memory_service_ipfs_cid }}"
         destination = "local/memory_service.tar"
         mode        = "file"
       }

--- a/ansible/roles/openclaw/templates/openclaw.nomad.j2
+++ b/ansible/roles/openclaw/templates/openclaw.nomad.j2
@@ -18,7 +18,7 @@ job "openclaw" {
       }
 
       artifact {
-        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ openclaw_ipfs_cid }}"
+        source      = "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ openclaw_ipfs_cid }}"
         destination = "local/openclaw.tar"
         mode        = "file"
       }

--- a/ansible/roles/openclaw/templates/openclaw.nomad.j2
+++ b/ansible/roles/openclaw/templates/openclaw.nomad.j2
@@ -18,14 +18,14 @@ job "openclaw" {
       }
 
       artifact {
-        source      = "http://127.0.0.1:8080/ipfs/{{ openclaw_ipfs_cid }}"
-        destination = "local/image.tar"
+        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ openclaw_ipfs_cid }}"
+        destination = "local/openclaw.tar"
         mode        = "file"
       }
 
       config {
         command = "docker"
-        args    = ["load", "-i", "local/image.tar"]
+        args    = ["load", "-i", "local/openclaw.tar"]
       }
     }
 

--- a/ansible/roles/opengravity/tasks/main.yaml
+++ b/ansible/roles/opengravity/tasks/main.yaml
@@ -37,6 +37,27 @@
   ansible.builtin.include_tasks:
     file: "../../tasks/build_cached_image.yaml"
 
+- name: Export opengravity image to tarball
+  ansible.builtin.command: docker save -o /tmp/opengravity.tar opengravity:local
+  become: yes
+
+- name: Pin opengravity tarball to IPFS
+  ansible.builtin.command: ipfs add -Q /tmp/opengravity.tar
+  become: yes
+  register: ipfs_add_result_opengravity
+  environment:
+    IPFS_PATH: "{{ nomad_volumes_dir | default('/opt/cluster-infra/data') }}/ipfs"
+
+- name: Clean up temporary opengravity tarball
+  ansible.builtin.file:
+    path: /tmp/opengravity.tar
+    state: absent
+  become: yes
+
+- name: Set opengravity_ipfs_cid fact
+  ansible.builtin.set_fact:
+    opengravity_ipfs_cid: "{{ ipfs_add_result_opengravity.stdout }}"
+
 - name: Create OpenGravity job file
   ansible.builtin.template:
     src: opengravity.nomad.j2

--- a/ansible/roles/opengravity/templates/opengravity.nomad.j2
+++ b/ansible/roles/opengravity/templates/opengravity.nomad.j2
@@ -30,11 +30,29 @@ job "opengravity" {
       }
     }
 
+    task "load-image" {
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
+      }
+
+      artifact {
+        source      = "http://127.0.0.1:8080/ipfs/{{ opengravity_ipfs_cid }}"
+        destination = "local/image.tar"
+        mode        = "file"
+      }
+
+      config {
+        command = "docker"
+        args    = ["load", "-i", "local/image.tar"]
+      }
+    }
+
     task "nginx" {
       driver = "docker"
 
       config {
-        image = "opengravity:{{ image_tag | default('latest') }}"
+        image = "opengravity:local"
         ports = ["http"]
       }
 

--- a/ansible/roles/opengravity/templates/opengravity.nomad.j2
+++ b/ansible/roles/opengravity/templates/opengravity.nomad.j2
@@ -37,14 +37,14 @@ job "opengravity" {
       }
 
       artifact {
-        source      = "http://127.0.0.1:8080/ipfs/{{ opengravity_ipfs_cid }}"
-        destination = "local/image.tar"
+        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ opengravity_ipfs_cid }}"
+        destination = "local/opengravity.tar"
         mode        = "file"
       }
 
       config {
         command = "docker"
-        args    = ["load", "-i", "local/image.tar"]
+        args    = ["load", "-i", "local/opengravity.tar"]
       }
     }
 

--- a/ansible/roles/opengravity/templates/opengravity.nomad.j2
+++ b/ansible/roles/opengravity/templates/opengravity.nomad.j2
@@ -37,7 +37,7 @@ job "opengravity" {
       }
 
       artifact {
-        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ opengravity_ipfs_cid }}"
+        source      = "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ opengravity_ipfs_cid }}"
         destination = "local/opengravity.tar"
         mode        = "file"
       }

--- a/ansible/roles/pipecatapp/templates/architect.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/architect.nomad.j2
@@ -67,7 +67,7 @@ job "architect" {
       }
 
       artifact {
-        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
+        source      = "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ pipecatapp_ipfs_cid }}"
         destination = "local/pipecatapp.tar"
         mode        = "file"
       }

--- a/ansible/roles/pipecatapp/templates/architect.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/architect.nomad.j2
@@ -67,14 +67,14 @@ job "architect" {
       }
 
       artifact {
-        source      = "http://127.0.0.1:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
-        destination = "local/image.tar"
+        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
+        destination = "local/pipecatapp.tar"
         mode        = "file"
       }
 
       config {
         command = "docker"
-        args    = ["load", "-i", "local/image.tar"]
+        args    = ["load", "-i", "local/pipecatapp.tar"]
       }
     }
 

--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -111,14 +111,14 @@ job "{{ job_name | default('pipecat-app') }}" {
       }
 
       artifact {
-        source      = "http://127.0.0.1:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
-        destination = "local/image.tar"
+        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
+        destination = "local/pipecatapp.tar"
         mode        = "file"
       }
 
       config {
         command = "docker"
-        args    = ["load", "-i", "local/image.tar"]
+        args    = ["load", "-i", "local/pipecatapp.tar"]
       }
     }
 

--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -111,7 +111,7 @@ job "{{ job_name | default('pipecat-app') }}" {
       }
 
       artifact {
-        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
+        source      = "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ pipecatapp_ipfs_cid }}"
         destination = "local/pipecatapp.tar"
         mode        = "file"
       }

--- a/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
@@ -58,7 +58,7 @@ job "seed-agent" {
       }
 
       artifact {
-        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
+        source      = "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ pipecatapp_ipfs_cid }}"
         destination = "local/pipecatapp.tar"
         mode        = "file"
       }

--- a/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
@@ -58,14 +58,14 @@ job "seed-agent" {
       }
 
       artifact {
-        source      = "http://127.0.0.1:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
-        destination = "local/image.tar"
+        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ pipecatapp_ipfs_cid }}"
+        destination = "local/pipecatapp.tar"
         mode        = "file"
       }
 
       config {
         command = "docker"
-        args    = ["load", "-i", "local/image.tar"]
+        args    = ["load", "-i", "local/pipecatapp.tar"]
       }
     }
 

--- a/ansible/roles/seed_models/files/reference_data/README.md
+++ b/ansible/roles/seed_models/files/reference_data/README.md
@@ -1,0 +1,8 @@
+# Reference Data Directory
+
+This directory holds static reference corpora, base vector indices, and global agent configurations.
+These files are automatically pinned to IPFS during the `seed_models` provisioning phase and
+distributed to worker nodes as read-only artifacts.
+
+Place any immutable system prompts, rule sets, hardware datasheets, or open-source fabrication
+guides here to have them distributed seamlessly across the swarm.

--- a/ansible/roles/seed_models/tasks/main.yaml
+++ b/ansible/roles/seed_models/tasks/main.yaml
@@ -1,0 +1,440 @@
+---
+# tasks file for seed_models (runs ONLY on controller)
+
+- name: Get Consul token from file
+  ansible.builtin.slurp:
+    src: /etc/consul.d/management_token
+  register: consul_token_slurp
+  failed_when: false
+
+- name: Set Consul token fact
+  ansible.builtin.set_fact:
+    consul_token: "{{ consul_token_slurp.content | b64decode | trim }}"
+  when: consul_token_slurp.content is defined
+
+- name: Fetch ALL models configuration from Consul KV
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8500/v1/kv/models/{{ item }}?raw=true"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
+    method: GET
+    headers:
+      X-Consul-Token: "{{ consul_token }}"
+    status_code: [200, 404]
+    return_content: true
+  check_mode: no
+  loop:
+    - main
+    - coding
+    - math
+    - extract
+    - rag
+    - tool
+    - thinking
+    - instruct
+    - router
+    - qwen
+    - cynic
+    - gpt-oss
+    - qwen3-5
+    - orthrus
+    - vllm_expert_models
+    - piper_voice_files
+    - embedding_models
+    - stt_models
+    - vision_models
+  register: consul_models
+  until: consul_models.status in [200, 404]
+  retries: 5
+  delay: 2
+  failed_when: false
+
+- name: Set model facts from Consul KV
+  ansible.builtin.set_fact:
+    llm_models_to_download: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'in', ['main', 'coding', 'math', 'extract', 'rag', 'tool', 'thinking', 'instruct', 'router', 'qwen', 'cynic', 'gpt-oss', 'qwen3-5', 'orthrus']) | map(attribute='content') | map('from_json') | sum(start=[]) }}"
+    vllm_expert_models: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'vllm_expert_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
+    piper_voice_files: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'piper_voice_files') | map(attribute='content') | map('from_json') | first | default([]) }}"
+    embedding_models: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'embedding_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
+    stt_models: "{{ ((consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'stt_models') | first).content | default('{}')) | from_json }}"
+    vision_models: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'vision_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
+
+# --- LLM Models ---
+- name: Ensure LLM model directory exists
+  ansible.builtin.file:
+    path: "{{ nomad_models_dir }}/llm"
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Check for existing LLM models
+  ansible.builtin.stat:
+    path: "{{ nomad_models_dir }}/llm/{{ item.filename }}"
+  loop: "{{ llm_models_to_download | selectattr('filename', 'defined') | list | unique(attribute='filename') }}"
+  register: llm_model_files
+  become: yes
+
+- name: Download all LLM models if they do not exist
+  ansible.builtin.get_url:
+    url: "{{ item.item.url }}"
+    dest: "{{ nomad_models_dir }}/llm/{{ item.item.filename }}"
+    mode: '0644'
+    timeout: 3600
+  loop: "{{ llm_model_files.results }}"
+  when: not (item.stat.exists | default(false))
+  become: yes
+  loop_control:
+    loop_var: item
+
+- name: Pin LLM models to IPFS
+  ansible.builtin.command:
+    cmd: ipfs add -Q "{{ nomad_models_dir }}/llm/{{ item.filename }}"
+  environment:
+    IPFS_PATH: "{{ nomad_volumes_dir | default('/opt/cluster-infra/data') }}/ipfs"
+  register: llm_ipfs_cids
+  loop: "{{ llm_models_to_download | selectattr('filename', 'defined') | list | unique(attribute='filename') }}"
+  become: yes
+
+- name: Store LLM model CIDs in Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/llm/{{ item.item.filename }}"
+    method: PUT
+    body: "{{ item.stdout }}"
+    headers:
+      X-Consul-Token: "{{ consul_token }}"
+  loop: "{{ llm_ipfs_cids.results }}"
+  when: item.stdout is defined
+
+# --- vLLM Models ---
+- name: Ensure vLLM model directory exists
+  ansible.builtin.file:
+    path: "{{ nomad_models_dir }}/vllm"
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Check for existing vLLM models (Hub-based)
+  ansible.builtin.stat:
+    path: "{{ nomad_models_dir }}/vllm/{{ item.repo_id.split('/')[-1] }}"
+  loop: "{{ vllm_expert_models | selectattr('repo_id', 'defined') | list }}"
+  register: vllm_model_files_hub
+  become: yes
+
+- name: Download all vLLM models (Hub-based) if they do not exist
+  ansible.builtin.command:
+    cmd: >
+      /opt/pipecatapp/venv/bin/python3
+      {{ role_path }}/../download_models/files/download_hf_repo.py
+      "{{ item.item.repo_id }}"
+      "{{ nomad_models_dir }}/vllm/{{ item.item.repo_id.split('/')[-1] }}"
+  environment:
+    HF_TOKEN: "{{ hf_token }}"
+  loop: "{{ vllm_model_files_hub.results }}"
+  when: not item.stat.exists
+  become: yes
+  loop_control:
+    loop_var: item
+
+- name: Pin vLLM models to IPFS
+  ansible.builtin.command:
+    cmd: ipfs add -Q -r "{{ nomad_models_dir }}/vllm/{{ item.repo_id.split('/')[-1] }}"
+  environment:
+    IPFS_PATH: "{{ nomad_volumes_dir | default('/opt/cluster-infra/data') }}/ipfs"
+  register: vllm_ipfs_cids
+  loop: "{{ vllm_expert_models | selectattr('repo_id', 'defined') | list }}"
+  become: yes
+
+- name: Store vLLM model CIDs in Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/vllm/{{ item.item.repo_id.split('/')[-1] }}"
+    method: PUT
+    body: "{{ item.stdout }}"
+    headers:
+      X-Consul-Token: "{{ consul_token }}"
+  loop: "{{ vllm_ipfs_cids.results }}"
+  when: item.stdout is defined
+
+# --- STT Models ---
+- name: Create provider-specific STT model directories
+  ansible.builtin.file:
+    path: "{{ nomad_models_dir }}/stt/{{ item.key }}"
+    state: directory
+    mode: '0755'
+  loop: "{{ stt_models | dict2items }}"
+  become: yes
+
+- name: Check for existing STT models (URL-based)
+  ansible.builtin.stat:
+    path: "{{ nomad_models_dir }}/stt/{{ item[0].key }}/{{ item[1].filename }}"
+  loop: "{{ stt_models | dict2items | subelements('value') | selectattr(1, 'match', 'url') | list }}"
+  register: stt_model_files_url
+  become: yes
+
+- name: Check for existing STT models (Hub-based)
+  ansible.builtin.stat:
+    path: "{{ nomad_models_dir }}/stt/{{ item[0].key }}/{{ item[1].name }}"
+  loop: "{{ stt_models | dict2items | subelements('value') | selectattr(1, 'match', 'repo_id') | list }}"
+  register: stt_model_files_hub
+  become: yes
+
+- name: Download all STT models (URL-based) if they do not exist
+  ansible.builtin.get_url:
+    url: "{{ item.item[1].url }}"
+    dest: "{{ nomad_models_dir }}/stt/{{ item.item[0].key }}/{{ item.item[1].filename }}"
+    mode: '0644'
+  loop: "{{ stt_model_files_url.results }}"
+  when: not item.stat.exists
+  become: yes
+  loop_control:
+    loop_var: item
+
+- name: Download all STT models (Hub-based) if they do not exist
+  ansible.builtin.command:
+    cmd: >
+      /opt/pipecatapp/venv/bin/python3
+      {{ role_path }}/../download_models/files/download_hf_repo.py
+      "{{ item.item[1].repo_id }}"
+      "{{ nomad_models_dir }}/stt/{{ item.item[0].key }}/{{ item.item[1].name }}"
+  environment:
+    HF_TOKEN: "{{ hf_token }}"
+  loop: "{{ stt_model_files_hub.results }}"
+  when: not item.stat.exists
+  become: yes
+  loop_control:
+    loop_var: item
+
+- name: Pin STT models (URL-based) to IPFS
+  ansible.builtin.command:
+    cmd: ipfs add -Q "{{ nomad_models_dir }}/stt/{{ item[0].key }}/{{ item[1].filename }}"
+  environment:
+    IPFS_PATH: "{{ nomad_volumes_dir | default('/opt/cluster-infra/data') }}/ipfs"
+  register: stt_url_ipfs_cids
+  loop: "{{ stt_models | dict2items | subelements('value') | selectattr(1, 'match', 'url') | list }}"
+  become: yes
+
+- name: Store STT (URL) CIDs in Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/stt/{{ item.item[0].key }}/{{ item.item[1].filename }}"
+    method: PUT
+    body: "{{ item.stdout }}"
+    headers:
+      X-Consul-Token: "{{ consul_token }}"
+  loop: "{{ stt_url_ipfs_cids.results }}"
+  when: item.stdout is defined
+
+- name: Pin STT models (Hub-based) to IPFS
+  ansible.builtin.command:
+    cmd: ipfs add -Q -r "{{ nomad_models_dir }}/stt/{{ item[0].key }}/{{ item[1].name }}"
+  environment:
+    IPFS_PATH: "{{ nomad_volumes_dir | default('/opt/cluster-infra/data') }}/ipfs"
+  register: stt_hub_ipfs_cids
+  loop: "{{ stt_models | dict2items | subelements('value') | selectattr(1, 'match', 'repo_id') | list }}"
+  become: yes
+
+- name: Store STT (Hub) CIDs in Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/stt/{{ item.item[0].key }}/{{ item.item[1].name }}"
+    method: PUT
+    body: "{{ item.stdout }}"
+    headers:
+      X-Consul-Token: "{{ consul_token }}"
+  loop: "{{ stt_hub_ipfs_cids.results }}"
+  when: item.stdout is defined
+
+# --- TTS Models ---
+- name: Ensure TTS model directory exists
+  ansible.builtin.file:
+    path: "{{ nomad_models_dir }}/tts"
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Check for existing TTS model files
+  ansible.builtin.stat:
+    path: "{{ nomad_models_dir }}/tts/{{ item.filename }}"
+  loop: "{{ piper_voice_files }}"
+  register: tts_model_files
+  become: yes
+
+- name: Download all Text-to-Speech model files if they do not exist
+  ansible.builtin.get_url:
+    url: "{{ item.item.url }}"
+    dest: "{{ nomad_models_dir }}/tts/{{ item.item.filename }}"
+    mode: '0644'
+  loop: "{{ tts_model_files.results }}"
+  when: not item.stat.exists
+  become: yes
+  loop_control:
+    loop_var: item
+
+- name: Pin TTS models to IPFS
+  ansible.builtin.command:
+    cmd: ipfs add -Q "{{ nomad_models_dir }}/tts/{{ item.filename }}"
+  environment:
+    IPFS_PATH: "{{ nomad_volumes_dir | default('/opt/cluster-infra/data') }}/ipfs"
+  register: tts_ipfs_cids
+  loop: "{{ piper_voice_files }}"
+  become: yes
+
+- name: Store TTS model CIDs in Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/tts/{{ item.item.filename }}"
+    method: PUT
+    body: "{{ item.stdout }}"
+    headers:
+      X-Consul-Token: "{{ consul_token }}"
+  loop: "{{ tts_ipfs_cids.results }}"
+  when: item.stdout is defined
+
+# --- Vision Models ---
+- name: Ensure Vision model directory exists
+  ansible.builtin.file:
+    path: "{{ nomad_models_dir }}/vision"
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Check for existing Vision models (URL-based)
+  ansible.builtin.stat:
+    path: "{{ nomad_models_dir }}/vision/{{ item.filename }}"
+  loop: "{{ vision_models | selectattr('filename', 'defined') | list }}"
+  register: vision_model_files_url
+  become: yes
+
+- name: Check for existing Vision models (Hub-based)
+  ansible.builtin.stat:
+    path: "{{ nomad_models_dir }}/vision/{{ item.name }}"
+  loop: "{{ vision_models | selectattr('repo_id', 'defined') | list }}"
+  register: vision_model_files_hub
+  become: yes
+
+- name: Download all Vision models (URL-based) if they do not exist
+  ansible.builtin.get_url:
+    url: "{{ item.item.url }}"
+    dest: "{{ nomad_models_dir }}/vision/{{ item.item.filename }}"
+    mode: '0644'
+  loop: "{{ vision_model_files_url.results }}"
+  when: not item.stat.exists
+  become: yes
+  loop_control:
+    loop_var: item
+
+- name: Download all Vision models (Hub-based) if they do not exist
+  ansible.builtin.command:
+    cmd: >
+      /opt/pipecatapp/venv/bin/python3
+      {{ role_path }}/../download_models/files/download_hf_repo.py
+      "{{ item.item.repo_id }}"
+      "{{ nomad_models_dir }}/vision/{{ item.item.name }}"
+  environment:
+    HF_TOKEN: "{{ hf_token }}"
+  loop: "{{ vision_model_files_hub.results }}"
+  when: not item.stat.exists
+  become: yes
+  loop_control:
+    loop_var: item
+
+- name: Pin Vision models (URL) to IPFS
+  ansible.builtin.command:
+    cmd: ipfs add -Q "{{ nomad_models_dir }}/vision/{{ item.filename }}"
+  environment:
+    IPFS_PATH: "{{ nomad_volumes_dir | default('/opt/cluster-infra/data') }}/ipfs"
+  register: vision_url_ipfs_cids
+  loop: "{{ vision_models | selectattr('filename', 'defined') | list }}"
+  become: yes
+
+- name: Store Vision (URL) CIDs in Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/vision/{{ item.item.filename }}"
+    method: PUT
+    body: "{{ item.stdout }}"
+    headers:
+      X-Consul-Token: "{{ consul_token }}"
+  loop: "{{ vision_url_ipfs_cids.results }}"
+  when: item.stdout is defined
+
+- name: Pin Vision models (Hub) to IPFS
+  ansible.builtin.command:
+    cmd: ipfs add -Q -r "{{ nomad_models_dir }}/vision/{{ item.name }}"
+  environment:
+    IPFS_PATH: "{{ nomad_volumes_dir | default('/opt/cluster-infra/data') }}/ipfs"
+  register: vision_hub_ipfs_cids
+  loop: "{{ vision_models | selectattr('repo_id', 'defined') | list }}"
+  become: yes
+
+- name: Store Vision (Hub) CIDs in Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/vision/{{ item.item.name }}"
+    method: PUT
+    body: "{{ item.stdout }}"
+    headers:
+      X-Consul-Token: "{{ consul_token }}"
+  loop: "{{ vision_hub_ipfs_cids.results }}"
+  when: item.stdout is defined
+
+# --- Embedding Models ---
+- name: Ensure Embedding model directory exists
+  ansible.builtin.file:
+    path: "{{ nomad_models_dir }}/embedding"
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Check for existing Embedding models (Hub-based)
+  ansible.builtin.stat:
+    path: "{{ nomad_models_dir }}/embedding/{{ item.name }}"
+  loop: "{{ embedding_models | selectattr('repo_id', 'defined') | list }}"
+  register: embedding_model_files_hub
+  become: yes
+
+- name: Download all Embedding models (Hub-based) if they do not exist
+  ansible.builtin.command:
+    cmd: >
+      /opt/pipecatapp/venv/bin/python3
+      {{ role_path }}/../download_models/files/download_hf_repo.py
+      "{{ item.item.repo_id }}"
+      "{{ nomad_models_dir }}/embedding/{{ item.item.name }}"
+  environment:
+    HF_TOKEN: "{{ hf_token }}"
+  loop: "{{ embedding_model_files_hub.results }}"
+  when: not item.stat.exists
+  become: yes
+  loop_control:
+    loop_var: item
+
+- name: Pin Embedding models to IPFS
+  ansible.builtin.command:
+    cmd: ipfs add -Q -r "{{ nomad_models_dir }}/embedding/{{ item.name }}"
+  environment:
+    IPFS_PATH: "{{ nomad_volumes_dir | default('/opt/cluster-infra/data') }}/ipfs"
+  register: embedding_ipfs_cids
+  loop: "{{ embedding_models | selectattr('repo_id', 'defined') | list }}"
+  become: yes
+
+- name: Store Embedding model CIDs in Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/embedding/{{ item.item.name }}"
+    method: PUT
+    body: "{{ item.stdout }}"
+    headers:
+      X-Consul-Token: "{{ consul_token }}"
+  loop: "{{ embedding_ipfs_cids.results }}"
+  when: item.stdout is defined
+
+# --- Reference Data ---
+- name: Pin reference data directory to IPFS
+  ansible.builtin.command:
+    cmd: ipfs add -Q -r "{{ role_path }}/files/reference_data"
+  environment:
+    IPFS_PATH: "{{ nomad_volumes_dir | default('/opt/cluster-infra/data') }}/ipfs"
+  register: reference_data_ipfs_cid
+  become: yes
+
+- name: Store Reference Data CID in Consul
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/reference_data/main"
+    method: PUT
+    body: "{{ reference_data_ipfs_cid.stdout }}"
+    headers:
+      X-Consul-Token: "{{ consul_token }}"
+  when: reference_data_ipfs_cid.stdout is defined

--- a/ansible/roles/seed_models/tasks/main.yaml
+++ b/ansible/roles/seed_models/tasks/main.yaml
@@ -14,7 +14,7 @@
 
 - name: Fetch ALL models configuration from Consul KV
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/kv/models/{{ item }}?raw=true"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/{{ item }}?raw=true"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
     validate_certs: false
@@ -97,7 +97,7 @@
 
 - name: Store LLM model CIDs in Consul
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/llm/{{ item.item.filename }}"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/llm/{{ item.item.filename }}"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -146,7 +146,7 @@
 
 - name: Store vLLM model CIDs in Consul
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/vllm/{{ item.item.repo_id.split('/')[-1] }}"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/vllm/{{ item.item.repo_id.split('/')[-1] }}"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -214,7 +214,7 @@
 
 - name: Store STT (URL) CIDs in Consul
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/stt/{{ item.item[0].key }}/{{ item.item[1].filename }}"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/stt/{{ item.item[0].key }}/{{ item.item[1].filename }}"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -233,7 +233,7 @@
 
 - name: Store STT (Hub) CIDs in Consul
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/stt/{{ item.item[0].key }}/{{ item.item[1].name }}"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/stt/{{ item.item[0].key }}/{{ item.item[1].name }}"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -278,7 +278,7 @@
 
 - name: Store TTS model CIDs in Consul
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/tts/{{ item.item.filename }}"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/tts/{{ item.item.filename }}"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -345,7 +345,7 @@
 
 - name: Store Vision (URL) CIDs in Consul
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/vision/{{ item.item.filename }}"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/vision/{{ item.item.filename }}"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -364,7 +364,7 @@
 
 - name: Store Vision (Hub) CIDs in Consul
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/vision/{{ item.item.name }}"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/vision/{{ item.item.name }}"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -413,7 +413,7 @@
 
 - name: Store Embedding model CIDs in Consul
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/embedding/{{ item.item.name }}"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/embedding/{{ item.item.name }}"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -432,7 +432,7 @@
 
 - name: Store Reference Data CID in Consul
   ansible.builtin.uri:
-    url: "http://127.0.0.1:8500/v1/kv/models/ipfs/reference_data/main"
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/reference_data/main"
     method: PUT
     body: "{{ reference_data_ipfs_cid.stdout }}"
     headers:

--- a/ansible/roles/tool_server/templates/tool_server.nomad.j2
+++ b/ansible/roles/tool_server/templates/tool_server.nomad.j2
@@ -18,14 +18,14 @@ job "tool-server" {
       }
 
       artifact {
-        source      = "http://127.0.0.1:8080/ipfs/{{ tool_server_ipfs_cid }}"
-        destination = "local/image.tar"
+        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ tool_server_ipfs_cid }}"
+        destination = "local/tool_server.tar"
         mode        = "file"
       }
 
       config {
         command = "docker"
-        args    = ["load", "-i", "local/image.tar"]
+        args    = ["load", "-i", "local/tool_server.tar"]
       }
     }
 

--- a/ansible/roles/tool_server/templates/tool_server.nomad.j2
+++ b/ansible/roles/tool_server/templates/tool_server.nomad.j2
@@ -18,7 +18,7 @@ job "tool-server" {
       }
 
       artifact {
-        source      = "http://${attr.unique.network.ip-address}:8080/ipfs/{{ tool_server_ipfs_cid }}"
+        source      = "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ tool_server_ipfs_cid }}"
         destination = "local/tool_server.tar"
         mode        = "file"
       }

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -83,6 +83,9 @@ prometheus_port: 9090
 grafana_port: 3000
 mqtt_exporter_metrics_port: 9341
 traceway_port: 8089
+ipfs_swarm_port: 4001
+ipfs_api_port: 5001
+ipfs_gateway_port: 8080
 
 # Standard Paths
 consul_data_dir: "/opt/consul"

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -12,6 +12,7 @@
 - import_playbook: playbooks/app_jobs.yaml
 - import_playbook: playbooks/services/app_services.yaml
 - import_playbook: playbooks/services/monitoring.yaml
+- import_playbook: playbooks/services/seed_models_to_ipfs.yaml
 - import_playbook: playbooks/services/model_services.yaml
 - import_playbook: playbooks/services/core_ai_services.yaml
 - import_playbook: playbooks/services/ai_experts.yaml

--- a/playbooks/services/seed_models_to_ipfs.yaml
+++ b/playbooks/services/seed_models_to_ipfs.yaml
@@ -1,0 +1,16 @@
+- name: Seed Models to IPFS
+  hosts: controller_nodes[0]
+  connection: local
+  gather_facts: yes
+  vars_files:
+    - "../../group_vars/models.yaml"
+    - "../../group_vars/external_experts.yaml"
+  remote_user: "{{ target_user }}"
+  become: yes
+
+  tags:
+    - seed-models
+    - ipfs
+
+  roles:
+    - role: seed_models

--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -793,6 +793,7 @@ def main():
         app_services_playbooks = [
             "playbooks/services/app_services.yaml",
             "playbooks/services/monitoring.yaml",
+            "playbooks/services/seed_models_to_ipfs.yaml",
             "playbooks/services/model_services.yaml",
             "playbooks/services/core_ai_services.yaml",
             "playbooks/services/ai_experts.yaml",
@@ -806,6 +807,7 @@ def main():
         partial_stack_playbooks = [
             "playbooks/services/app_services.yaml",
             "playbooks/services/monitoring.yaml",
+            "playbooks/services/seed_models_to_ipfs.yaml",
             "playbooks/services/model_services.yaml",
             "playbooks/services/core_ai_services.yaml",
             "playbooks/services/ai_experts.yaml",


### PR DESCRIPTION
…rence data

- Created `seed_models_to_ipfs.yaml` and `ansible/roles/seed_models` role to run once on the controller. It downloads all models (LLM, vLLM, STT, TTS, Vision, Embeddings) from HuggingFace/URLs, recursively adds them to IPFS, and publishes the CIDs to Consul KV (`models/ipfs/type/name`).
- Updated `download_models` role on worker nodes to act entirely as an IPFS Consumer, querying Consul KV for the CIDs and downloading via `ipfs get <CID>`.
- Included a `reference_data` directory in the seed task for static, persistent read-only data, pinned to IPFS and fetched on all nodes for tasks to bind-mount or access.
- Refactored `opengravity` UI deployment to build, tarball, and pin the frontend static assets to IPFS via the Nomad prestart `artifact` mechanism, matching the other container distribution workflows.
- Re-sequenced the `playbook.yaml` and `scripts/provisioning.py` stack to execute `seed_models_to_ipfs.yaml` correctly before the application service deployments.