### PR TITLE
Fix Ansible `from_json` parsing issues on empty strings

### DIFF
--- a/ansible/roles/benchmark_models/tasks/benchmark_loop.yaml
+++ b/ansible/roles/benchmark_models/tasks/benchmark_loop.yaml
@@ -28,7 +28,7 @@
     NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
     NOMAD_TLS_SKIP_VERIFY: "1"
   register: benchmark_models_job_status_result
-  until: "((benchmark_models_job_status_result.stdout | from_json).Status == 'dead') and ((benchmark_models_job_status_result.stdout | from_json).JobSummary.Summary.Complete == 1)"
+  until: "(benchmark_models_job_status_result.stdout | default('{}', true) | from_json).get('Status') == 'dead' and (benchmark_models_job_status_result.stdout | default('{}', true) | from_json).get('JobSummary', {}).get('Summary', {}).get('Complete') == 1"
   retries: 60 # 5 minutes (60 * 5s)
   delay: 5
   changed_when: false
@@ -47,7 +47,7 @@
 
 - name: "Capture benchmark logs for model {{ model.name }}"
   ansible.builtin.command:
-    cmd: "nomad alloc logs {{ (benchmark_models_job_allocs_result.stdout | from_json)[0].ID }} benchmark-task"
+    cmd: "nomad alloc logs {{ (benchmark_models_job_allocs_result.stdout | default('[{}]', true) | from_json)[0].get('ID', '') }} benchmark-task"
   environment:
     NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
     NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"

--- a/ansible/roles/influxdb/tasks/main.yaml
+++ b/ansible/roles/influxdb/tasks/main.yaml
@@ -25,7 +25,7 @@
 
 - name: Extract job status
   ansible.builtin.set_fact:
-    influxdb_job_state: "{{ (influxdb_job_status.stdout | from_json).Status | default('missing') }}"
+    influxdb_job_state: "{{ (influxdb_job_status.stdout | default('{\"Status\": \"missing\"}', true) | from_json).get('Status', 'missing') }}"
 
 - name: Purge influxdb job if in failed state
   ansible.builtin.command:

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -280,7 +280,7 @@
 
 - name: Set benchmark_results fact from parsed content
   ansible.builtin.set_fact:
-    benchmark_results: "{{ benchmark_parser_result.stdout | from_json }}"
+    benchmark_results: "{{ benchmark_parser_result.stdout | default('{}', true) | from_json }}"
 
 - name: Create control vectors directory
   ansible.builtin.file:

--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -55,7 +55,7 @@
   when: >
     nomad_status_json.stdout is defined and
     (nomad_status_json.stdout | trim | length > 0) and
-    'consul.version' not in (nomad_status_json.stdout | from_json).get('Attributes', {})
+    'consul.version' not in (nomad_status_json.stdout | default('{}', true) | from_json).get('Attributes', {})
   block:
     - name: Debug Consul Token
       ansible.builtin.debug:

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -25,7 +25,7 @@
 
     - name: Set benchmark_results fact from parsed content
       ansible.builtin.set_fact:
-        benchmark_results: "{{ (parsed_json.stdout | from_json) if (parsed_json.stdout is defined and parsed_json.stdout) else [] }}"
+        benchmark_results: "{{ parsed_json.stdout | default('[]', true) | from_json }}"
       when: benchmark_log_raw.content is defined
   rescue:
     - name: Set empty benchmark results on failure

--- a/ansible/roles/seed_models/tasks/main.yaml
+++ b/ansible/roles/seed_models/tasks/main.yaml
@@ -56,7 +56,7 @@
     vllm_expert_models: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'vllm_expert_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
     piper_voice_files: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'piper_voice_files') | map(attribute='content') | map('from_json') | first | default([]) }}"
     embedding_models: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'embedding_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
-    stt_models: "{{ ((consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'stt_models') | first).content | default('{}')) | from_json }}"
+    stt_models: "{{ ((consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'stt_models') | first).content | default('{}', true)) | from_json }}"
     vision_models: "{{ consul_models.results | selectattr('status', 'defined') | selectattr('status', 'equalto', 200) | selectattr('item', 'equalto', 'vision_models') | map(attribute='content') | map('from_json') | first | default([]) }}"
 
 # --- LLM Models ---

--- a/ansible/roles/telegraf/tasks/main.yaml
+++ b/ansible/roles/telegraf/tasks/main.yaml
@@ -32,7 +32,7 @@
 
 - name: Extract job status
   ansible.builtin.set_fact:
-    telegraf_job_state: "{{ (telegraf_job_status.stdout | from_json).Status | default('missing') }}"
+    telegraf_job_state: "{{ (telegraf_job_status.stdout | default('{\"Status\": \"missing\"}', true) | from_json).get('Status', 'missing') }}"
 
 - name: Purge telegraf job if in failed state
   ansible.builtin.command:

--- a/ansible/roles/zigbee2mqtt/tasks/main.yaml
+++ b/ansible/roles/zigbee2mqtt/tasks/main.yaml
@@ -25,7 +25,7 @@
 
 - name: Extract job status
   ansible.builtin.set_fact:
-    zigbee2mqtt_job_state: "{{ (zigbee2mqtt_job_status.stdout | from_json).Status | default('missing') }}"
+    zigbee2mqtt_job_state: "{{ (zigbee2mqtt_job_status.stdout | default('{\"Status\": \"missing\"}', true) | from_json).get('Status', 'missing') }}"
 
 - name: Purge zigbee2mqtt job if in failed state
   ansible.builtin.command:


### PR DESCRIPTION
Fix Ansible `from_json` parsing issues on empty strings

Multiple Ansible roles (e.g. `zigbee2mqtt`, `influxdb`, `llama_cpp`) were using the `from_json` filter directly on shell outputs (like `nomad job status -json`). When these commands returned an empty string (e.g., if a job doesn't exist), the `from_json` filter would crash with `Expecting value: line 1 column 1 (char 0)`.

This commit replaces the brittle usage with a robust pattern `(var.stdout | default('{"Status": "missing"}', true) | from_json).get('Status', 'missing')`. The `true` argument to the `default` filter ensures that empty strings evaluate to truthy so that the default value is supplied. It also replaces nested dot-notation access with safer `.get()` chain calls where necessary.

---
*PR created automatically by Jules for task [12381911835120628031](https://jules.google.com/task/12381911835120628031) started by @LokiMetaSmith*