### PR TITLE
Fix apt-get hanging on dead proxy during bootstrap

### DIFF
--- a/playbooks/common_setup.yaml
+++ b/playbooks/common_setup.yaml
@@ -8,6 +8,11 @@
         - common
 
   tasks:
+    - name: Ensure leftover APT proxy configuration is removed before bootstrap
+      ansible.builtin.file:
+        path: /etc/apt/apt.conf.d/01proxy
+        state: absent
+
     - name: Ensure Debian repositories are configured (needed for minimal/live ISOs)
       raw: |
         cat <<EOF > /etc/apt/sources.list

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -40,6 +40,12 @@ if command -v apt-get &> /dev/null; then
     echo -e "\n${BOLD}📦 Cleaning Apt Cache...${NC}"
     sudo apt-get clean
     sudo apt-get autoremove -y
+
+    # Remove proxy config if it exists so next apt-get runs without hanging on a dead proxy container
+    if [ -f "/etc/apt/apt.conf.d/01proxy" ]; then
+        echo "Removing stale apt proxy configuration..."
+        sudo rm -f /etc/apt/apt.conf.d/01proxy
+    fi
 else
     echo "Apt not found, skipping Apt cleanup."
 fi


### PR DESCRIPTION
The `--system-cleanup` command was deleting all docker containers, which destroyed the `apt_proxy` container running on `127.0.0.1:3142`. However, it left behind the `/etc/apt/apt.conf.d/01proxy` file created by the `apt_proxy` ansible role. The next time the bootstrap playbook (`common_setup.yaml`) ran, the `apt-get update` task failed because it was trying to connect to a dead proxy.

This fix ensures that the configuration file is purged during system cleanup and prior to the initial apt update in the bootstrap sequence.

---
*PR created automatically by Jules for task [10239978865010499867](https://jules.google.com/task/10239978865010499867) started by @LokiMetaSmith*