### PR TITLE
feat: introduce lightweight smol_agent_server with LFM2.5-1.2B

### DIFF
--- a/ansible/jobs/smol-agent-server.nomad.j2
+++ b/ansible/jobs/smol-agent-server.nomad.j2
@@ -1,0 +1,47 @@
+job "smol-agent-server" {
+  datacenters = ["dc1"]
+  type = "service"
+
+  group "server" {
+    count = 1
+
+    network {
+      port "http" {
+        static = 8089
+      }
+    }
+
+    service {
+      name = "smol-agent-server"
+      port = "http"
+      tags = ["llm", "smolagents", "llama-cpp"]
+
+      check {
+        type     = "http"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "llama-server" {
+      driver = "raw_exec"
+
+      config {
+        command = "/usr/local/bin/llama-server"
+        args = [
+          "-m", "{{ nomad_models_dir }}/LFM2.5-1.2B-Instruct-Q4_K_M.gguf",
+          "--host", "0.0.0.0",
+          "--port", "${NOMAD_PORT_http}",
+          "-c", "4096",
+          "--alias", "LFM2.5-1.2B"
+        ]
+      }
+
+      resources {
+        cpu    = 2000
+        memory = 4096
+      }
+    }
+  }
+}

--- a/ansible/roles/smol_agent_server/tasks/main.yaml
+++ b/ansible/roles/smol_agent_server/tasks/main.yaml
@@ -1,0 +1,22 @@
+- name: Template smol-agent-server job
+  ansible.builtin.template:
+    src: ../../jobs/smol-agent-server.nomad.j2
+    dest: /tmp/smol-agent-server.nomad
+    mode: '0644'
+
+- name: Deploy smol-agent-server job
+  ansible.builtin.command:
+    cmd: /usr/local/bin/nomad job run -detach /tmp/smol-agent-server.nomad
+  environment:
+    NOMAD_ADDR: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "/etc/nomad.d/tls/ca.pem"
+    NOMAD_CLIENT_CERT: "/etc/nomad.d/tls/cli.cert.pem"
+    NOMAD_CLIENT_KEY: "/etc/nomad.d/tls/cli.key.pem"
+    NOMAD_TLS_SKIP_VERIFY: "1"
+  register: smol_job_run
+  changed_when: "'Eval ID' in smol_job_run.stdout"
+
+- name: Clean up temporary job file
+  ansible.builtin.file:
+    path: /tmp/smol-agent-server.nomad
+    state: absent

--- a/pipecatapp/tools/smol_agent_tool.py
+++ b/pipecatapp/tools/smol_agent_tool.py
@@ -50,8 +50,12 @@ class SmolAgentTool:
             if not shutil.which("deno"):
                 raise FileNotFoundError("The 'deno' runtime is not installed or not in the system's PATH.")
 
-            # This model will use the environment's LLM provider configuration (e.g., OPENAI_API_KEY).
-            model = LiteLLMModel(model_id="gpt-4o")
+            # Configure LiteLLMModel to use our local llama.cpp endpoint hosting LFM2.5-1.2B
+            model = LiteLLMModel(
+                model_id="openai/LFM2.5-1.2B",
+                api_base="http://127.0.0.1:8089/v1",
+                api_key="sk-no-key-required"
+            )
             self.agent = CodeAgent(model=model, stream_outputs=False)
             self._initialized = True
 

--- a/playbooks/services/core_ai_services.yaml
+++ b/playbooks/services/core_ai_services.yaml
@@ -19,6 +19,10 @@
       when: node_tier in ['mid', 'core', 'high']
       tags:
         - term_everything
+    - role: smol_agent_server
+      when: node_tier in ['mid', 'core', 'high']
+      tags:
+        - smol_agent_server
     - role: opencode
       when: node_tier in ['mid', 'core', 'high']
       tags:


### PR DESCRIPTION
Adds a new lightweight local agent server (`smol_agent_server`) running `LFM2.5-1.2B` and configures `SmolAgentTool` to use it instead of GPT-4o.

---
*PR created automatically by Jules for task [16908515757646889106](https://jules.google.com/task/16908515757646889106) started by @LokiMetaSmith*