### PR TITLE
Fix shared template resolution in Nomad job deployments

### DIFF
--- a/ansible/roles/exo/templates/exo.nomad.j2
+++ b/ansible/roles/exo/templates/exo.nomad.j2
@@ -16,7 +16,7 @@ job "exo" {
 
     {% set image_tar_name = 'exo' %}
 
-    {% include 'shared/load_image_task.nomad.j2' %}
+    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
 
     task "exo" {
       driver = "docker"

--- a/ansible/roles/memory_graph/templates/memory-graph.nomad.j2
+++ b/ansible/roles/memory_graph/templates/memory-graph.nomad.j2
@@ -11,7 +11,7 @@ job "memory-graph" {
 
     {% set image_tar_name = 'memory_graph' %}
 
-    {% include 'shared/load_image_task.nomad.j2' %}
+    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
 
     task "server" {
       driver = "docker"

--- a/ansible/roles/memory_service/templates/memory_service.nomad.j2
+++ b/ansible/roles/memory_service/templates/memory_service.nomad.j2
@@ -25,7 +25,7 @@ job "memory-service" {
 
     {% set image_tar_name = 'memory_service' %}
 
-    {% include 'shared/load_image_task.nomad.j2' %}
+    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
 
     task "api" {
       driver = "docker"

--- a/ansible/roles/openclaw/templates/openclaw.nomad.j2
+++ b/ansible/roles/openclaw/templates/openclaw.nomad.j2
@@ -15,7 +15,7 @@ job "openclaw" {
 
     {% set image_tar_name = 'openclaw' %}
 
-    {% include 'shared/load_image_task.nomad.j2' %}
+    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
 
     task "openclaw" {
       driver = "docker"

--- a/ansible/roles/opengravity/templates/opengravity.nomad.j2
+++ b/ansible/roles/opengravity/templates/opengravity.nomad.j2
@@ -34,7 +34,7 @@ job "opengravity" {
 
     {% set image_tar_name = 'opengravity' %}
 
-    {% include 'shared/load_image_task.nomad.j2' %}
+    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
 
     task "nginx" {
       driver = "docker"

--- a/ansible/roles/pipecatapp/templates/architect.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/architect.nomad.j2
@@ -64,7 +64,7 @@ job "architect" {
 
     {% set image_tar_name = 'pipecatapp' %}
 
-    {% include 'shared/load_image_task.nomad.j2' %}
+    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
 
     task "architect-task" {
       driver = "docker"

--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -106,7 +106,7 @@ job "{{ job_name | default('pipecat-app') }}" {
     {% if pipecat_deployment_style == 'docker' %}
     {% set image_cid = pipecatapp_ipfs_cid %}
     {% set image_tar_name = 'pipecatapp' %}
-    {% include 'shared/load_image_task.nomad.j2' %}
+    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
 
     task "pipecat-task" {
       driver = "docker"

--- a/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
@@ -55,7 +55,7 @@ job "seed-agent" {
 
     {% set image_tar_name = 'pipecatapp' %}
 
-    {% include 'shared/load_image_task.nomad.j2' %}
+    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
 
     task "seed-agent-task" {
       driver = "docker"

--- a/ansible/roles/tool_server/templates/tool_server.nomad.j2
+++ b/ansible/roles/tool_server/templates/tool_server.nomad.j2
@@ -15,7 +15,7 @@ job "tool-server" {
 
     {% set image_tar_name = 'tool_server' %}
 
-    {% include 'shared/load_image_task.nomad.j2' %}
+    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
 
     task "tool-server-task" {
       driver = "docker"


### PR DESCRIPTION
Resolves the "template not found" errors impacting Nomad job deployments due to Ansible sandbox restrictions.

**Issue:**
Ansible roles using the `{% include 'shared/load_image_task.nomad.j2' %}` statement failed to evaluate when deployed (e.g. `app_services.yaml`). Ansible's secure sandbox environment restricts native Jinja includes to specific contextual folders, causing relative traversal like `../../../` to throw execution exceptions.

**Solution:**
1. Replaced the `{% include %}` directive with Ansible's native `lookup('template')` plugin.
2. Formatted the reference to point to an absolute template path dynamically constructed via `(inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2'`.

This maintains local Jinja context correctly across variable sets like `image_cid` and applies across all associated `.nomad.j2` services.

---
*PR created automatically by Jules for task [16696121233336767676](https://jules.google.com/task/16696121233336767676) started by @LokiMetaSmith*