### PR TITLE
docs: Add GEMINI.md custom instructions file

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,11 @@
+# AI Agent Custom Instructions
+
+Welcome to the project! This repository contains important files that dictate your operating procedures, highlight past architectural learnings, and outline critical security vulnerabilities you must avoid.
+
+Please read and internalize the contents of the following files before proceeding with your tasks:
+
+* **[AGENTS.md](AGENTS.md)**: Contains mandatory playbooks, executable oracles, and operating procedures for working within this repository. **You must strictly adhere to these instructions.**
+* **[.jules/bolt.md](.jules/bolt.md)**: A collection of technical learnings, performance optimization techniques, and architectural insights specific to this project (e.g., handling async blocking, array processing, and serialization).
+* **[.jules/sentinel.md](.jules/sentinel.md)**: A repository of historical security vulnerabilities, bug post-mortems, and preventative measures. Pay close attention to these to avoid re-introducing similar flaws (e.g., SSRF, Path Traversal, and Command Injection).
+
+By incorporating the knowledge from these files, you ensure your contributions are secure, performant, and aligned with the project's established practices.


### PR DESCRIPTION
Creates `GEMINI.md` to serve as a set of custom instructions for the Gemini agent. It includes links and references to the `.jules/` directory (specifically `.jules/bolt.md` and `.jules/sentinel.md` for historical learning and security vulnerabilities) and the `AGENTS.md` file (for mandatory playbooks and procedures), as requested.

---
*PR created automatically by Jules for task [4051249002869841226](https://jules.google.com/task/4051249002869841226) started by @LokiMetaSmith*