### PR TITLE
Fix: Add missing copy task for gossip_discovery.py to Ansible playbook

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -113,6 +113,14 @@
   tags:
     - deploy_app
 
+- name: Copy gossip_discovery module
+  ansible.builtin.copy:
+    src: "{{ inventory_dir }}/pipecatapp/gossip_discovery.py"
+    dest: "{{ pipecat_app_dir }}/gossip_discovery.py"
+  become: yes
+  tags:
+    - deploy_app
+
 - name: Install python dependencies
   ansible.builtin.pip:
     requirements: "{{ pipecat_app_dir }}/requirements.txt"


### PR DESCRIPTION
This PR resolves an application pre-flight deployment error caused by a missing file. 

The `pipecatapp.gossip_discovery` module was recently added to the codebase but was omitted from the Ansible deployment roles, leading to a `ModuleNotFoundError` during startup. 

**Changes:**
- Modified `ansible/roles/pipecatapp/tasks/main.yaml` to include an explicit `ansible.builtin.copy` task for `pipecatapp/gossip_discovery.py`.

**Verification:**
- Validated that the file path in the copy task is correct and conforms to the existing playbook structure.
- Simulated the Python import in an isolated context successfully (ignoring an unrelated `cv2` missing dependency error in the test suite).

---
*PR created automatically by Jules for task [14734530373684508513](https://jules.google.com/task/14734530373684508513) started by @LokiMetaSmith*