### PR TITLE
Fix undefined pipecatapp_ipfs_cid variable in nomad job templates

### DIFF
--- a/ansible/roles/pipecatapp/templates/architect.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/architect.nomad.j2
@@ -60,10 +60,10 @@ job "architect" {
       tags     = ["architect", "ai-agent"]
     }
 
+
+    {% if pipecat_deployment_style == 'docker' %}
     {% set image_cid = pipecatapp_ipfs_cid %}
-
     {% set image_tar_name = 'pipecatapp' %}
-
     {% include 'load_image_task.nomad.j2' %}
 
     task "architect-task" {
@@ -92,5 +92,28 @@ job "architect" {
         memory = 2048 # 2 GB
       }
     }
+    {% else %}
+    task "architect-task" {
+      driver = "raw_exec"
+      {{ env_vars }}
+
+      user = "{{ target_user | default('pipecatapp') }}"
+
+      constraint {
+        attribute = "${meta.node_type}"
+        value     = "controller"
+      }
+
+      config {
+        command = "/bin/bash"
+        args = ["-c", "cd /opt/pipecatapp && source venv/bin/activate && python3 task_supervisor.py"]
+      }
+
+      resources {
+        cpu    = 2000 # 2 GHz
+        memory = 2048 # 2 GB
+      }
+    }
+    {% endif %}
   }
 }

--- a/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
@@ -51,10 +51,10 @@ job "seed-agent" {
       tags     = ["seed", "infrastructure-manager"]
     }
 
+
+    {% if pipecat_deployment_style == 'docker' %}
     {% set image_cid = pipecatapp_ipfs_cid %}
-
     {% set image_tar_name = 'pipecatapp' %}
-
     {% include 'load_image_task.nomad.j2' %}
 
     task "seed-agent-task" {
@@ -86,5 +86,28 @@ job "seed-agent" {
         memory = 1024 # 1 GB
       }
     }
+    {% else %}
+    task "seed-agent-task" {
+      driver = "raw_exec"
+      {{ env_vars }}
+
+      user = "root" # Needs root privileges for infrastructure management
+
+      constraint {
+        attribute = "${meta.node_type}"
+        value     = "controller"
+      }
+
+      config {
+        command = "/bin/bash"
+        args = ["-c", "cd /opt/pipecatapp && source venv/bin/activate && python3 worker_agent.py"]
+      }
+
+      resources {
+        cpu    = 1000 # 1 GHz
+        memory = 1024 # 1 GB
+      }
+    }
+    {% endif %}
   }
 }


### PR DESCRIPTION
Fix undefined pipecatapp_ipfs_cid variable in nomad job templates

In raw_exec deployment mode, the pipecatapp_ipfs_cid variable is not
defined because the docker build and IPFS export steps are skipped.
However, seed-agent.nomad.j2 and architect.nomad.j2 unconditionally
referenced this variable, causing Ansible provisioning to fail.

This commit wraps the docker-specific image loading variables and task
with a conditional block checking if pipecat_deployment_style == 'docker'.
It also adds the raw_exec task definitions for seed-agent and architect
so they run properly when docker deployment is bypassed.

---
*PR created automatically by Jules for task [12982510439425253898](https://jules.google.com/task/12982510439425253898) started by @LokiMetaSmith*