### PR TITLE
Fix Ansible JSON parsing and resolve test import error

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -266,7 +266,7 @@
             output="$output,$line"
           fi
         fi
-      done < /var/log/llama_benchmarks.jsonl
+      done < <(cat /var/log/llama_benchmarks.jsonl | iconv -c -f utf-8 -t utf-8)
       if [ -n "$output" ]; then
         output="$output]"
       else

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -39,7 +39,7 @@
         executable: /bin/bash
         cmd: |
           set -o pipefail
-          echo '{{ benchmark_log_raw.content }}' | base64 --decode | while IFS= read -r line; do
+          echo '{{ benchmark_log_raw.content }}' | base64 --decode | iconv -c -f utf-8 -t utf-8 | while IFS= read -r line; do
             # Skip empty or whitespace-only lines
             if [[ -n "${line// /}" ]]; then
               # Check if the line is valid JSON and print it if it is

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -45,7 +45,7 @@
                 executable: /bin/bash
                 cmd: |
                   set -o pipefail
-                  echo '{{ benchmark_log_raw.content }}' | base64 --decode | while IFS= read -r line; do
+                  echo '{{ benchmark_log_raw.content }}' | base64 --decode | iconv -c -f utf-8 -t utf-8 | while IFS= read -r line; do
                     # Skip empty or whitespace-only lines
                     if [[ -n "${line// /}" ]]; then
                       # Check if the line is valid JSON and print it if it is

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -37,3 +37,4 @@ vulture
 mypy
 pytest-cov
 mcp
+opencv-python-headless


### PR DESCRIPTION
- Fixed Ansible JSON parsing errors caused by non-UTF-8 characters in benchmark logs by sanitizing pipelines with `iconv -c -f utf-8 -t utf-8`.
- Replaced missing `cv2` module during test imports by adding `opencv-python-headless` to `requirements-dev.txt` for server-side environments.
- Ensured atomic commits by cleanly isolating the parsing fix from the test environment update.

---
*PR created automatically by Jules for task [13096631804529124981](https://jules.google.com/task/13096631804529124981) started by @LokiMetaSmith*