### PR TITLE
Fix Broken Tests in Master

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -292,10 +292,10 @@ This section tracks identified placeholder files, corrupted binaries, and code t
 - [x] Improve `test_websocket_default_secure_same_origin_success` in `pipecatapp/tests/test_websocket_security.py`
 - [x] Improve `test_yolo_internal_process_frame_failover` in `tests/unit/test_vision_failover.py`
 - [ ] **Fix Broken Tests in Master:**
-  - `tests/unit/test_dependency_scanner.py` (Mock assertion mismatch on `scan_package`)
-  - `tests/unit/test_get_nomad_job.py` (AssertionError for None != Mock)
-  - `tests/unit/test_ha_tool.py` (AssertionError string mismatch)
-  - `tests/unit/test_jules_tool.py` (Exception handling assertions)
+  - [x] `tests/unit/test_dependency_scanner.py` (Mock assertion mismatch on `scan_package`)
+  - [x] `tests/unit/test_get_nomad_job.py` (AssertionError for None != Mock)
+  - [x] `tests/unit/test_ha_tool.py` (AssertionError string mismatch)
+  - [x] `tests/unit/test_jules_tool.py` (Exception handling assertions)
   - `tests/unit/test_memory.py` (KeyError '0' from store reads)
   - `tests/unit/test_pipecat_app_unit.py` (AssertionError)
   - `tests/unit/test_planner_tool.py` (TypeError with async generator)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ pytest-asyncio
 pytest-mock
 pyautogui
 httpx
+requests
 watchdog
 opencv-python-headless
 # Note: torch should be installed with --index-url https://download.pytorch.org/whl/cpu

--- a/tests/unit/test_container_registry_tool.py
+++ b/tests/unit/test_container_registry_tool.py
@@ -2,7 +2,6 @@ import pytest
 import sys
 from unittest.mock import patch, MagicMock
 
-sys.modules['requests'] = MagicMock()
 
 from pipecatapp.tools.container_registry_tool import ContainerRegistryTool
 

--- a/tests/unit/test_dependency_scanner.py
+++ b/tests/unit/test_dependency_scanner.py
@@ -48,15 +48,15 @@ class TestDependencyScanner(unittest.TestCase):
 
     @patch('pipecatapp.tools.code_runner_tool.DependencyScannerTool')
     @patch('pipecatapp.tools.code_runner_tool.SandboxSession')
-    @patch('pipecatapp.tools.code_runner_tool.docker.from_env')
-    def test_code_runner_blocks_unsafe_lib(self, mock_docker_env, MockSandbox, MockScanner):
+    @patch('pipecatapp.tools.code_runner_tool.docker')
+    def test_code_runner_blocks_unsafe_lib(self, mock_docker, MockSandbox, MockScanner):
         # Setup Mock Scanner
         mock_scanner_instance = MockScanner.return_value
         mock_scanner_instance.scan_package.return_value = "⚠️ UNSAFE: Found 1 vulnerabilities..."
 
         runner = CodeRunnerTool()
 
-        result = runner.run_code_in_sandbox("print('hello')", libraries=["vulnerable-lib"])
+        result = runner.executor.execute("print('hello')", libraries=["vulnerable-lib"])
 
         # Debugging output if assertion fails
         if "Operation blocked by security policy" not in result:
@@ -69,8 +69,8 @@ class TestDependencyScanner(unittest.TestCase):
 
     @patch('pipecatapp.tools.code_runner_tool.DependencyScannerTool')
     @patch('pipecatapp.tools.code_runner_tool.SandboxSession')
-    @patch('pipecatapp.tools.code_runner_tool.docker.from_env')
-    def test_code_runner_allows_safe_lib(self, mock_docker_env, MockSandbox, MockScanner):
+    @patch('pipecatapp.tools.code_runner_tool.docker')
+    def test_code_runner_allows_safe_lib(self, mock_docker, MockSandbox, MockScanner):
          # Setup Mock Scanner
         mock_scanner_instance = MockScanner.return_value
         mock_scanner_instance.scan_package.return_value = "Safe: No known vulnerabilities."
@@ -86,7 +86,7 @@ class TestDependencyScanner(unittest.TestCase):
         mock_session.run.return_value = mock_result
 
         runner = CodeRunnerTool()
-        result = runner.run_code_in_sandbox("print('hello')", libraries=["safe-lib"])
+        result = runner.executor.execute("print('hello')", libraries=["safe-lib"])
 
         self.assertEqual(result, "Success")
         mock_scanner_instance.scan_package.assert_called_with("safe-lib", None)

--- a/tests/unit/test_dependency_scanner_tool.py
+++ b/tests/unit/test_dependency_scanner_tool.py
@@ -2,7 +2,6 @@ import pytest
 import sys
 from unittest.mock import patch, MagicMock
 
-sys.modules['httpx'] = MagicMock()
 
 from pipecatapp.tools.dependency_scanner_tool import DependencyScannerTool
 

--- a/tests/unit/test_document_tool.py
+++ b/tests/unit/test_document_tool.py
@@ -7,7 +7,6 @@ from unittest.mock import patch, MagicMock
 # mock fitz before import
 import sys
 sys.modules['fitz'] = MagicMock()
-sys.modules['requests'] = MagicMock()
 
 from pipecatapp.tools.document_tool import DocumentTool, LocalDirectoryBackend, PaperlessBackend
 

--- a/tests/unit/test_get_nomad_job.py
+++ b/tests/unit/test_get_nomad_job.py
@@ -1,3 +1,4 @@
+# Fixed: Resolved AssertionError by removing global sys.modules HTTP mocks in the test suite that shadowed exception classes.
 import pytest
 import sys
 import os

--- a/tests/unit/test_ha_tool.py
+++ b/tests/unit/test_ha_tool.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 import requests
 
 # Add tools directory to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'ansible', 'roles', 'pipecatapp', 'files', 'tools')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp', 'tools')))
 
 from ha_tool import HA_Tool
 

--- a/tests/unit/test_jules_tool.py
+++ b/tests/unit/test_jules_tool.py
@@ -1,3 +1,4 @@
+# Fixed: Resolved TypeError by removing global sys.modules HTTP mocks in the test suite that shadowed exception classes.
 import os
 import unittest
 from unittest.mock import patch, MagicMock, AsyncMock


### PR DESCRIPTION
The commit addresses 4 unit tests (`test_dependency_scanner.py`, `test_get_nomad_job.py`, `test_ha_tool.py`, `test_jules_tool.py`) that were failing due to missing dependencies, outdated paths, and aggressive top-level `sys.modules` patching across the test suite that broke basic Python exception handling.

---
*PR created automatically by Jules for task [10645618605713665183](https://jules.google.com/task/10645618605713665183) started by @LokiMetaSmith*