### PR TITLE
Fix --skip-setup flag propagation in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -307,6 +307,7 @@ for ((i=0; i<${#ARGS[@]}; i++)); do
             ;;
         --skip-setup)
             DO_SKIP_SETUP=true
+            PROCESSED_ARGS+=("--skip-setup")
             ;;
         --tags)
             NEXT_ARG="${ARGS[$((i+1))]}"


### PR DESCRIPTION
Fix `--skip-setup` flag propagation when using container mode.

---
*PR created automatically by Jules for task [16392096023897155874](https://jules.google.com/task/16392096023897155874) started by @LokiMetaSmith*