### PR TITLE
Explicitly route apt-get traffic to cluster IP

### DIFF
--- a/ansible/roles/apt_proxy/tasks/main.yml
+++ b/ansible/roles/apt_proxy/tasks/main.yml
@@ -41,7 +41,7 @@
   ansible.builtin.copy:
     dest: /etc/apt/apt.conf.d/01proxy
     content: |
-      Acquire::http::Proxy "http://127.0.0.1:{{ apt_proxy_port | default(3142) }}";
+      Acquire::http::Proxy "http://{{ apt_proxy_host }}:{{ apt_proxy_port | default(3142) }}";
       Acquire::https::Proxy "false";
     mode: '0644'
   become: true

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -87,6 +87,7 @@ ipfs_swarm_port: 4001
 ipfs_api_port: 5001
 ipfs_gateway_port: 8080
 pypi_proxy_port: 3141
+apt_proxy_host: "{{ cluster_ip }}"
 apt_proxy_port: 3142
 
 # Standard Paths


### PR DESCRIPTION
Fixes a failure during node provisioning (`Unable to connect to 127.0.0.1:3142:`). The `core_infra` playbook `apt-get` tasks were implicitly failing on workers that were not running the central `apt_proxy` service because they were looking for a proxy on `127.0.0.1`. Added a global `apt_proxy_host` value referencing the overlay network `cluster_ip` and updated the injection logic for the `01proxy` file.

---
*PR created automatically by Jules for task [14513344698917715679](https://jules.google.com/task/14513344698917715679) started by @LokiMetaSmith*