### PR TITLE
Fix Nomad API communication scheme in job templates and troubleshooting scripts

### DIFF
--- a/ansible/roles/pipecatapp/templates/architect.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/architect.nomad.j2
@@ -31,7 +31,7 @@ job "architect" {
       USE_SUMMARIZER         = "{{ use_summarizer | default('false') }}"
       STT_SERVICE            = "{{ stt_service | default('faster-whisper') }}"
       SANDBOX_EXECUTOR       = "{{ sandbox_executor | default('docker') }}"
-      NOMAD_ADDR             = "http://{{ cluster_ip }}:4646"
+      NOMAD_ADDR             = "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
       PIPECAT_API_KEYS        = "{{ pipecat_api_keys }}"
       EXTERNAL_EXPERTS_CONFIG = "{{ external_experts_config | to_json | replace('\"', '\\\"') }}"
       OPENAI_API_KEY         = "{{ openai_api_key }}"

--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -31,7 +31,7 @@ job "{{ job_name | default('pipecat-app') }}" {
       USE_SUMMARIZER         = "{{ use_summarizer | default('false') }}"
       STT_SERVICE            = "{{ stt_service | default('faster-whisper') }}"
       SANDBOX_EXECUTOR       = "{{ sandbox_executor | default('docker') }}"
-      NOMAD_ADDR             = "http://{{ cluster_ip }}:4646"
+      NOMAD_ADDR             = "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
       PIPECAT_API_KEYS        = "{{ pipecat_api_keys }}"
       EXTERNAL_EXPERTS_CONFIG = "{{ external_experts_config | to_json | replace('\"', '\\\"') }}"
       OPENAI_API_KEY         = "{{ openai_api_key }}"

--- a/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
@@ -27,7 +27,7 @@ job "seed-agent" {
 
     {% set env_vars %}
     env {
-      NOMAD_ADDR             = "http://{{ cluster_ip }}:4646"
+      NOMAD_ADDR             = "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
       CONSUL_HOST            = "{{ cluster_ip }}"
       CONSUL_PORT            = "{{ consul_http_port }}"
       CONSUL_HTTP_TOKEN      = "{{ consul_bootstrap_token | default('') }}"

--- a/ansible/roles/tool_server/tools/get_nomad_job.py
+++ b/ansible/roles/tool_server/tools/get_nomad_job.py
@@ -13,7 +13,7 @@ def get_nomad_job_definition(job_id):
         print(f"Error: Invalid job_id '{job_id}'. Only alphanumeric characters, dashes, underscores, and dots are allowed.", file=sys.stderr)
         return None
 
-    nomad_addr = os.environ.get("NOMAD_ADDR", "http://localhost:4646")
+    nomad_addr = os.environ.get("NOMAD_ADDR", "https://127.0.0.1:4646")
     url = f"{nomad_addr}/v1/job/{job_id}"
 
     try:

--- a/scripts/troubleshoot.py
+++ b/scripts/troubleshoot.py
@@ -18,7 +18,7 @@ import getpass
 import tempfile
 from datetime import datetime
 
-NOMAD_URL = os.environ.get("NOMAD_ADDR", "http://localhost:4646")
+NOMAD_URL = os.environ.get("NOMAD_ADDR", "https://127.0.0.1:4646")
 
 def get_ssl_context():
     if NOMAD_URL.startswith("https"):


### PR DESCRIPTION
This PR fixes the issue where core cluster components (like `pipecat-app` and LLM agents) would stay "dead" or fail to communicate with Nomad. The internal environment variables (`NOMAD_ADDR`) and fallback Python scripts (`troubleshoot.py`, `get_nomad_job.py`) were hardcoded to use `http://...:4646`, but the Nomad cluster is correctly configured to listen securely over TLS (`https://...:4646`). 

By updating these hardcoded URLs to use `https://` (and correctly referencing `nomad_http_port`), the components can correctly connect to the Nomad API.

---
*PR created automatically by Jules for task [4724162743192534492](https://jules.google.com/task/4724162743192534492) started by @LokiMetaSmith*