### PR TITLE
fix: Add missing gossip_discovery copy task in ansible

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -113,6 +113,14 @@
   tags:
     - deploy_app
 
+- name: Copy gossip_discovery module
+  ansible.builtin.copy:
+    src: "{{ inventory_dir }}/pipecatapp/gossip_discovery.py"
+    dest: "{{ pipecat_app_dir }}/gossip_discovery.py"
+  become: yes
+  tags:
+    - deploy_app
+
 - name: Install python dependencies
   ansible.builtin.pip:
     requirements: "{{ pipecat_app_dir }}/requirements.txt"


### PR DESCRIPTION
Fixed an issue where the pipecatapp failed to start because the `gossip_discovery.py` module was not being copied to the application directory by Ansible. Added the appropriate task to `ansible/roles/pipecatapp/tasks/main.yaml`.

---
*PR created automatically by Jules for task [13119349930487192876](https://jules.google.com/task/13119349930487192876) started by @LokiMetaSmith*