### PR TITLE
fix(ipfs): Bump kubo to v0.33.2 to match repo v18

### DIFF
--- a/ansible/roles/ipfs/tasks/main.yaml
+++ b/ansible/roles/ipfs/tasks/main.yaml
@@ -4,6 +4,13 @@
     path: /usr/local/bin/ipfs
   register: ipfs_binary
 
+- name: Check IPFS version if installed
+  ansible.builtin.command: /usr/local/bin/ipfs --version
+  register: ipfs_version
+  changed_when: false
+  failed_when: false
+  when: ipfs_binary.stat.exists
+
 - name: Install IPFS CLI
   block:
     - name: Download kubo (IPFS CLI)
@@ -33,7 +40,7 @@
         - "/tmp/kubo.tar.gz"
         - "/tmp/kubo"
   become: yes
-  when: not ipfs_binary.stat.exists
+  when: not ipfs_binary.stat.exists or (ipfs_version is defined and ipfs_version.stdout is defined and '0.33.2' not in ipfs_version.stdout)
 
 - name: Ensure IPFS data directory exists
   ansible.builtin.file:


### PR DESCRIPTION
The docker image `ipfs/kubo:latest` uses IPFS repository version 18. The host binary we download during provisioning was hardcoded to `v0.32.1`, which is only compatible up to repository version 16. This caused `ipfs add` commands to fail with the error: `Error: Your programs version (16) is lower than your repos (18)`. Upgrading the host binary to `v0.33.2` resolves this repo format mismatch. This also includes idempotency logic checking `ipfs --version` to force an upgrade of the binary.