### PR TITLE
Fix Ansible template syntax errors in Nomad jobs

### DIFF
--- a/ansible/roles/pipecatapp/templates/architect.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/architect.nomad.j2
@@ -65,7 +65,6 @@ job "architect" {
     {% set image_cid = pipecatapp_ipfs_cid %}
     {% set image_tar_name = 'pipecatapp' %}
     {% include 'load_image_task.nomad.j2' %}
-    {% endif %}
 
     task "architect-task" {
       driver = "docker"

--- a/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/seed-agent.nomad.j2
@@ -56,7 +56,6 @@ job "seed-agent" {
     {% set image_cid = pipecatapp_ipfs_cid %}
     {% set image_tar_name = 'pipecatapp' %}
     {% include 'load_image_task.nomad.j2' %}
-    {% endif %}
 
     task "seed-agent-task" {
       driver = "docker"


### PR DESCRIPTION
Fixes the 'Encountered unknown tag "else"' error when templating Nomad job files during Ansible deployment.

---
*PR created automatically by Jules for task [5636046777898319501](https://jules.google.com/task/5636046777898319501) started by @LokiMetaSmith*