### PR TITLE
fix: deploy network_scanner module with ansible

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -344,6 +344,14 @@
   tags:
     - deploy_app
 
+- name: Copy network_scanner module
+  ansible.builtin.copy:
+    src: "{{ inventory_dir }}/pipecatapp/network_scanner.py"
+    dest: "{{ pipecat_app_dir }}/network_scanner.py"
+  become: yes
+  tags:
+    - deploy_app
+
 - name: Copy moondream_detector module
   ansible.builtin.copy:
     src: "{{ inventory_dir }}/pipecatapp/moondream_detector.py"


### PR DESCRIPTION
Added a missing `ansible.builtin.copy` task for `pipecatapp/network_scanner.py` in `ansible/roles/pipecatapp/tasks/main.yaml`. Previously, this missing copy task prevented the file from being deployed to the `pipecatapp` directory on the target nodes, which resulted in a `ModuleNotFoundError: No module named 'pipecatapp.network_scanner'` when the startup script attempted its pre-flight import checks.

---
*PR created automatically by Jules for task [2107642222667163670](https://jules.google.com/task/2107642222667163670) started by @LokiMetaSmith*