### PR TITLE
feat: Extract RAG Tool into microservice (Phase 2)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -139,7 +139,7 @@ These structural suggestions are targeted for a future major release to signific
 - [x] **Strict Infrastructure vs. Payload Separation:** Created `scripts/run_nomad.sh` - a dedicated script to deploy Nomad job files without Ansible. Ansible now only provisions infrastructure (OS, Docker, Consul, Nomad, network overlay). Application payloads (pipecatapp, llamacpp, AI experts) deployed via `./run_nomad.sh run ansible/jobs/<job>.nomad`.
 - [ ] **Microservice De-monolithization of `TwinService`:** To improve robustness on legacy hardware, the main `pipecatapp` (router/workflow engine) should be made as lightweight as possible. Extract heavy, blocking tools (e.g., RAG document embedding, isolated Python code execution sandboxes) into independent microservices running as separate Nomad jobs. The core agent should interact with these tools exclusively via the Consul Service Mesh.
   - [x] Phase 1: Architectural Design (Created `TWINSERVICE_DEMONOLITHIZATION_DESIGN.md`)
-  - [ ] Phase 2: RAG Microservice Extraction
+  - [x] Phase 2: RAG Microservice Extraction
   - [ ] Phase 3: Code Runner Sandbox Extraction
 
 ## Future Enhancements and Backlog

