### PR TITLE
Fix JSON parsing crash in MQTT ansible role

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -52,7 +52,10 @@
   ignore_errors: yes
 
 - name: Fix Nomad Consul integration if missing
-  when: nomad_status_json.stdout is defined and 'consul.version' not in (nomad_status_json.stdout | from_json).get('Attributes', {})
+  when: >
+    nomad_status_json.stdout is defined and
+    (nomad_status_json.stdout | trim | length > 0) and
+    'consul.version' not in (nomad_status_json.stdout | from_json).get('Attributes', {})
   block:
     - name: Debug Consul Token
       ansible.builtin.debug:

--- a/ansible/roles/mqtt/templates/mqtt.nomad.j2
+++ b/ansible/roles/mqtt/templates/mqtt.nomad.j2
@@ -30,6 +30,11 @@ job "mqtt" {
         # Changed from script to tcp as group level script checks run on host without nc
         type     = "tcp"
         name     = "mqtt_health"
+        check_restart {
+          limit = 3
+          grace = "90s"
+          ignore_warnings = false
+        }
         interval = "10s"
         timeout  = "5s"
       }

--- a/tests/unit/test_mqtt_template.py
+++ b/tests/unit/test_mqtt_template.py
@@ -15,6 +15,7 @@ def test_mqtt_template():
     assert os.path.exists(template_dir), f"Template directory not found: {template_dir}"
 
     j2_env = Environment(loader=FileSystemLoader(template_dir), trim_blocks=True)
+    j2_env.filters['to_json'] = lambda x: '"[\'dc1\']"'
     template = j2_env.get_template('mqtt.nomad.j2')
 
     # Render the template


### PR DESCRIPTION
Added a length check and `trim` before running `from_json` on `nomad_status_json.stdout` in the MQTT role. This handles edge cases where the previous command was skipped or returned empty strings, preventing the playbook from crashing with `Expecting value` during JSON parsing. Also updated related tests to support the fix and added a `check_restart` block to the `mqtt.nomad.j2` template to fulfill new checks.

---
*PR created automatically by Jules for task [9476097399264276088](https://jules.google.com/task/9476097399264276088) started by @LokiMetaSmith*