### PR TITLE
Fix ansi colors missing on console text

### DIFF
--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -394,13 +394,13 @@ def run_playbook(playbook_path, extra_vars, tags, verbose_level, dry_run=False):
 
                 # If verbose, write to stdout
                 if verbose_level >= 2:
-                    sys.stdout.write(clean_line)
+                    sys.stdout.write(line)
                 elif verbose_level < 2:
                     # Keep a small buffer in case of error?
                     # If error happens, we might want to dump the last N lines or point to the log.
                     # The user said "highlight when errors occur... running list of warnings and errors".
                     # We can store everything in memory if it's not too huge, or just rely on the file.
-                    captured_lines.append(clean_line)
+                    captured_lines.append(line)
 
             process.wait()
             return_code = process.returncode


### PR DESCRIPTION
Fix ansi colors missing on console text by piping raw stdout lines to standard output for logging processes instead of regex-stripped lines.

---
*PR created automatically by Jules for task [15615531230574717066](https://jules.google.com/task/15615531230574717066) started by @LokiMetaSmith*