### PR TITLE
Fix missing driver in load-image task of expert nomad job

### DIFF
--- a/ansible/jobs/expert.nomad.j2
+++ b/ansible/jobs/expert.nomad.j2
@@ -160,6 +160,7 @@ EOH
 
     {% if pipecat_deployment_style | default('docker') == 'docker' %}
     task "load-image" {
+      driver = "raw_exec"
       lifecycle {
         hook    = "prestart"
         sidecar = false


### PR DESCRIPTION
Resolves an issue where the `expert-main` Nomad job would fail to submit due to the `load-image` task lacking a `driver` configuration. The change matches the `raw_exec` configuration used in other similar shared templates (`ansible/templates/shared/load_image_task.nomad.j2`).

---
*PR created automatically by Jules for task [15566638215674840986](https://jules.google.com/task/15566638215674840986) started by @LokiMetaSmith*