### PR TITLE
Implement Stateless Bootstrapping Cache (Gnutella Option 2)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -184,6 +184,12 @@ These structural suggestions are targeted for a future major release to signific
 - [x] **Investigate RPC Provider Monitoring:** Added documentation to `llamacpp-rpc.nomad.j2` explaining how to configure Prometheus scraping for rpc-server providers. Note: rpc-server doesn't expose native metrics - requires wrapper script or external monitoring.
 - [x] **Evaluate Ouro/LoopLM Support in llama.cpp:** In 3 months, check if the upstream `llama.cpp` project has added support for the Ouro LoopLM architecture. If so, create a plan to integrate it as a native model option. (Note: Ouro works in `llama.cpp` using the standard Llama GGUF format, but custom architectural features are skipped as they are not yet supported. Full native support for the LoopLM architecture is still lacking in llama.cpp, so no integration plan is needed at this time.)
 
+## Gnutella Analysis Integration Ideas
+
+This section tracks actionable ideas derived from the `docs/analysis/GNUTELLA_ANALYSIS.md` document.
+
+- [x] **Stateless Bootstrapping (GWebCache-style):** Implement a lightweight, stateless HTTP cache to serve active Nomad/Consul server IPs dynamically to new legacy nodes without relying on hardcoded variables in `inventory.yaml`. (Implemented in `cluster_cache/`)
+
 ## 4. Maintenance & Clean Up
 
 This section tracks identified placeholder files, corrupted binaries, and code that needs to be fixed or removed.

--- a/cluster_cache/README.md
+++ b/cluster_cache/README.md
@@ -1,0 +1,40 @@
+# Cluster Cache
+
+Inspired by the Gnutella protocol's GWebCaches, `cluster_cache` is a lightweight, stateless HTTP API designed to facilitate dynamic node bootstrapping in a distributed network.
+
+## Purpose
+
+Instead of relying on static definitions (like `inventory.yaml`) or a strictly defined Nomad control node, new legacy nodes can hit this HTTP endpoint to fetch the IPs of currently active Nomad/Consul servers. This allows nodes to auto-join the mesh and eases dynamic scaling, aligning with Option 2 from the `docs/analysis/GNUTELLA_ANALYSIS.md`.
+
+## Features
+
+- **Stateless Operation:** Maintains a simple in-memory cache of active node IPs.
+- **Auto-Expiration:** Nodes must regularly ping the cache (e.g., every few minutes). Stale nodes are automatically removed.
+- **RESTful API:** Provides simple `/register` and `/nodes` endpoints.
+
+## Usage
+
+Start the cache server:
+
+```bash
+pip install -r requirements.txt
+uvicorn app:app --host 0.0.0.0 --port 8080
+```
+
+Register a node (defaults to client IP if not provided):
+
+```bash
+curl -X POST http://localhost:8080/register
+```
+
+Register a node with a specific IP:
+
+```bash
+curl -X POST http://localhost:8080/register -H "Content-Type: application/json" -d '{"ip_address": "192.168.1.100"}'
+```
+
+Get a list of active nodes:
+
+```bash
+curl http://localhost:8080/nodes
+```

