### PR TITLE
Add dry-run support to bootstrap and provisioning

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -42,6 +42,7 @@ show_help() {
     echo "  --continue                   Resume from the last successfully completed playbook."
     echo "  --benchmark                  Run benchmark tests."
     echo "  --deploy-docker              Deploy the pipecat application using Docker (Default)."
+    echo "  --dry-run                    Perform a dry run to validate playbooks without applying changes."
     echo "  --run-local                  Deploy the pipecat application using local raw_exec (for debugging)."
     echo "  --home-assistant-debug       Enable debug mode for Home Assistant."
     echo "  --container                  Run the entire infrastructure inside a single large container."
@@ -71,6 +72,7 @@ DO_CLEAN_GIT=false
 DO_SYSTEM_CLEANUP=false
 DO_PURGE_JOBS=false
 DO_STATUS=false
+DO_DRY_RUN=false
 DO_HEAL_CLUSTER=false
 DO_RECOVER_NODE=false
 VERBOSE_LEVEL=0
@@ -108,6 +110,10 @@ find_controller() {
 
     # Install nmap if missing
     if ! command -v nmap >/dev/null 2>&1; then
+        if [ "$DO_DRY_RUN" = true ]; then
+            echo -e "${RED}❌ Dry run failed: nmap is missing. Please install it manually before running a dry run.${NC}"
+            exit 1
+        fi
         echo -e "⏳ Installing nmap for network scanning..."
         if sudo -n true 2>/dev/null; then
             sudo apt-get update -qq && sudo apt-get install -y nmap -qq >/dev/null 2>&1
@@ -290,6 +296,10 @@ for ((i=0; i<${#ARGS[@]}; i++)); do
             ;;
         --test-mode)
             PROCESSED_ARGS+=("--test-mode")
+            ;;
+        --dry-run)
+            DO_DRY_RUN=true
+            PROCESSED_ARGS+=("--dry-run")
             ;;
         --clean-git|--clean) # Support legacy --clean just in case, but map to clean-git
             DO_CLEAN_GIT=true
@@ -636,7 +646,9 @@ ensure_python_environment() {
         echo "⚠️  Warning: requirements-dev.txt not found. Skipping dependency installation."
     fi
 
-    run_step "Installing OpenCode AI Agent" "npm ci"
+    if [ "$DO_DRY_RUN" != true ]; then
+        run_step "Installing OpenCode AI Agent" "npm ci"
+    fi
 
     run_step "Installing Ansible Core" "pip install ansible-core pyyaml"
 
@@ -857,7 +869,9 @@ fi
 # --- Run Initial Machine Setup ---
 echo -e "${BOLD}=== System Bootstrap ===${NC}"
 if [ -f "initial-setup/setup.sh" ]; then
-    if [ -f "/.dockerenv" ] && [ "$(hostname)" = "pipecat-dev-runner" ]; then
+    if [ "$DO_DRY_RUN" = true ]; then
+        echo -e "⏭️  Skipping initial machine setup script due to --dry-run."
+    elif [ -f "/.dockerenv" ] && [ "$(hostname)" = "pipecat-dev-runner" ]; then
          echo "🐳 Container environment detected. Skipping initial machine setup (setup.sh)."
     else
         # We need to ensure sudo doesn't hang on prompt hidden by redirection

--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -317,9 +317,12 @@ def purge_nomad_jobs():
     print("Process cleanup complete.")
 
 
-def run_playbook(playbook_path, extra_vars, tags, verbose_level):
+def run_playbook(playbook_path, extra_vars, tags, verbose_level, dry_run=False):
     """Runs a single ansible playbook."""
     cmd = [".venv/bin/ansible-playbook", "-i", INVENTORY_FILE, playbook_path]
+
+    if dry_run:
+        cmd.extend(["--check", "--diff"])
 
     for key, value in extra_vars.items():
         cmd.extend(["--extra-vars", f"{key}={value}"])
@@ -663,6 +666,7 @@ def main():
     parser.add_argument("--purge-jobs", action="store_true", help="Purge Nomad jobs (handled by wrapper mostly, but var passed)")
     parser.add_argument("--only-purge", action="store_true", help="Only purge jobs and exit (requires --purge-jobs)")
     parser.add_argument("--test-mode", action="store_true", help="Test mode: Purges application jobs after they are deployed to save memory during testing.")
+    parser.add_argument("--dry-run", action="store_true", help="Perform a dry run to validate playbooks without applying changes.")
     parser.add_argument("--only-status", action="store_true", help="Only print status and exit")
     parser.add_argument("--deploy-docker", action="store_true", help="Deploy via Docker")
     parser.add_argument("--run-local", action="store_true", help="Deploy via raw_exec")
@@ -857,7 +861,7 @@ def main():
         disk_used_before, _ = get_current_disk_usage()
 
         # --- Run ---
-        run_playbook(pb_path, extra_vars, args.tags, verbose_level)
+        run_playbook(pb_path, extra_vars, args.tags, verbose_level, dry_run=args.dry_run)
         executed_playbooks.append(pb_path)
 
         # --- Test Mode Purge ---


### PR DESCRIPTION
Implemented a dry run capability for `bootstrap.sh` and `scripts/provisioning.py` by adding a `--dry-run` flag.

- Validated requirements and properly propagated `--dry-run` to all levels.
- Safely skips mutating host operations like running `apt-get`, `npm ci`, and `initial-setup/setup.sh`.
- Appends Ansible's `--check` and `--diff` parameters to print the diffs without actually applying the changes to the infrastructure.

---
*PR created automatically by Jules for task [6994861705714246702](https://jules.google.com/task/6994861705714246702) started by @LokiMetaSmith*