### PR TITLE
feat: implement gossip-based service fallback for legacy nodes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -191,6 +191,10 @@ These structural suggestions are targeted for a future major release to signific
 ## Gnutella Analysis Integration Ideas
 
 This section tracks actionable ideas derived from the `docs/analysis/GNUTELLA_ANALYSIS.md` document.
+- [ ] **Option 1: Gossip-Based Service Fallback**
+- [ ] **Option 3: Bloom Filter Capability Routing**
+- [ ] **Option 4: PUSH-style Reverse Proxies for NAT Traversal**
+- [ ] **Option 5: Extensible Job Payloads (Inspired by GGEP)**
 
 - [x] **Stateless Bootstrapping (GWebCache-style):** Implement a lightweight, stateless HTTP cache to serve active Nomad/Consul server IPs dynamically to new legacy nodes without relying on hardcoded variables in `inventory.yaml`. (Implemented in `cluster_cache/`)
 

--- a/pipecatapp/gossip_discovery.py
+++ b/pipecatapp/gossip_discovery.py
@@ -1,0 +1,156 @@
+import asyncio
+import json
+import logging
+import socket
+import time
+from typing import Dict, Optional, List, Tuple, Any
+
+logger = logging.getLogger(__name__)
+
+class GossipDiscovery:
+    """
+    A lightweight UDP gossip protocol for service discovery.
+    Provides a fallback when Consul/Raft is unavailable.
+    """
+    def __init__(self, port: int = 7946, host: str = "0.0.0.0", local_ip: Optional[str] = None):
+        self.port = port
+        self.host = host
+        self.local_ip = local_ip or self._get_local_ip()
+        self.services: Dict[str, Dict[str, Any]] = {}  # service_name -> {"ip": "1.2.3.4", "port": 8080, "last_seen": 12345}
+        self.transport = None
+        self.running = False
+        self.ttl = 30  # seconds until a service is considered dead without heartbeat
+
+    def _get_local_ip(self) -> str:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            # Doesn't have to be reachable
+            s.connect(('10.255.255.255', 1))
+            ip = s.getsockname()[0]
+        except Exception:
+            ip = '127.0.0.1'
+        finally:
+            s.close()
+        return ip
+
+    def register_service(self, service_name: str, port: int):
+        """Registers a local service to be broadcasted."""
+        self.services[service_name] = {
+            "ip": self.local_ip,
+            "port": port,
+            "last_seen": time.time(),
+            "local": True
+        }
+
+    def get_service(self, service_name: str) -> Optional[Tuple[str, int]]:
+        """Returns the (ip, port) of a requested service, or None if not found/expired."""
+        self._cleanup_stale_services()
+        svc = self.services.get(service_name)
+        if svc:
+            return svc["ip"], svc["port"]
+        return None
+
+    def _cleanup_stale_services(self):
+        now = time.time()
+        stale_keys = []
+        for name, data in self.services.items():
+            if not data.get("local", False) and now - data["last_seen"] > self.ttl:
+                stale_keys.append(name)
+
+        for k in stale_keys:
+            logger.info(f"Gossip: Removing stale service {k}")
+            del self.services[k]
+
+    class GossipProtocol(asyncio.DatagramProtocol):
+        def __init__(self, parent):
+            self.parent = parent
+
+        def connection_made(self, transport):
+            self.parent.transport = transport
+
+        def datagram_received(self, data, addr):
+            try:
+                message = json.loads(data.decode('utf-8'))
+                self.parent._handle_message(message, addr)
+            except json.JSONDecodeError:
+                pass
+
+    def _handle_message(self, message: dict, addr: Tuple[str, int]):
+        if message.get("type") == "ANNOUNCE":
+            service_name = message.get("service")
+            port = message.get("port")
+            ip = message.get("ip", addr[0])  # Trust payload IP, or fallback to packet source
+
+            if service_name and port:
+                # Update our registry
+                self.services[service_name] = {
+                    "ip": ip,
+                    "port": port,
+                    "last_seen": time.time(),
+                    "local": False
+                }
+
+    async def _broadcast_loop(self):
+        """Periodically broadcasts local services to the subnet."""
+        # Simple UDP broadcast to the local /24 subnet
+        parts = self.local_ip.split('.')
+        if len(parts) == 4 and self.local_ip != '127.0.0.1':
+            broadcast_ip = f"{parts[0]}.{parts[1]}.{parts[2]}.255"
+        else:
+            broadcast_ip = "255.255.255.255"
+
+        while self.running:
+            if self.transport:
+                for name, data in self.services.items():
+                    if data.get("local", False):
+                        msg = {
+                            "type": "ANNOUNCE",
+                            "service": name,
+                            "ip": self.local_ip,
+                            "port": data["port"]
+                        }
+                        payload = json.dumps(msg).encode('utf-8')
+                        try:
+                            self.transport.sendto(payload, (broadcast_ip, self.port))
+                        except Exception as e:
+                            logger.debug(f"Gossip broadcast failed: {e}")
+            await asyncio.sleep(5)  # Broadcast every 5 seconds
+
+    async def start(self):
+        """Starts the gossip UDP listener and broadcast loop."""
+        if self.running:
+            return
+
+        logger.info(f"Starting Gossip Discovery on {self.host}:{self.port}")
+        self.running = True
+        loop = asyncio.get_running_loop()
+
+        # We need to set SO_BROADCAST to allow sending broadcast packets
+        # And SO_REUSEADDR so multiple apps on the same host can bind to the port
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+
+        # On some systems, binding to "" or "0.0.0.0" is needed to receive broadcasts
+        try:
+            sock.bind((self.host, self.port))
+        except OSError as e:
+            logger.warning(f"Gossip failed to bind to {self.host}:{self.port}: {e}")
+            self.running = False
+            return
+
+        await loop.create_datagram_endpoint(
+            lambda: self.GossipProtocol(self),
+            sock=sock
+        )
+
+        # Start background broadcaster
+        asyncio.create_task(self._broadcast_loop())
+
+    async def stop(self):
+        self.running = False
+        if self.transport:
+            self.transport.close()
+
+# Global instance for the app to use
+gossip_registry = GossipDiscovery()