--- a/cluster_cache/app.py
+++ b/cluster_cache/app.py
@@ -1,0 +1,70 @@
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+from typing import List, Optional
+import time
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="Cluster Cache",
+    description="A GWebCache-style stateless bootstrap cache for dynamic node discovery",
+    version="1.0.0"
+)
+
+# In-memory store of active nodes
+# Mapping of IP address to last seen timestamp
+active_nodes = {}
+
+# Expiration time for nodes (in seconds)
+NODE_TTL = 300  # 5 minutes
+
+class NodeRegistration(BaseModel):
+    ip_address: Optional[str] = None
+
+class NodeList(BaseModel):
+    nodes: List[str]
+
+def cleanup_expired_nodes():
+    """Removes nodes that haven't been seen within the TTL."""
+    current_time = time.time()
+    expired = [ip for ip, last_seen in active_nodes.items() if current_time - last_seen > NODE_TTL]
+    for ip in expired:
+        logger.info(f"Removing expired node from cache: {ip}")
+        del active_nodes[ip]
+
+@app.post("/register", summary="Register or update a node's active status")
+async def register_node(request: Request, node: NodeRegistration = None):
+    """
+    Register a node to the cluster cache.
+    If no IP is provided in the body, the client's IP from the request is used.
+    """
+    ip_address = None
+    if node and node.ip_address:
+        ip_address = node.ip_address
+    else:
+        ip_address = request.client.host
+
+    if not ip_address:
+        raise HTTPException(status_code=400, detail="Could not determine IP address")
+
+    active_nodes[ip_address] = time.time()
+    logger.info(f"Registered node: {ip_address}")
+
+    # Cleanup on registration to keep the list fresh
+    cleanup_expired_nodes()
+
+    return {"status": "success", "ip_address": ip_address}
+
+@app.get("/nodes", response_model=NodeList, summary="Get active nodes")
+async def get_nodes():
+    """
+    Retrieve the list of currently active nodes.
+    """
+    cleanup_expired_nodes()
+    return {"nodes": list(active_nodes.keys())}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/cluster_cache/requirements.txt
+++ b/cluster_cache/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+pydantic==2.6.4

--- a/tests/unit/cluster_cache/test_cluster_cache.py
+++ b/tests/unit/cluster_cache/test_cluster_cache.py
@@ -1,0 +1,66 @@
+import pytest
+from fastapi.testclient import TestClient
+import time
+import sys
+import os
+
+# Add the repository root to the sys.path so we can import from cluster_cache
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+
+from cluster_cache.app import app, active_nodes, cleanup_expired_nodes
+
+client = TestClient(app)
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Reset the active_nodes dictionary before each test."""
+    active_nodes.clear()
+    yield
+    active_nodes.clear()
+
+def test_get_nodes_empty():
+    response = client.get("/nodes")
+    assert response.status_code == 200
+    assert response.json() == {"nodes": []}
+
+def test_register_node_client_ip():
+    # Test client IP registration
+    response = client.post("/register")
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    # TestClient's default client IP is "testclient"
+    assert response.json()["ip_address"] == "testclient"
+
+    response = client.get("/nodes")
+    assert response.status_code == 200
+    assert "testclient" in response.json()["nodes"]
+
+def test_register_node_explicit_ip():
+    test_ip = "192.168.1.100"
+    response = client.post("/register", json={"ip_address": test_ip})
+    assert response.status_code == 200
+    assert response.json() == {"status": "success", "ip_address": test_ip}
+
+    response = client.get("/nodes")
+    assert response.status_code == 200
+    assert test_ip in response.json()["nodes"]
+
+def test_node_expiration(monkeypatch):
+    # Register a node
+    test_ip = "192.168.1.50"
+    client.post("/register", json={"ip_address": test_ip})
+
+    response = client.get("/nodes")
+    assert test_ip in response.json()["nodes"]
+
+    # Mock time.time to simulate expiration
+    original_time = time.time
+
+    # Fast forward time beyond NODE_TTL (300 seconds)
+    monkeypatch.setattr(time, 'time', lambda: original_time() + 400)
+
+    # Querying should trigger cleanup
+    response = client.get("/nodes")
+    assert response.status_code == 200
+    assert test_ip not in response.json()["nodes"]
+    assert response.json() == {"nodes": []}


### PR DESCRIPTION
Implements the "Option 2: Stateless Bootstrapping (GWebCache-style)" suggested in `docs/analysis/GNUTELLA_ANALYSIS.md`. 

A new lightweight FastAPI web server lives in `cluster_cache/` that allows new legacy nodes to query and auto-discover active Nomad/Consul server IPs rather than relying on a static `inventory.yaml`. Stale nodes are automatically removed. Includes unit tests via pytest.

---
*PR created automatically by Jules for task [6984747642714233638](https://jules.google.com/task/6984747642714233638) started by @LokiMetaSmith*