### PR TITLE
Add Gnutella Architectural Analysis

### DIFF
--- a/docs/analysis/GNUTELLA_ANALYSIS.md
+++ b/docs/analysis/GNUTELLA_ANALYSIS.md
@@ -1,0 +1,82 @@
+# Analysis: Lessons from the Gnutella Project for Distributed AI Pipelines
+
+## 1. Overview
+The Gnutella protocol is a pioneer in decentralized, peer-to-peer (P2P) systems, best known for its role in file sharing during the early 2000s (e.g., via LimeWire, BearShare). An analysis of its architecture reveals several resilient design patterns for distributed networks that operate without centralized control.
+
+This document explores what we can learn from Gnutella, evaluating its architectural concepts against our current legacy-cluster AI pipeline (Nomad, Consul, IPFS), and considering whether any of its solutions could inspire improvements in our architecture.
+
+## 2. Key Lessons from Gnutella
+
+1. **Decentralized Resource Discovery (Gossip Protocol):**
+   - Gnutella is essentially a decentralized P2P search engine. It relies on a gossip protocol (PING/PONG messages) to maintain a live map of the network topology and discover peers dynamically.
+   - **Lesson:** A mesh network approach to state and discovery is highly resilient to node churn, eliminating single points of failure.
+
+2. **Bootstrapping via Web Caches (GWebCache):**
+   - Because Gnutella lacks a central registry, new peers enter the network using lightweight, federated bootstrap nodes (GWebCaches) that provide lists of active peers.
+   - **Lesson:** Bootstrapping doesn't need a heavy central server; a simple, stateless cache of known active IPs is enough to connect a node to the broader mesh.
+
+3. **Dealing with Firewalls (PUSH Mechanism):**
+   - Inbound TCP ports are often blocked by NAT and firewalls. Gnutella implemented a "PUSH" message where the downloader asks the firewalled uploader to initiate the connection outward.
+   - **Lesson:** Reverse-connection mechanisms are critical for decentralized networks running on consumer-grade hardware or legacy clusters behind NATs.
+
+4. **Extensibility Built-in (GGEP):**
+   - The Gnutella Generic Extension Protocol (GGEP) allowed developers to append arbitrary metadata and new features to the core protocol without breaking older clients.
+   - **Lesson:** Designing protocols with reserved spaces for optional extensions allows organic evolution over decades without requiring synchronized hard forks.
+
+5. **Query Routing Efficiency:**
+   - Early Gnutella used inefficient flood routing (QUERY/QUERYHIT), but later scaled to millions of users via "Dynamic Query Routing" using Bloom filters to summarize shared content and avoid querying nodes that obviously lack the data.
+
+## 3. Pros and Cons: Gnutella vs. Current Architecture
+
+Our current architecture relies on **Nomad (Orchestration)**, **Consul (Service Discovery/KV)**, and **IPFS (Decentralized Storage)**.
+
+### **Current Architecture (Nomad + Consul + IPFS)**
+**Pros:**
+- **Strong Consistency & State Management:** Consul's Raft consensus ensures a reliable source of truth for service discovery and configuration.
+- **Enterprise-grade Orchestration:** Nomad handles complex job placement, lifecycle management, and resource constraints natively.
+- **Robust Data Layer:** IPFS provides content-addressable storage and DHT-based routing, which is highly optimized for distributing large artifacts (e.g., LLM weights).
+
+**Cons:**
+- **Control Plane Vulnerability:** If the Nomad/Consul server quorum is lost, the cluster halts. It requires careful Raft management (e.g., our `watchdog.sh` for single-node recovery).
+- **Overhead:** Consul and Nomad agents have a higher continuous overhead on legacy Intel Core 2 Duo CPUs compared to a raw gossip protocol.
+
+### **Gnutella-Inspired Architecture (Pure P2P Mesh / Gossip)**
+**Pros:**
+- **Extreme Resilience:** Zero single points of failure. The network continues to function even if 90% of the nodes go offline.
+- **Lightweight Discovery:** PING/PONG and Bloom filter-based discovery use minimal CPU overhead compared to maintaining a Raft consensus log.
+- **NAT Traversal:** Built-in PUSH routing is highly effective for legacy nodes behind restrictive residential firewalls.
+
+**Cons:**
+- **Eventual (or No) Consistency:** Gnutella makes no guarantees about state. It is difficult to reliably assign specific AI jobs (like a specialized expert model) without a central coordinator.
+- **Search Latency:** Querying a mesh can take minutes as messages propagate, unlike Consul's instantaneous local lookups.
+- **Security:** Pure P2P meshes are vulnerable to Sybil attacks and malicious nodes feeding fake data, requiring complex trust/reputation layers.
+
+## 4. Are Gnutella's Libraries and Tools Useful Today?
+
+**Direct Usage:** Using actual Gnutella protocol libraries (like modern implementations in GTK-Gnutella or hobbyist clients) is likely **not useful** for our pipeline. The protocol is heavily optimized for human-driven file searching (like MP3s), not automated API routing or large-scale AI orchestration. Our use of IPFS already provides a vastly superior, modern solution for P2P data distribution (via IPFS CID routing).
+
+**Architectural Inspiration:** The *solutions* Gnutella used are very relevant, particularly for dealing with legacy, unreliable nodes.
+
+## 5. TODO List / Implementation Options
+
+Based on the Gnutella lessons, here are actionable implementation options to explore for our legacy cluster:
+
+- [ ] **Option 1: Gossip-Based Service Fallback**
+  - **Idea:** If Consul fails (loss of Raft quorum), implement a lightweight UDP/TCP gossip protocol (like Serf or a custom PING/PONG mechanism) as a fallback so nodes can still discover LLM experts locally.
+  - **Justification:** Improves cluster survivability on unstable hardware.
+
+- [ ] **Option 2: Stateless Bootstrapping (GWebCache-style)**
+  - **Idea:** Instead of relying entirely on static IP definitions in Ansible (`inventory.yaml`) or a strictly defined Nomad control node, deploy a lightweight, stateless "Cluster Cache" API.
+  - **Justification:** New legacy nodes could simply hit an HTTP endpoint to fetch the IPs of current active Nomad/Consul servers and auto-join the mesh, easing dynamic scaling.
+
+- [ ] **Option 3: Bloom Filter Capability Routing**
+  - **Idea:** Instead of registering every individual AI capability in a centralized Consul KV, nodes could advertise a Bloom filter representing their supported AI models/tools during routine gossip.
+  - **Justification:** Reduces memory overhead and Raft write-amplification on older hardware when nodes frequently join or leave.
+
+- [ ] **Option 4: PUSH-style Reverse Proxies for NAT Traversal**
+  - **Idea:** For nodes deployed at the "edge" (e.g., external residential networks), implement a "connect-back" PUSH model. If a controller cannot reach a worker via direct IP (due to NAT), the worker initiates the connection to a known jump-server to receive Nomad allocations.
+  - **Justification:** Eliminates the need to configure VPNs or Tailscale on heavily constrained legacy nodes, mirroring Gnutella's firewall bypass.
+
+- [ ] **Option 5: Extensible Job Payloads (Inspired by GGEP)**
+  - **Idea:** Utilize a flexible, extensible header format (like Gnutella's GGEP) within our internal RPC messaging between AI expert nodes, ensuring forward compatibility when introducing new routing parameters or AI features.
+  - **Justification:** Prevents cluster partition issues when rolling out updates to a subset of legacy nodes.


### PR DESCRIPTION
Added a new markdown document `docs/analysis/GNUTELLA_ANALYSIS.md` that analyzes the architecture of the Gnutella project, compares it to the current Nomad/Consul/IPFS architecture, and explores potential implementation options inspired by Gnutella's solutions.

---
*PR created automatically by Jules for task [2827531734693702898](https://jules.google.com/task/2827531734693702898) started by @LokiMetaSmith*