### PR TITLE
Secure tool_server metadata endpoint

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -246,8 +246,8 @@ This section tracks identified placeholder files, corrupted binaries, and code t
   - Audit frontend code (`pipecatapp/static/js`), workflows (`workflows/`), and tools (`pipecatapp/tools/`) for hardcoded secrets, API keys, or tokens.
   - Remove any found secrets and replace them with secure environment variable loading.
 - [x] **Audit unauthenticated API endpoints:**
-  - Review `pipecatapp/web_server.py` and other API definitions to ensure sensitive data endpoints are authenticated.
-  - Specifically check endpoints returning user data or configuration.
+  - [x] Review `pipecatapp/web_server.py` and other API definitions to ensure sensitive data endpoints are authenticated.
+  - [x] Specifically check endpoints returning user data or configuration.
 - [x] **Audit WebSocket security:**
   - Verify that WebSocket connections enforce strict Origin checks to prevent Cross-Site WebSocket Hijacking (CSWSH).
   - Consider implementing authentication for WebSocket connections.

--- a/pipecatapp/tool_server.py
+++ b/pipecatapp/tool_server.py
@@ -145,10 +145,21 @@ async def run_tool(request: ToolRequest, authorization: Optional[str] = Header(N
         raise HTTPException(status_code=500, detail=f"Error executing tool: {str(e)}")
 
 @app.get("/tools/")
-async def list_tools():
+async def list_tools(authorization: Optional[str] = Header(None)):
     """
     Returns a list of available tools and their methods.
     """
+    if not API_KEY:
+        raise HTTPException(status_code=500, detail="API key not configured on server.")
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header is missing.")
+    try:
+        auth_type, token = authorization.split()
+        if auth_type.lower() != "bearer" or not secrets.compare_digest(token, API_KEY):
+            raise HTTPException(status_code=403, detail="Invalid credentials.")
+    except ValueError:
+        raise HTTPException(status_code=401, detail="Invalid authorization header format.")
+
     available_tools = {}
     for tool_name, tool_instance in tools.items():
         methods = {}


### PR DESCRIPTION
This submission secures the `/tools/` API endpoint in `pipecatapp/tool_server.py` by requiring Bearer token authentication. It also marks the corresponding task ("Audit unauthenticated API endpoints") as complete in `TODO.md`.

*   `pipecatapp/tool_server.py`: Added authorization header validation to `list_tools`.
*   `TODO.md`: Marked the unauthenticated API endpoint audit task as `[x]`.

---
*PR created automatically by Jules for task [11568721657278512274](https://jules.google.com/task/11568721657278512274) started by @LokiMetaSmith*