### PR TITLE
Fix opengravity docker save tag error

### DIFF
--- a/ansible/roles/opengravity/tasks/main.yaml
+++ b/ansible/roles/opengravity/tasks/main.yaml
@@ -33,6 +33,7 @@
 - name: Build OpenGravity custom Docker image
   vars:
     image_name: opengravity
+    image_tag: "local"
     build_dir: "/opt/opengravity-build"
   ansible.builtin.include_tasks:
     file: "../../tasks/build_cached_image.yaml"


### PR DESCRIPTION
Fix opengravity docker save tag error\n\nThe opengravity ansible role was failing to export the built docker image because it expected the `local` tag, but the shared build task was defaulting to `latest` due to `image_tag` not being provided.\n\nExplicitly defining `image_tag: "local"` inside `ansible/roles/opengravity/tasks/main.yaml` fixes this.

---
*PR created automatically by Jules for task [15300010239480349772](https://jules.google.com/task/15300010239480349772) started by @LokiMetaSmith*