### PR TITLE
Feat: Distributed PyPI cache proxy over IPFS

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,8 @@
 # TODO
 
+## Next
+- [ ] Implement `apt` package caching proxy via IPFS.
+
 ## Immediate Actions
 
 - [x] **Fix Authentik Nomad Job:**

--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -54,8 +54,18 @@ client {
   enabled = true
   servers = ["{{ hostvars[groups['controller_nodes'][0]]['cluster_ip'] }}"]
   
+  env {
+    PIP_INDEX_URL = "http://127.0.0.1:3141/simple/"
+    PIP_TRUSTED_HOST = "127.0.0.1"
+  }
+
   meta {
     node_type = "worker"
+  }
+
+  host_volume "pypi_proxy" {
+    path      = "{{ nomad_volumes_dir }}/pypi_proxy"
+    read_only = false
   }
 
   host_volume "pipecatapp" {

--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -55,7 +55,7 @@ client {
   servers = ["{{ hostvars[groups['controller_nodes'][0]]['cluster_ip'] }}"]
   
   env {
-    PIP_INDEX_URL = "http://127.0.0.1:3141/simple/"
+    PIP_INDEX_URL = "http://127.0.0.1:{{ pypi_proxy_port | default(3141) }}/simple/"
     PIP_TRUSTED_HOST = "127.0.0.1"
   }
 

--- a/ansible/roles/pypi_proxy/tasks/main.yml
+++ b/ansible/roles/pypi_proxy/tasks/main.yml
@@ -1,0 +1,38 @@
+- name: Ensure PyPI Proxy volume directory exists
+  ansible.builtin.file:
+    path: "{{ nomad_volumes_dir }}/pypi_proxy"
+    state: directory
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: '0755'
+
+- name: Create temporary directory for PyPI Proxy source
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: _pypi_proxy
+  register: pypi_proxy_src_dir
+
+- name: Copy PyPI Proxy source files to target
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../pipecatapp/services/ipfs_pypi_proxy/"
+    dest: "{{ pypi_proxy_src_dir.path }}/"
+    mode: '0644'
+
+- name: Build PyPI Proxy Docker image locally
+  ansible.builtin.command:
+    cmd: docker build -t pypi_proxy:latest .
+    chdir: "{{ pypi_proxy_src_dir.path }}"
+  changed_when: true
+
+- name: Remove temporary source directory
+  ansible.builtin.file:
+    path: "{{ pypi_proxy_src_dir.path }}"
+    state: absent
+
+- name: Template PyPI Proxy Nomad job
+  ansible.builtin.template:
+    src: pypi_proxy.nomad.j2
+    dest: "{{ nomad_jobs_dir }}/pypi_proxy.nomad"
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: '0644'

--- a/ansible/roles/pypi_proxy/templates/pypi_proxy.nomad.j2
+++ b/ansible/roles/pypi_proxy/templates/pypi_proxy.nomad.j2
@@ -1,0 +1,39 @@
+job "pypi-proxy" {
+  datacenters = {{ nomad_datacenters | default(['dc1']) | to_json }}
+  type        = "system"
+
+  group "proxy" {
+    network {
+      port "http" {
+        static = 3141
+      }
+    }
+
+    task "fastapi" {
+      driver = "docker"
+
+      config {
+        # Using a pre-built image or build block if possible.
+        # To avoid adding a whole CI/CD build step here for now, we'll build it locally on the nodes
+        # or assume an image name like "pypi_proxy:latest" that we can build in the Ansible tasks.
+        image = "pypi_proxy:latest"
+        network_mode = "host"
+        volumes = [
+          "{{ nomad_volumes_dir }}/pypi_proxy:/data"
+        ]
+      }
+
+      env {
+        DB_PATH = "/data/cache.db"
+        PROXY_BASE_URL = "http://127.0.0.1:3141"
+        IPFS_API_URL = "http://127.0.0.1:5001"
+        IPFS_GATEWAY_URL = "http://127.0.0.1:8080"
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+  }
+}

--- a/ansible/roles/pypi_proxy/templates/pypi_proxy.nomad.j2
+++ b/ansible/roles/pypi_proxy/templates/pypi_proxy.nomad.j2
@@ -5,7 +5,7 @@ job "pypi-proxy" {
   group "proxy" {
     network {
       port "http" {
-        static = 3141
+        static = {{ pypi_proxy_port | default(3141) }}
       }
     }
 
@@ -25,9 +25,10 @@ job "pypi-proxy" {
 
       env {
         DB_PATH = "/data/cache.db"
-        PROXY_BASE_URL = "http://127.0.0.1:3141"
-        IPFS_API_URL = "http://127.0.0.1:5001"
-        IPFS_GATEWAY_URL = "http://127.0.0.1:8080"
+        PORT = "{{ pypi_proxy_port | default(3141) }}"
+        PROXY_BASE_URL = "http://127.0.0.1:{{ pypi_proxy_port | default(3141) }}"
+        IPFS_API_URL = "http://127.0.0.1:{{ ipfs_api_port | default(5001) }}"
+        IPFS_GATEWAY_URL = "http://127.0.0.1:{{ ipfs_gateway_port | default(8080) }}"
       }
 
       resources {

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -86,6 +86,7 @@ traceway_port: 8089
 ipfs_swarm_port: 4001
 ipfs_api_port: 5001
 ipfs_gateway_port: 8080
+pypi_proxy_port: 3141
 
 # Standard Paths
 consul_data_dir: "/opt/consul"

--- a/pipecatapp/services/ipfs_pypi_proxy/Dockerfile
+++ b/pipecatapp/services/ipfs_pypi_proxy/Dockerfile
@@ -9,7 +9,8 @@ COPY main.py .
 
 ENV DB_PATH=/data/cache.db
 ENV PROXY_BASE_URL=http://127.0.0.1:3141
+ENV PORT=3141
 
-EXPOSE 3141
+EXPOSE $PORT
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "3141"]
+CMD uvicorn main:app --host 0.0.0.0 --port $PORT

--- a/pipecatapp/services/ipfs_pypi_proxy/Dockerfile
+++ b/pipecatapp/services/ipfs_pypi_proxy/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+ENV DB_PATH=/data/cache.db
+ENV PROXY_BASE_URL=http://127.0.0.1:3141
+
+EXPOSE 3141
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "3141"]

--- a/pipecatapp/services/ipfs_pypi_proxy/main.py
+++ b/pipecatapp/services/ipfs_pypi_proxy/main.py
@@ -1,0 +1,164 @@
+import os
+import sqlite3
+import json
+import logging
+from typing import Optional
+from fastapi import FastAPI, Request, HTTPException, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+import httpx
+import tempfile
+import aiofiles
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="IPFS PyPI Proxy")
+
+# Configuration
+PYPI_SIMPLE_URL = "https://pypi.org/simple"
+IPFS_API_URL = os.getenv("IPFS_API_URL", "http://127.0.0.1:5001")
+IPFS_GATEWAY_URL = os.getenv("IPFS_GATEWAY_URL", "http://127.0.0.1:8080")
+DB_PATH = os.getenv("DB_PATH", "/data/cache.db")
+PROXY_BASE_URL = os.getenv("PROXY_BASE_URL", "http://127.0.0.1:3141")
+
+# Initialize SQLite database
+def init_db():
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS package_cache (
+            filename TEXT PRIMARY KEY,
+            cid TEXT NOT NULL
+        )
+    ''')
+    conn.commit()
+    conn.close()
+
+init_db()
+
+def get_cid_for_filename(filename: str) -> Optional[str]:
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute("SELECT cid FROM package_cache WHERE filename = ?", (filename,))
+    row = cursor.fetchone()
+    conn.close()
+    return row[0] if row else None
+
+def save_cid_for_filename(filename: str, cid: str):
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute("INSERT OR REPLACE INTO package_cache (filename, cid) VALUES (?, ?)", (filename, cid))
+    conn.commit()
+    conn.close()
+
+@app.get("/")
+def index():
+    return {"status": "ok", "service": "IPFS PyPI Proxy"}
+
+@app.get("/simple/")
+async def simple_index():
+    # Pip usually doesn't request the root /simple/ with JSON, but we forward it just in case
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{PYPI_SIMPLE_URL}/")
+        return Response(content=resp.content, status_code=resp.status_code, media_type=resp.headers.get("content-type"))
+
+@app.get("/simple/{package}/")
+async def package_index(package: str, request: Request):
+    headers = {"Accept": "application/vnd.pypi.simple.v1+json"}
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{PYPI_SIMPLE_URL}/{package}/", headers=headers)
+
+        if resp.status_code != 200:
+            return Response(content=resp.content, status_code=resp.status_code)
+
+        data = resp.json()
+
+        # Rewrite URLs in the files list
+        for file_info in data.get("files", []):
+            original_url = file_info["url"]
+            filename = file_info["filename"]
+            # Save original URL in fragment so we know where to fetch it from
+            file_info["url"] = f"{PROXY_BASE_URL}/download/{filename}?source={original_url}"
+
+        return JSONResponse(content=data, media_type="application/vnd.pypi.simple.v1+json")
+
+@app.get("/download/{filename}")
+async def download_package(filename: str, source: str):
+    cid = get_cid_for_filename(filename)
+
+    if cid:
+        logger.info(f"Cache hit for {filename}: CID {cid}")
+        # Ensure it is available locally via gateway
+        try:
+            # We must not use `async with` for the client if we are returning a StreamingResponse
+            # that will consume it after the function returns, or we need to manage the lifecycle in the generator.
+            # A cleaner way is to let StreamingResponse manage it by yielding from a generator that manages the client.
+            async def stream_from_ipfs():
+                async with httpx.AsyncClient(timeout=30.0) as ipfs_client:
+                    req = ipfs_client.build_request("GET", f"{IPFS_GATEWAY_URL}/ipfs/{cid}")
+                    r = await ipfs_client.send(req, stream=True)
+                    if r.status_code != 200:
+                        raise Exception(f"IPFS Gateway returned status {r.status_code}")
+                    async for chunk in r.aiter_raw():
+                        yield chunk
+
+            # Since we can't easily catch an exception raised inside the generator *before* returning the response
+            # to fall back, let's just make a HEAD or initial GET request to verify it's there.
+            async with httpx.AsyncClient(timeout=5.0) as check_client:
+                check_r = await check_client.head(f"{IPFS_GATEWAY_URL}/ipfs/{cid}")
+                if check_r.status_code == 200:
+                    return StreamingResponse(stream_from_ipfs(), media_type="application/octet-stream")
+                else:
+                    logger.warning(f"CID {cid} not found on gateway (status {check_r.status_code}), falling back to download")
+        except Exception as e:
+            logger.error(f"Failed to stream from IPFS gateway for {cid}: {e}")
+            # Fall back to downloading
+
+    logger.info(f"Cache miss for {filename}, downloading from {source}")
+
+    # Download from PyPI to a temp file
+    with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+        tmp_path = tmp_file.name
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            async with client.stream("GET", source) as response:
+                response.raise_for_status()
+                async with aiofiles.open(tmp_path, 'wb') as f:
+                    async for chunk in response.aiter_bytes():
+                        await f.write(chunk)
+
+            # Add to IPFS
+            logger.info(f"Adding {filename} to IPFS")
+            with open(tmp_path, "rb") as f:
+                add_resp = await client.post(
+                    f"{IPFS_API_URL}/api/v0/add",
+                    files={"file": (filename, f)},
+                    timeout=60.0
+                )
+                add_resp.raise_for_status()
+                ipfs_data = add_resp.json()
+                cid = ipfs_data["Hash"]
+
+                logger.info(f"Added {filename} to IPFS with CID {cid}")
+                save_cid_for_filename(filename, cid)
+
+        # Stream the file back to the client
+        async def stream_file():
+            try:
+                async with aiofiles.open(tmp_path, 'rb') as f:
+                    while chunk := await f.read(8192):
+                        yield chunk
+            finally:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+
+        return StreamingResponse(stream_file(), media_type="application/octet-stream")
+
+    except Exception as e:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        logger.error(f"Error processing {filename}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/pipecatapp/services/ipfs_pypi_proxy/requirements.txt
+++ b/pipecatapp/services/ipfs_pypi_proxy/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+httpx
+aiofiles

--- a/playbooks/services/pypi_proxy.yaml
+++ b/playbooks/services/pypi_proxy.yaml
@@ -1,0 +1,12 @@
+- name: Deploy PyPI Proxy over IPFS
+  hosts: all
+  remote_user: "{{ target_user }}"
+  become: yes
+
+  tags:
+    - pypi_proxy
+
+  roles:
+    - role: pypi_proxy
+      tags:
+        - pypi_proxy


### PR DESCRIPTION
Implemented a lightweight proxy API that intercepts PyPI requests and downloads missing packages to the local IPFS daemon. It caches IPFS CIDs via a local SQLite database, resulting in a distributed internal package manager. Configured Nomad clients to transparently redirect all `pip` requests to this proxy cache.

---
*PR created automatically by Jules for task [6359046036978932237](https://jules.google.com/task/6359046036978932237) started by @LokiMetaSmith*