--- a/ansible/jobs/rag-service.nomad
+++ b/ansible/jobs/rag-service.nomad
@@ -1,0 +1,53 @@
+job "rag-service" {
+  datacenters = ["dc1"]
+  type = "service"
+
+  group "rag-group" {
+    count = 1
+
+    network {
+      mode = "bridge"
+      port "http" {
+        to = 8000
+      }
+    }
+
+    service {
+      name = "rag-service"
+      port = "8000"
+
+      connect {
+        sidecar_service {}
+      }
+
+      check {
+        name     = "RAG Service HTTP Check"
+        type     = "http"
+        path     = "/docs"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "rag-server" {
+      driver = "docker"
+
+      config {
+        image = "rag-service:local"
+        ports = ["http"]
+      }
+
+      env {
+        PORT = "8000"
+        # Mount the repository if needed, or rely on internal knowledge base
+        RAG_BASE_DIR = "/repo"
+        RAG_ALLOW_ROOT_SCAN = "True"
+      }
+
+      resources {
+        cpu    = 1000 # 1000 MHz
+        memory = 2048 # 2GB RAM for embedding models
+      }
+    }
+  }
+}

--- a/pipecatapp/services/rag/Dockerfile
+++ b/pipecatapp/services/rag/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy requirement list (ensure it exists or we copy from root)
+# For this service, we need fastapi, uvicorn, faiss-cpu, sentence-transformers, langchain_community
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+RUN pip install --no-cache-dir fastapi uvicorn faiss-cpu sentence-transformers langchain_community chromadb
+
+# Copy the application code
+# We copy the entire pipecatapp since RAG_Tool depends on PMMMemory and utils
+COPY pipecatapp/ /app/pipecatapp/
+
+# Setup Environment
+ENV PYTHONPATH=/app
+ENV PORT=8000
+
+# Expose port
+EXPOSE 8000
+
+# Run the RAG server
+CMD ["python", "pipecatapp/services/rag/rag_server.py"]

--- a/pipecatapp/services/rag/rag_server.py
+++ b/pipecatapp/services/rag/rag_server.py
@@ -1,0 +1,77 @@
+import uvicorn
+from fastapi import FastAPI, HTTPException, Security, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from pydantic import BaseModel
+import os
+import sys
+
+# Ensure pipecatapp is in path so we can import RAG_Tool
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+
+from pipecatapp.tools.rag_tool import RAG_Tool
+
+app = FastAPI(title="RAG Microservice")
+
+# A simple security scheme if needed, though Consul Connect handles mTLS
+security = HTTPBearer(auto_error=False)
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    expected_token = os.getenv("RAG_SERVICE_API_KEY")
+    if expected_token and (not credentials or credentials.credentials != expected_token):
+        raise HTTPException(status_code=403, detail="Invalid authorization token")
+    return True
+
+# Initialize the RAG Tool singleton
+rag_tool_instance = None
+
+@app.on_event("startup")
+async def startup_event():
+    global rag_tool_instance
+    # Using defaults or env vars for initialization
+    base_dir = os.getenv("RAG_BASE_DIR", ".")
+    allowed_root = os.getenv("RAG_ALLOWED_ROOT", None)
+    allow_root_scan = os.getenv("RAG_ALLOW_ROOT_SCAN", "False").lower() == "true"
+
+    rag_tool_instance = RAG_Tool(
+        base_dir=base_dir,
+        allowed_root=allowed_root,
+        allow_root_scan=allow_root_scan
+    )
+
+class AddDocumentRequest(BaseModel):
+    filepath: str
+
+class SearchRequest(BaseModel):
+    query: str
+    k: int = 5
+
+class ScanDirectoryRequest(BaseModel):
+    directory: str
+
+@app.post("/add_document", dependencies=[Depends(verify_token)])
+def add_document(req: AddDocumentRequest):
+    try:
+        result = rag_tool_instance.add_document(req.filepath)
+        return {"status": "success", "result": result}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/search", dependencies=[Depends(verify_token)])
+def search(req: SearchRequest):
+    try:
+        result = rag_tool_instance.search(req.query, k=req.k)
+        return {"status": "success", "result": result}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/scan_directory", dependencies=[Depends(verify_token)])
+def scan_directory(req: ScanDirectoryRequest):
+    try:
+        result = rag_tool_instance.scan_directory(req.directory)
+        return {"status": "success", "result": result}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", 8000))
+    uvicorn.run("rag_server:app", host="0.0.0.0", port=port, reload=False)

--- a/pipecatapp/tools/remote_rag_tool.py
+++ b/pipecatapp/tools/remote_rag_tool.py
@@ -1,0 +1,70 @@
+import os
+import requests
+import json
+from typing import Optional
+
+class RemoteRAGTool:
+    """
+    A proxy class that forwards RAG method calls to the remote RAG Microservice.
+    """
+    def __init__(self, base_url: Optional[str] = None, api_key: Optional[str] = None):
+        # Default to the Consul Service Mesh address
+        self.base_url = (base_url or os.getenv("RAG_SERVICE_URL", "http://rag-service.service.consul:8000")).rstrip('/')
+        self.api_key = api_key or os.getenv("RAG_SERVICE_API_KEY")
+
+    def _make_request(self, endpoint: str, payload: dict):
+        headers = {
+            "Content-Type": "application/json"
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        try:
+            response = requests.post(f"{self.base_url}/{endpoint}", json=payload, headers=headers)
+            response.raise_for_status()
+            return response.json().get("result")
+        except requests.exceptions.RequestException as e:
+            if e.response is not None:
+                return f"RAG Service Error: {e.response.status_code} - {e.response.text}"
+            return f"Failed to connect to RAG Service at {self.base_url}: {e}"
+
+    def add_document(self, filepath: str) -> str:
+        return self._make_request("add_document", {"filepath": filepath})
+
+    def search(self, query: str, k: int = 5) -> str:
+        return self._make_request("search", {"query": query, "k": k})
+
+    def scan_directory(self, directory: str) -> str:
+        return self._make_request("scan_directory", {"directory": directory})
+
+    # The executor expects an `execute` method for generic tool routing
+    def execute(self, arguments: dict = None) -> str:
+        """
+        Executes the RAG tool remotely.
+        Expects a dictionary with 'action' (search, add_document, scan_directory)
+        and relevant parameters.
+        """
+        if not arguments:
+            return "Error: RAG tool requires arguments."
+
+        action = arguments.get("action")
+        if not action:
+            # Default to search if just given a query
+            if "query" in arguments:
+                return self.search(arguments["query"], arguments.get("k", 5))
+            return "Error: RAG tool requires an 'action' (search, add_document, scan_directory) or 'query'."
+
+        if action == "search":
+            if "query" not in arguments:
+                return "Error: 'query' argument is required for search action."
+            return self.search(arguments["query"], arguments.get("k", 5))
+        elif action == "add_document":
+            if "filepath" not in arguments:
+                return "Error: 'filepath' argument is required for add_document action."
+            return self.add_document(arguments["filepath"])
+        elif action == "scan_directory":
+            if "directory" not in arguments:
+                return "Error: 'directory' argument is required for scan_directory action."
+            return self.scan_directory(arguments["directory"])
+        else:
+            return f"Error: Unknown action '{action}' for RAG tool."


### PR DESCRIPTION
- Implemented `rag_server.py`, a lightweight FastAPI wrapper for `RAG_Tool`.
- Added a `Dockerfile` for the new `rag-service`.
- Created Nomad job `rag-service.nomad` utilizing Consul Connect.
- Implemented `RemoteRAGTool` as a drop-in proxy for `TwinService`.
- Marked Phase 2 as complete in `TODO.md`.