### PR TITLE
fix(ansible): update Rust toolchain before llmfit compilation

### DIFF
--- a/ansible/roles/llmfit/tasks/main.yaml
+++ b/ansible/roles/llmfit/tasks/main.yaml
@@ -13,6 +13,10 @@
     version: main
     update: yes
 
+- name: Update Rust via rustup to ensure compatibility with latest crates
+  ansible.builtin.shell: /root/.cargo/bin/rustup update || ~/.cargo/bin/rustup update || rustup update
+  become: yes
+
 - name: Install llmfit binary globally using Cargo
   ansible.builtin.command:
     cmd: cargo install --path llmfit-tui --root /usr/local


### PR DESCRIPTION
This PR fixes the bootstrap failure caused by an outdated `rustc` compiler when compiling the `llmfit` binary. It inserts a `rustup update` command before `cargo install` using safe fallback paths (`/root/.cargo/...`, `~/.cargo/...`) and elevated privileges.

---
*PR created automatically by Jules for task [8019912139819960763](https://jules.google.com/task/8019912139819960763) started by @LokiMetaSmith*