### PR TITLE
Fix APT Proxy and PyPI Proxy relative paths in Ansible roles

### DIFF
--- a/ansible/roles/apt_proxy/tasks/main.yml
+++ b/ansible/roles/apt_proxy/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Copy APT Proxy source files to target
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../pipecatapp/services/ipfs_apt_proxy/"
+    src: "{{ playbook_dir }}/../../pipecatapp/services/ipfs_apt_proxy/"
     dest: "{{ apt_proxy_src_dir.path }}/"
     mode: '0644'
 

--- a/ansible/roles/pypi_proxy/tasks/main.yml
+++ b/ansible/roles/pypi_proxy/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Copy PyPI Proxy source files to target
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../pipecatapp/services/ipfs_pypi_proxy/"
+    src: "{{ playbook_dir }}/../../pipecatapp/services/ipfs_pypi_proxy/"
     dest: "{{ pypi_proxy_src_dir.path }}/"
     mode: '0644'
 


### PR DESCRIPTION
The Ansible playbooks for `apt_proxy` and `pypi_proxy` were failing during deployment with an error indicating that they could not find the source files on the Ansible Controller.

This was caused by an incorrect relative path construction. The tasks attempted to reference the `pipecatapp/services/...` directories using `{{ playbook_dir }}/../pipecatapp/...`. However, since the playbooks executing these roles are located in the `playbooks/services/` directory, `playbook_dir` evaluates to that directory. Going up one level (`../`) only reached the `playbooks/` directory, not the repository root where `pipecatapp/` resides.

I fixed this issue by changing the paths to `{{ playbook_dir }}/../../pipecatapp/services/...` in both the `apt_proxy` and `pypi_proxy` roles, ensuring they correctly navigate up two levels to the repository root to find the necessary files.

---
*PR created automatically by Jules for task [10715651201436647316](https://jules.google.com/task/10715651201436647316) started by @LokiMetaSmith*