### PR TITLE
fix: preserve ansible color output in provisioning script

### DIFF
--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -394,13 +394,13 @@ def run_playbook(playbook_path, extra_vars, tags, verbose_level, dry_run=False):
 
                 # If verbose, write to stdout
                 if verbose_level >= 2:
-                    sys.stdout.write(clean_line)
+                    sys.stdout.write(line)
                 elif verbose_level < 2:
                     # Keep a small buffer in case of error?
                     # If error happens, we might want to dump the last N lines or point to the log.
                     # The user said "highlight when errors occur... running list of warnings and errors".
                     # We can store everything in memory if it's not too huge, or just rely on the file.
-                    captured_lines.append(clean_line)
+                    captured_lines.append(line)
 
             process.wait()
             return_code = process.returncode


### PR DESCRIPTION
Restores ANSI color codes when printing `subprocess` output (like Ansible playbook runs) to standard out in `scripts/provisioning.py`.

The script was previously stripping ANSI codes from the line before printing to the console and appending to the `captured_lines` buffer, which removed all colors (like Ansible's green/red output). The logic has been adjusted to print the raw line while continuing to write the stripped version (`clean_line`) to the log file to keep the text logs clean.

---
*PR created automatically by Jules for task [17402085071208683227](https://jules.google.com/task/17402085071208683227) started by @LokiMetaSmith*