### PR TITLE
fix(ansible): copy gossip_discovery module during pipecatapp deployment

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -344,6 +344,14 @@
   tags:
     - deploy_app
 
+- name: Copy gossip_discovery module
+  ansible.builtin.copy:
+    src: "{{ inventory_dir }}/pipecatapp/gossip_discovery.py"
+    dest: "{{ pipecat_app_dir }}/gossip_discovery.py"
+  become: yes
+  tags:
+    - deploy_app
+
 - name: Copy network_scanner module
   ansible.builtin.copy:
     src: "{{ inventory_dir }}/pipecatapp/network_scanner.py"


### PR DESCRIPTION
Fixes deployment error caused by missing `gossip_discovery.py` module during pipecatapp startup. Added the explicit `ansible.builtin.copy` task to the Ansible deployment role (`ansible/roles/pipecatapp/tasks/main.yaml`) to ensure it gets copied to the server alongside the rest of the application.

---
*PR created automatically by Jules for task [724553637548120108](https://jules.google.com/task/724553637548120108) started by @LokiMetaSmith*