### PR TITLE
Fix ansible-galaxy PermissionError in bootstrap.sh

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,7 +2,7 @@
 force_valid_group_names = silently
 inject_facts_as_vars = False
 deprecation_warnings = False
-collections_path = /root/.ansible/collections:/usr/share/ansible/collections
+collections_path = ~/.ansible/collections:/usr/share/ansible/collections
 fact_caching = jsonfile
 fact_caching_connection = /tmp/ansible_facts_cache
 fact_caching_timeout = 86400


### PR DESCRIPTION
Updates `ansible.cfg` to resolve `collections_path` to `~/.ansible/collections` instead of a hardcoded `/root/.ansible/collections`. This resolves `PermissionError: [Errno 13]` when non-root users execute `bootstrap.sh`.

---
*PR created automatically by Jules for task [128200434877065672](https://jules.google.com/task/128200434877065672) started by @LokiMetaSmith*