### PR TITLE
Fix playwright browser path permissions

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -567,6 +567,8 @@
     cmd: "{{ pipecat_app_dir }}/venv/bin/python -m playwright install"
   become: yes
   become_user: "{{ target_user }}"
+  environment:
+    PLAYWRIGHT_BROWSERS_PATH: "{{ pipecat_app_dir }}/pw-browsers"
   async: 900 # Set timeout to 15 minutes
   poll: 10   # Check status every 10 seconds
 

--- a/ansible/roles/pipecatapp/templates/start_pipecatapp.sh.j2
+++ b/ansible/roles/pipecatapp/templates/start_pipecatapp.sh.j2
@@ -146,12 +146,14 @@ if [ "$IS_DOCKER" -eq 1 ] && check_venv_valid "$CONTAINER_VENV_DIR"; then
     ACTIVATE="$CONTAINER_VENV_DIR/bin/activate"
     source "$ACTIVATE"
     USING_CONTAINER_VENV=1
+    export PLAYWRIGHT_BROWSERS_PATH="/opt/pw-browsers"
 
 # 2. Try local/development venv (bind mount location)
 elif check_venv_valid "$VENV_DIR"; then
     log_msg "Found existing valid venv at $VENV_DIR"
     ACTIVATE="$VENV_DIR/bin/activate"
     source "$ACTIVATE"
+    export PLAYWRIGHT_BROWSERS_PATH="$APP_DIR/pw-browsers"
 
 # 3. Last resort: Create a new venv in the local directory
 else
@@ -165,6 +167,7 @@ else
     fi
 
     source "$ACTIVATE"
+    export PLAYWRIGHT_BROWSERS_PATH="$APP_DIR/pw-browsers"
 fi
 
 if [ "$USING_CONTAINER_VENV" -eq 1 ]; then

--- a/pipecatapp/Dockerfile
+++ b/pipecatapp/Dockerfile
@@ -58,6 +58,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Install Playwright browsers
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
 RUN playwright install
 
 # Download required AI models
@@ -74,6 +75,6 @@ COPY . .
 RUN mv /opt/pipecatapp/start_pipecat.sh /opt/start_pipecat.sh && chmod +x /opt/start_pipecat.sh
 
 # Set the entrypoint for the container
-RUN useradd -m -s /bin/bash pipecatapp && chown -R pipecatapp:pipecatapp /opt/pipecatapp /opt/pipecat_venv /opt/start_pipecat.sh
+RUN useradd -m -s /bin/bash pipecatapp && chown -R pipecatapp:pipecatapp /opt/pipecatapp /opt/pipecat_venv /opt/start_pipecat.sh /opt/pw-browsers
 USER pipecatapp
 ENTRYPOINT ["/opt/start_pipecat.sh"]

--- a/tests/playbooks/e2e-tests.yaml
+++ b/tests/playbooks/e2e-tests.yaml
@@ -63,6 +63,8 @@
   tasks:
     - name: Install Playwright browser dependencies
       ansible.builtin.command: python -m playwright install
+      environment:
+        PLAYWRIGHT_BROWSERS_PATH: "/tmp/pw-browsers"
       register: playwright_install
       changed_when: "'Browsers installed' in playwright_install.stdout"
 


### PR DESCRIPTION
Fixes the permission denied error related to playwright browsers in Docker/raw_exec environments.
Because `playwright install` and running tests attempt to write to `/root/.cache/ms-playwright` by default and fail when run by the non-privileged user `pipecatapp`, this pull request resolves the issue by explicitly setting the `PLAYWRIGHT_BROWSERS_PATH` environment variable. The paths are scoped inside the `/opt/` or application directory, and ownership is securely mapped to the unprivileged application user in both Dockerfiles and Ansible playbooks.

---
*PR created automatically by Jules for task [1882870066019951898](https://jules.google.com/task/1882870066019951898) started by @LokiMetaSmith*