### PR TITLE
Fix 'image_cid is undefined' by replacing lookup with include for load_image_task

### DIFF
--- a/ansible/roles/exo/templates/exo.nomad.j2
+++ b/ansible/roles/exo/templates/exo.nomad.j2
@@ -16,7 +16,7 @@ job "exo" {
 
     {% set image_tar_name = 'exo' %}
 
-    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
+    {% include 'load_image_task.nomad.j2' %}
 
     task "exo" {
       driver = "docker"

--- a/ansible/roles/exo/templates/load_image_task.nomad.j2
+++ b/ansible/roles/exo/templates/load_image_task.nomad.j2
@@ -1,0 +1,1 @@
+../../../templates/shared/load_image_task.nomad.j2

--- a/ansible/roles/memory_graph/templates/load_image_task.nomad.j2
+++ b/ansible/roles/memory_graph/templates/load_image_task.nomad.j2
@@ -1,0 +1,1 @@
+../../../templates/shared/load_image_task.nomad.j2

--- a/ansible/roles/memory_graph/templates/memory-graph.nomad.j2
+++ b/ansible/roles/memory_graph/templates/memory-graph.nomad.j2
@@ -11,7 +11,7 @@ job "memory-graph" {
 
     {% set image_tar_name = 'memory_graph' %}
 
-    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
+    {% include 'load_image_task.nomad.j2' %}
 
     task "server" {
       driver = "docker"

--- a/ansible/roles/memory_service/templates/load_image_task.nomad.j2
+++ b/ansible/roles/memory_service/templates/load_image_task.nomad.j2
@@ -1,0 +1,1 @@
+../../../templates/shared/load_image_task.nomad.j2

--- a/ansible/roles/memory_service/templates/memory_service.nomad.j2
+++ b/ansible/roles/memory_service/templates/memory_service.nomad.j2
@@ -25,7 +25,7 @@ job "memory-service" {
 
     {% set image_tar_name = 'memory_service' %}
 
-    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
+    {% include 'load_image_task.nomad.j2' %}
 
     task "api" {
       driver = "docker"

--- a/ansible/roles/openclaw/templates/load_image_task.nomad.j2
+++ b/ansible/roles/openclaw/templates/load_image_task.nomad.j2
@@ -1,0 +1,1 @@
+../../../templates/shared/load_image_task.nomad.j2

--- a/ansible/roles/openclaw/templates/openclaw.nomad.j2
+++ b/ansible/roles/openclaw/templates/openclaw.nomad.j2
@@ -15,7 +15,7 @@ job "openclaw" {
 
     {% set image_tar_name = 'openclaw' %}
 
-    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
+    {% include 'load_image_task.nomad.j2' %}
 
     task "openclaw" {
       driver = "docker"

--- a/ansible/roles/opengravity/templates/load_image_task.nomad.j2
+++ b/ansible/roles/opengravity/templates/load_image_task.nomad.j2
@@ -1,0 +1,1 @@
+../../../templates/shared/load_image_task.nomad.j2

--- a/ansible/roles/opengravity/templates/opengravity.nomad.j2
+++ b/ansible/roles/opengravity/templates/opengravity.nomad.j2
@@ -34,7 +34,7 @@ job "opengravity" {
 
     {% set image_tar_name = 'opengravity' %}
 
-    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
+    {% include 'load_image_task.nomad.j2' %}
 
     task "nginx" {
       driver = "docker"

--- a/ansible/roles/pipecatapp/templates/architect.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/architect.nomad.j2
@@ -64,7 +64,7 @@ job "architect" {
 
     {% set image_tar_name = 'pipecatapp' %}
 
-    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
+    {% include 'load_image_task.nomad.j2' %}
 
     task "architect-task" {
       driver = "docker"

--- a/ansible/roles/pipecatapp/templates/load_image_task.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/load_image_task.nomad.j2
@@ -1,0 +1,1 @@
+../../../templates/shared/load_image_task.nomad.j2

--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -106,7 +106,7 @@ job "{{ job_name | default('pipecat-app') }}" {
     {% if pipecat_deployment_style == 'docker' %}
     {% set image_cid = pipecatapp_ipfs_cid %}
     {% set image_tar_name = 'pipecatapp' %}
-    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
+    {% include 'load_image_task.nomad.j2' %}
 
     task "pipecat-task" {
       driver = "docker"

--- a/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
@@ -55,7 +55,7 @@ job "seed-agent" {
 
     {% set image_tar_name = 'pipecatapp' %}
 
-    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
+    {% include 'load_image_task.nomad.j2' %}
 
     task "seed-agent-task" {
       driver = "docker"

--- a/ansible/roles/tool_server/templates/load_image_task.nomad.j2
+++ b/ansible/roles/tool_server/templates/load_image_task.nomad.j2
@@ -1,0 +1,1 @@
+../../../templates/shared/load_image_task.nomad.j2

--- a/ansible/roles/tool_server/templates/tool_server.nomad.j2
+++ b/ansible/roles/tool_server/templates/tool_server.nomad.j2
@@ -15,7 +15,7 @@ job "tool-server" {
 
     {% set image_tar_name = 'tool_server' %}
 
-    {{ lookup('template', (inventory_dir | default(playbook_dir)) + '/ansible/templates/shared/load_image_task.nomad.j2') }}
+    {% include 'load_image_task.nomad.j2' %}
 
     task "tool-server-task" {
       driver = "docker"


### PR DESCRIPTION
The issue reported an Ansible error `[ERROR]: Task failed: 'image_cid' is undefined` when templating `tool_server.nomad.j2`. This error occurs because `tool_server.nomad.j2` uses `lookup('template', ...)` to include `load_image_task.nomad.j2`, but `lookup` does not inherit the local context set by `{% set image_cid = ... %}`. 

To fix this, according to the AGENTS.md guidelines, I updated the template rendering logic. I replaced the `lookup` call with an `{% include 'load_image_task.nomad.j2' %}` statement and created symlinks inside the respective `templates/` directory of each affected role pointing to `../../../templates/shared/load_image_task.nomad.j2`.

Roles affected and updated:
- exo
- memory_graph
- memory_service
- openclaw
- opengravity
- pipecatapp
- tool_server

---
*PR created automatically by Jules for task [15207147449519779662](https://jules.google.com/task/15207147449519779662) started by @LokiMetaSmith*