--- a/pipecatapp/network_scanner.py
+++ b/pipecatapp/network_scanner.py
@@ -2,6 +2,7 @@ import socket
 import asyncio
 import logging
 import httpx
+from pipecatapp.gossip_discovery import gossip_registry
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,16 @@ async def scan_network_for_llms(timeout: float = 0.5) -> str | None:
     Returns the first found base_url (e.g., http://192.168.1.100:11434/v1).
     """
     logger.info("Starting local network scan for LLM services...")
+
+    # Fast path: Check Gossip Registry First
+    # Assuming the services register themselves as "rpc-main", "rpc-coding", or "ollama"
+    for svc_name in ["rpc-main", "rpc-coding", "ollama", "llama.cpp"]:
+        addr = gossip_registry.get_service(svc_name)
+        if addr:
+            ip, port = addr
+            logger.info(f"Discovered LLM via Gossip at {ip}:{port} ({svc_name})")
+            return f"http://{ip}:{port}/v1"
+
     local_ip = get_local_ip()
     ports = [11434, 8080] # Ollama, Llama.cpp/OpenAI
 

--- a/tests/unit/test_gossip_discovery.py
+++ b/tests/unit/test_gossip_discovery.py
@@ -1,0 +1,89 @@
+import pytest
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+from pipecatapp.gossip_discovery import GossipDiscovery
+
+def test_gossip_registry_register_and_get():
+    gossip = GossipDiscovery(local_ip="10.0.0.1")
+    gossip.register_service("rpc-main", 8080)
+
+    # Check we can get it
+    addr = gossip.get_service("rpc-main")
+    assert addr is not None
+    assert addr == ("10.0.0.1", 8080)
+
+    # Check non-existent
+    assert gossip.get_service("missing") is None
+
+def test_gossip_handle_message():
+    gossip = GossipDiscovery(local_ip="10.0.0.1")
+    message = {
+        "type": "ANNOUNCE",
+        "service": "ollama",
+        "ip": "10.0.0.2",
+        "port": 11434
+    }
+
+    gossip._handle_message(message, ("10.0.0.2", 7946))
+
+    addr = gossip.get_service("ollama")
+    assert addr is not None
+    assert addr == ("10.0.0.2", 11434)
+
+    # Ensure it's marked as non-local
+    assert gossip.services["ollama"]["local"] is False
+
+def test_cleanup_stale_services():
+    gossip = GossipDiscovery(local_ip="10.0.0.1")
+    gossip.ttl = 1  # 1 second TTL
+
+    # Add a local service (should never expire)
+    gossip.register_service("local-svc", 8080)
+
+    # Add a remote service (should expire)
+    gossip.services["remote-svc"] = {
+        "ip": "10.0.0.2",
+        "port": 9090,
+        "last_seen": 0,  # Old timestamp
+        "local": False
+    }
+
+    # Before cleanup
+    assert "remote-svc" in gossip.services
+
+    # Trigger cleanup via get_service
+    gossip.get_service("remote-svc")
+
+    # After cleanup
+    assert "remote-svc" not in gossip.services
+    assert "local-svc" in gossip.services  # Local service remains
+
+@pytest.mark.asyncio
+async def test_gossip_broadcast_loop():
+    gossip = GossipDiscovery(local_ip="10.0.0.1")
+    gossip.running = True
+    gossip.register_service("rpc-main", 8080)
+
+    mock_transport = MagicMock()
+    gossip.transport = mock_transport
+
+    # Run one iteration of the loop
+    with patch("asyncio.sleep", side_effect=asyncio.CancelledError):
+        try:
+            await gossip._broadcast_loop()
+        except asyncio.CancelledError:
+            pass
+
+    # Verify sendto was called
+    assert mock_transport.sendto.called
+    args = mock_transport.sendto.call_args[0]
+
+    payload = json.loads(args[0].decode('utf-8'))
+    assert payload["type"] == "ANNOUNCE"
+    assert payload["service"] == "rpc-main"
+    assert payload["ip"] == "10.0.0.1"
+    assert payload["port"] == 8080
+
+    assert args[1][0] == "10.0.0.255"  # Broadcast IP based on /24
+    assert args[1][1] == 7946


### PR DESCRIPTION
Implemented a lightweight UDP gossip protocol in `pipecatapp/gossip_discovery.py` to allow legacy nodes to dynamically broadcast and discover critical LLM services (like `rpc-main`, `rpc-coding`, `ollama`) across the local subnet. This improves cluster survivability when Consul (Raft quorum) is unavailable. The mechanism has been integrated into `network_scanner.py` as a fast-path fallback check. Tests were also added and successfully validated.

---
*PR created automatically by Jules for task [17564373421533343509](https://jules.google.com/task/17564373421533343509) started by @LokiMetaSmith*