### PR TITLE
feat: Gossip-Based Service Fallback Implementation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -191,7 +191,7 @@ These structural suggestions are targeted for a future major release to signific
 ## Gnutella Analysis Integration Ideas
 
 This section tracks actionable ideas derived from the `docs/analysis/GNUTELLA_ANALYSIS.md` document.
-- [ ] **Option 1: Gossip-Based Service Fallback**
+- [x] **Option 1: Gossip-Based Service Fallback**
 - [ ] **Option 3: Bloom Filter Capability Routing**
 - [ ] **Option 4: PUSH-style Reverse Proxies for NAT Traversal**
 - [ ] **Option 5: Extensible Job Payloads (Inspired by GGEP)**

--- a/pipecatapp/app.py
+++ b/pipecatapp/app.py
@@ -22,6 +22,7 @@ from contextlib import asynccontextmanager
 from collections import defaultdict
 from pipecatapp.network_scanner import scan_network_for_llms
 
+from pipecatapp.gossip_discovery import gossip_registry
 from pipecatapp.services.obsidian_gardener import ObsidianGardener
 from pipecatapp.workflow.runner import WorkflowRunner
 
@@ -1775,6 +1776,9 @@ async def lifespan(app: FastAPI):
     """Manages the lifecycle of the agent background task."""
     global agent_task
 
+    # Start gossip registry
+    await gossip_registry.start()
+
     # Initialize Obsidian Gardener if Vault path is provided
     vault_path = os.getenv("OBSIDIAN_VAULT_PATH")
     gardener = None
@@ -1787,6 +1791,8 @@ async def lifespan(app: FastAPI):
     agent_task = asyncio.create_task(run_agent(), name="pipecat_agent_loop")
     yield
     # Cleanup on shutdown
+    await gossip_registry.stop()
+
     if gardener:
         gardener.stop()
 
@@ -1808,6 +1814,8 @@ if __name__ == "__main__":
         web_port = 8000
     else:
         web_port = int(web_port_str)
+
+    gossip_registry.register_service("pipecatapp", web_port)
 
     # Attach the lifespan context manager to the FastAPI app defined in web_server.py
     # This allows us to start the background tasks when Uvicorn starts the app


### PR DESCRIPTION
Implemented the Gossip-Based Service Fallback task from TODO.md by importing the pre-existing `gossip_discovery` module into the main server application (`pipecatapp/app.py`). Specifically, `gossip_registry` now safely starts and stops along with the FastAPI server lifespan context, and records its service registry presence at startup.

---
*PR created automatically by Jules for task [9012569720618301250](https://jules.google.com/task/9012569720618301250) started by @LokiMetaSmith*