### PR TITLE
Install IPFS CLI natively on nodes to fix missing ipfs command

### DIFF
--- a/ansible/roles/ipfs/tasks/main.yaml
+++ b/ansible/roles/ipfs/tasks/main.yaml
@@ -1,3 +1,40 @@
+# Ensure IPFS CLI is installed
+- name: Check if IPFS CLI is installed
+  ansible.builtin.stat:
+    path: /usr/local/bin/ipfs
+  register: ipfs_binary
+
+- name: Install IPFS CLI
+  block:
+    - name: Download kubo (IPFS CLI)
+      ansible.builtin.get_url:
+        url: "https://dist.ipfs.tech/kubo/v0.32.1/kubo_v0.32.1_linux-amd64.tar.gz"
+        dest: "/tmp/kubo.tar.gz"
+        mode: '0644'
+
+    - name: Extract kubo
+      ansible.builtin.unarchive:
+        src: "/tmp/kubo.tar.gz"
+        dest: "/tmp/"
+        remote_src: yes
+
+    - name: Move ipfs binary to /usr/local/bin
+      ansible.builtin.copy:
+        src: "/tmp/kubo/ipfs"
+        dest: "/usr/local/bin/ipfs"
+        mode: '0755'
+        remote_src: yes
+
+    - name: Clean up temporary files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "/tmp/kubo.tar.gz"
+        - "/tmp/kubo"
+  become: yes
+  when: not ipfs_binary.stat.exists
+
 - name: Ensure IPFS data directory exists
   ansible.builtin.file:
     path: "{{ nomad_volumes_dir }}/ipfs"

--- a/plan.md
+++ b/plan.md
@@ -1,24 +1,13 @@
-1. **Create Nomad Startup Wrapper Script (`start_nomad.sh.j2`)**
-   - Create `ansible/roles/nomad/templates/start_nomad.sh.j2`.
-   - Add logic to calculate `BOOTSTRAP_COUNT` dynamically by pinging expected controller nodes (`100.64.0.2`, `100.64.0.3` or based on `controller_nodes` IPs) to determine `-bootstrap-expect=1` or `-bootstrap-expect=3`.
-   - Start the main binary via `exec /usr/local/bin/nomad agent -config=/etc/nomad.d -bootstrap-expect=$BOOTSTRAP_COUNT` (ensure to use `/etc/nomad.d` directly instead of a specific file).
-
-2. **Update Nomad Service Execution (`nomad.service.j2` & `tasks/main.yaml`)**
-   - In `ansible/roles/nomad/templates/nomad.service.j2`, update `ExecStart` to `/usr/local/bin/start_nomad.sh`.
-   - In `ansible/roles/nomad/tasks/main.yaml`, add a task to deploy `start_nomad.sh.j2` to `/usr/local/bin/start_nomad.sh` with executable permissions before the service start.
-
-3. **Add Autopilot Configuration Blocks**
-   - In `ansible/roles/nomad/templates/nomad.hcl.server.j2`, add the `autopilot` block inside the `server` block.
-   - In `ansible/roles/nomad/templates/server.hcl.j2`, add the `autopilot` block inside the `server` block.
-
-4. **Create Single-Node Recovery Watchdog**
-   - Create `ansible/roles/power_manager/files/watchdog.sh` with the logic to monitor for `500 No Leader` on `/v1/status/leader` and manually inject `peers.json` if alone.
-   - Make it a separate service by adding `ansible/roles/power_manager/templates/nomad-watchdog.service.j2`.
-   - Update `ansible/roles/power_manager/tasks/main.yaml` to deploy `watchdog.sh` to `/opt/power_manager/watchdog.sh` and the systemd service template.
-   - Update handlers in `ansible/roles/power_manager/handlers/main.yaml` to include a handler for restarting the watchdog.
-
-5. **Complete pre-commit steps**
-   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-
-6. **Submit**
-   - Submit the changes using the git agnostic submit tool.
+1. **Understand the problem**:
+    - The `ansible/roles/tool_server/tasks/main.yaml` has a task to `Pin tool-server tarball to IPFS`.
+    - It runs the command `ipfs add -Q /tmp/tool-server.tar` natively on the host (not via Docker).
+    - But `ipfs` command is not installed on the system globally. The IPFS daemon is actually started as a Nomad job (`docker pull ipfs/kubo:latest` and then deployed via Nomad) in `ansible/roles/ipfs/tasks/main.yaml`.
+    - So when any app deployment role tries to upload to IPFS (e.g. `tool_server`, `pipecatapp`, `openclaw`, `exo`), it uses `ipfs add ...` assuming the CLI is present.
+2. **Solution**:
+    - Since `kubo` provides the `ipfs` command, and it makes sense to have it globally available for these operations, we should install the IPFS CLI locally on the controllers (or all nodes) where these playbooks run.
+    - I have modified `ansible/roles/ipfs/tasks/main.yaml` to download and install the `ipfs` CLI (kubo) binary from the official release tarball to `/usr/local/bin/ipfs` before it tries to run `ipfs add ...` in other roles.
+    - Since the `ipfs` role is run earlier in the playbook list (`playbooks/services/ipfs.yaml` comes before `playbooks/services/app_services.yaml`), modifying `ansible/roles/ipfs/tasks/main.yaml` to install the kubo CLI will fix all subsequent roles.
+3. **Pre-commit step**:
+    - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+4. **Submit**:
+    - Submit the change with a descriptive message.


### PR DESCRIPTION
Fixes the issue where Ansible fails to upload tarballs to IPFS.

Previously, `ipfs` was only deployed as a dockerized Nomad job without installing the `ipfs` (kubo) CLI natively on the nodes. Later playbooks like `tool_server` attempt to run `ipfs add -Q /tmp/tool-server.tar` from the host context, leading to a `No such file or directory: b'ipfs'` error.

This patch updates the `ipfs` role to natively download and extract `kubo` so that `ipfs` is globally available to other deployment roles. I've added a check to skip the download if `ipfs` is already installed, maintaining idempotency.

---
*PR created automatically by Jules for task [14222944756328955405](https://jules.google.com/task/14222944756328955405) started by @LokiMetaSmith*