### PR TITLE
fix(ipfs): Bump kubo to v0.33.2 to match repo v18

### DIFF
--- a/ansible/roles/ipfs/tasks/main.yaml
+++ b/ansible/roles/ipfs/tasks/main.yaml
@@ -8,7 +8,7 @@
   block:
     - name: Download kubo (IPFS CLI)
       ansible.builtin.get_url:
-        url: "https://dist.ipfs.tech/kubo/v0.32.1/kubo_v0.32.1_linux-amd64.tar.gz"
+        url: "https://dist.ipfs.tech/kubo/v0.33.2/kubo_v0.33.2_linux-amd64.tar.gz"
         dest: "/tmp/kubo.tar.gz"
         mode: '0644'
 


### PR DESCRIPTION
The docker image `ipfs/kubo:latest` uses IPFS repository version 18. The host binary we download during provisioning was hardcoded to `v0.32.1`, which is only compatible up to repository version 16. This caused `ipfs add` commands to fail with the error: `Error: Your programs version (16) is lower than your repos (18)`. Upgrading the host binary to `v0.33.2` resolves this repo format mismatch.