### PR TITLE
Fix Playwright browser startup crash

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -562,11 +562,19 @@
     dest: "{{ nomad_jobs_dir }}/test-runner.nomad.j2"
   become: yes
 
-- name: Install Playwright browsers using the virtual environment's python
+- name: Ensure global Playwright browsers directory exists
+  ansible.builtin.file:
+    path: /opt/ms-playwright
+    state: directory
+    mode: '0777'
+  become: yes
+
+- name: Install Playwright browsers globally as root
   ansible.builtin.command:
     cmd: "{{ pipecat_app_dir }}/venv/bin/python -m playwright install"
+  environment:
+    PLAYWRIGHT_BROWSERS_PATH: "/opt/ms-playwright"
   become: yes
-  become_user: "{{ target_user }}"
   async: 900 # Set timeout to 15 minutes
   poll: 10   # Check status every 10 seconds
 

--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -45,6 +45,8 @@ job "{{ job_name | default('pipecat-app') }}" {
       WEB_PORT               = "${NOMAD_PORT_http}"
       YOLO_MODEL_PATH        = "{{ nomad_models_dir }}/vision/yolov8n.pt"
       MAIN_API_SERVICE_NAME = "llama-api-main"
+      PLAYWRIGHT_BROWSERS_PATH = "/opt/ms-playwright"
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1"
     }
     {% endset %}
 
@@ -108,7 +110,7 @@ job "{{ job_name | default('pipecat-app') }}" {
     {% set image_tar_name = 'pipecatapp' %}
     {% include 'load_image_task.nomad.j2' %}
 
-    task "pipecat-task" {
+    task "pipecat-app" {
       driver = "docker"
       {{ env_vars }}
 
@@ -145,7 +147,7 @@ job "{{ job_name | default('pipecat-app') }}" {
       }
     }
     {% else %}
-    task "pipecat-task" {
+    task "pipecat-app" {
       driver = "raw_exec"
       {{ env_vars }}
 


### PR DESCRIPTION
Addresses the crash happening because the Nomad agent unprivileged user was attempting to download Playwright browser binaries into `/root/.cache`. This updates the Ansible provisioning to install these binaries globally to `/opt/ms-playwright`, and adjusts the Nomad template to skip downloads on execution while mapping to the new browser cache location.

---
*PR created automatically by Jules for task [10898088914806729010](https://jules.google.com/task/10898088914806729010) started by @LokiMetaSmith*