### PR TITLE
fix(llmfit): prioritize rustup path in cargo build

### DIFF
--- a/ansible/roles/llmfit/tasks/main.yaml
+++ b/ansible/roles/llmfit/tasks/main.yaml
@@ -18,7 +18,7 @@
     cmd: cargo install --path llmfit-tui --root /usr/local
     chdir: /opt/llmfit/src
   environment:
-    PATH: "/usr/local/bin:/usr/bin:/bin:/root/.cargo/bin"
+    PATH: "/root/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
   register: build_result
   changed_when: "'Compiling' in build_result.stderr or 'Installed' in build_result.stderr"
 


### PR DESCRIPTION
Resolves an issue where `llmfit` failed to compile during the `ansible-playbook` execution. The `system_deps` role was correctly updating `rustc` via `rustup` to version `1.96.0`, but the `llmfit` task explicitly set a `PATH` that favored the older system binaries, causing the compilation to fail with `rustc 1.94.1 is not supported`. 

I've updated the `ansible/roles/llmfit/tasks/main.yaml` to put `/root/.cargo/bin` at the beginning of the `PATH`.

---
*PR created automatically by Jules for task [2613491840309853670](https://jules.google.com/task/2613491840309853670) started by @LokiMetaSmith*