### PR TITLE
fix(ansible): robust jsonl parsing with jq slurping

### DIFF
--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -257,22 +257,11 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      output=""
-      while IFS= read -r line; do
-        if echo "$line" | jq -e . > /dev/null; then
-          if [ -z "$output" ]; then
-            output="[$line"
-          else
-            output="$output,$line"
-          fi
+      cat /var/log/llama_benchmarks.jsonl | iconv -c -f utf-8 -t utf-8 | while IFS= read -r line; do
+        if echo "$line" | jq -e . > /dev/null 2>&1; then
+          echo "$line"
         fi
-      done < <(cat /var/log/llama_benchmarks.jsonl | iconv -c -f utf-8 -t utf-8)
-      if [ -n "$output" ]; then
-        output="$output]"
-      else
-        output="[]"
-      fi
-      echo "$output"
+      done | jq -s -c .
     executable: /bin/bash
   register: benchmark_parser_result
   changed_when: false

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -47,7 +47,7 @@
                 echo "$line"
               fi
             fi
-          done | jq -s .
+          done | jq -s -c .
       register: parsed_json
       changed_when: false
       when: benchmark_log_raw.content is defined

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -53,7 +53,7 @@
                         echo "$line"
                       fi
                     fi
-                  done | jq -s .
+                  done | jq -s -c .
               register: parsed_json
               changed_when: false
               when: benchmark_log_raw.content is defined


### PR DESCRIPTION
The previous shell implementation manually concatenated JSON lines with `output="[$line"` into an array string. This frequently failed to decode as valid JSON if the standard output/error lines in the benchmarks contained unescaped characters, newlines, or control characters.

This update refactors the parsing tasks in `ansible/roles/llama_cpp/tasks/main.yaml`, `ansible/roles/pipecatapp/tasks/main.yaml`, and `playbooks/services/ai_experts.yaml`. It relies directly on `jq -s -c .` which cleanly slurp-reads multiple valid JSON objects and serializes them into a robust, compact JSON array.

---
*PR created automatically by Jules for task [6456691143315180825](https://jules.google.com/task/6456691143315180825) started by @LokiMetaSmith*