### PR TITLE
Fix missing pipecatapp modules and directories in Ansible deployment

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -107,6 +107,7 @@
 
 - name: Copy requirements.txt
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/requirements.txt"
     dest: "{{ pipecat_app_dir }}/requirements.txt"
   become: yes
@@ -115,6 +116,7 @@
 
 - name: Copy gossip_discovery module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/gossip_discovery.py"
     dest: "{{ pipecat_app_dir }}/gossip_discovery.py"
   become: yes
@@ -132,6 +134,7 @@
 
 - name: Copy pipecat app
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/app.py"
     dest: "{{ pipecat_app_dir }}/app.py"
   become: yes
@@ -140,6 +143,7 @@
 
 - name: Copy task supervisor
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/task_supervisor.py"
     dest: "{{ pipecat_app_dir }}/task_supervisor.py"
   become: yes
@@ -148,6 +152,7 @@
 
 - name: Copy agent factory
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/agent_factory.py"
     dest: "{{ pipecat_app_dir }}/agent_factory.py"
   become: yes
@@ -156,6 +161,7 @@
 
 - name: Copy worker agent
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/worker_agent.py"
     dest: "{{ pipecat_app_dir }}/worker_agent.py"
   become: yes
@@ -164,6 +170,7 @@
 
 - name: Copy pmm memory client
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/pmm_memory_client.py"
     dest: "{{ pipecat_app_dir }}/pmm_memory_client.py"
   become: yes
@@ -172,6 +179,7 @@
 
 - name: Copy pmm memory module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/pmm_memory.py"
     dest: "{{ pipecat_app_dir }}/pmm_memory.py"
   become: yes
@@ -180,6 +188,7 @@
 
 - name: Copy quality_control module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/quality_control.py"
     dest: "{{ pipecat_app_dir }}/quality_control.py"
   become: yes
@@ -188,6 +197,7 @@
 
 - name: Copy durable_execution module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/durable_execution.py"
     dest: "{{ pipecat_app_dir }}/durable_execution.py"
   become: yes
@@ -196,6 +206,7 @@
 
 - name: Copy workflow directory
   ansible.builtin.copy:
+    mode: '0755'
     src: "{{ inventory_dir }}/pipecatapp/workflow"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
@@ -249,6 +260,7 @@
 
 - name: Copy memory module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/memory.py"
     dest: "{{ pipecat_app_dir }}/memory.py"
   become: yes
@@ -257,6 +269,7 @@
 
 - name: Copy net_utils module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/net_utils.py"
     dest: "{{ pipecat_app_dir }}/net_utils.py"
   become: yes
@@ -265,6 +278,7 @@
 
 - name: Copy models module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/models.py"
     dest: "{{ pipecat_app_dir }}/models.py"
   become: yes
@@ -273,6 +287,7 @@
 
 - name: Copy rate_limiter module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/rate_limiter.py"
     dest: "{{ pipecat_app_dir }}/rate_limiter.py"
   become: yes
@@ -281,6 +296,7 @@
 
 - name: Copy security module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/security.py"
     dest: "{{ pipecat_app_dir }}/security.py"
   become: yes
@@ -289,6 +305,7 @@
 
 - name: Copy api_keys module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/api_keys.py"
     dest: "{{ pipecat_app_dir }}/api_keys.py"
   become: yes
@@ -297,6 +314,7 @@
 
 - name: Copy llm_clients module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/llm_clients.py"
     dest: "{{ pipecat_app_dir }}/llm_clients.py"
   become: yes
@@ -305,6 +323,7 @@
 
 - name: Copy archivist service
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/archivist_service.py"
     dest: "{{ pipecat_app_dir }}/archivist_service.py"
   become: yes
@@ -322,6 +341,7 @@
 
 - name: Copy web_server module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/web_server.py"
     dest: "{{ pipecat_app_dir }}/web_server.py"
   become: yes
@@ -330,6 +350,7 @@
 
 - name: Copy static assets
   ansible.builtin.copy:
+    mode: '0755'
     src: "{{ inventory_dir }}/pipecatapp/static"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
@@ -338,6 +359,7 @@
 
 - name: Copy tools directory
   ansible.builtin.copy:
+    mode: '0755'
     src: "{{ inventory_dir }}/pipecatapp/tools"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
@@ -346,6 +368,7 @@
 
 - name: Copy integrations directory
   ansible.builtin.copy:
+    mode: '0755'
     src: "{{ inventory_dir }}/pipecatapp/integrations"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
@@ -354,6 +377,7 @@
 
 - name: Copy network_scanner module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/network_scanner.py"
     dest: "{{ pipecat_app_dir }}/network_scanner.py"
   become: yes
@@ -362,11 +386,248 @@
 
 - name: Copy moondream_detector module
   ansible.builtin.copy:
+    mode: '0644'
     src: "{{ inventory_dir }}/pipecatapp/moondream_detector.py"
     dest: "{{ pipecat_app_dir }}/moondream_detector.py"
   become: yes
   tags:
     - deploy_app
+
+
+- name: Copy __init__ module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/__init__.py"
+    dest: "{{ pipecat_app_dir }}/__init__.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy expert_tracker module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/expert_tracker.py"
+    dest: "{{ pipecat_app_dir }}/expert_tracker.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy file_ingestion module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/file_ingestion.py"
+    dest: "{{ pipecat_app_dir }}/file_ingestion.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy generate_real_embeddings module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/generate_real_embeddings.py"
+    dest: "{{ pipecat_app_dir }}/generate_real_embeddings.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy janitor_agent module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/janitor_agent.py"
+    dest: "{{ pipecat_app_dir }}/janitor_agent.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy judge_agent module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/judge_agent.py"
+    dest: "{{ pipecat_app_dir }}/judge_agent.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy langchain_memory_wrappers module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/langchain_memory_wrappers.py"
+    dest: "{{ pipecat_app_dir }}/langchain_memory_wrappers.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy local_llm module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/local_llm.py"
+    dest: "{{ pipecat_app_dir }}/local_llm.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy local_world_model module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/local_world_model.py"
+    dest: "{{ pipecat_app_dir }}/local_world_model.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy manager_agent module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/manager_agent.py"
+    dest: "{{ pipecat_app_dir }}/manager_agent.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy memory_backends module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/memory_backends.py"
+    dest: "{{ pipecat_app_dir }}/memory_backends.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy memory_legacy module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/memory_legacy.py"
+    dest: "{{ pipecat_app_dir }}/memory_legacy.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy mqtt_world_model_client module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/mqtt_world_model_client.py"
+    dest: "{{ pipecat_app_dir }}/mqtt_world_model_client.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy secret_manager module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/secret_manager.py"
+    dest: "{{ pipecat_app_dir }}/secret_manager.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy skill_library module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/skill_library.py"
+    dest: "{{ pipecat_app_dir }}/skill_library.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy technician_agent module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/technician_agent.py"
+    dest: "{{ pipecat_app_dir }}/technician_agent.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy tool_server module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/tool_server.py"
+    dest: "{{ pipecat_app_dir }}/tool_server.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy train_router module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/train_router.py"
+    dest: "{{ pipecat_app_dir }}/train_router.py"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy datasets directory
+  ansible.builtin.copy:
+    mode: '0755'
+    src: "{{ inventory_dir }}/pipecatapp/datasets"
+    dest: "{{ pipecat_app_dir }}/"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy memory_backends_impl directory
+  ansible.builtin.copy:
+    mode: '0755'
+    src: "{{ inventory_dir }}/pipecatapp/memory_backends_impl"
+    dest: "{{ pipecat_app_dir }}/"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy memory_graph_service directory
+  ansible.builtin.copy:
+    mode: '0755'
+    src: "{{ inventory_dir }}/pipecatapp/memory_graph_service"
+    dest: "{{ pipecat_app_dir }}/"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy miniray directory
+  ansible.builtin.copy:
+    mode: '0755'
+    src: "{{ inventory_dir }}/pipecatapp/miniray"
+    dest: "{{ pipecat_app_dir }}/"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy servers directory
+  ansible.builtin.copy:
+    mode: '0755'
+    src: "{{ inventory_dir }}/pipecatapp/servers"
+    dest: "{{ pipecat_app_dir }}/"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy services directory
+  ansible.builtin.copy:
+    mode: '0755'
+    src: "{{ inventory_dir }}/pipecatapp/services"
+    dest: "{{ pipecat_app_dir }}/"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy ui directory
+  ansible.builtin.copy:
+    mode: '0755'
+    src: "{{ inventory_dir }}/pipecatapp/ui"
+    dest: "{{ pipecat_app_dir }}/"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Copy utils directory
+  ansible.builtin.copy:
+    mode: '0755'
+    src: "{{ inventory_dir }}/pipecatapp/utils"
+    dest: "{{ pipecat_app_dir }}/"
+  become: yes
+  tags:
+    - deploy_app
+
 
 - name: Ensure prompts directory exists
   ansible.builtin.file:
@@ -471,30 +732,35 @@
 
 - name: Copy pipecatapp Nomad job file
   ansible.builtin.template:
+    mode: '0644'
     src: pipecatapp.nomad.j2
     dest: "{{ nomad_jobs_dir }}/pipecatapp.nomad"
   become: yes
 
 - name: Template seed-agent Nomad job file
   ansible.builtin.template:
+    mode: '0644'
     src: seed-agent.nomad.j2
     dest: "{{ nomad_jobs_dir }}/seed-agent.nomad"
   become: yes
 
 - name: Template architect Nomad job file
   ansible.builtin.template:
+    mode: '0644'
     src: architect.nomad.j2
     dest: "{{ nomad_jobs_dir }}/architect.nomad"
   become: yes
 
 - name: Template prompt evolution Nomad job file
   ansible.builtin.template:
+    mode: '0644'
     src: ../../jobs/evolve-prompt.nomad.j2
     dest: "{{ nomad_jobs_dir }}/evolve-prompt.nomad"
   become: yes
 
 - name: Template archivist Nomad job file
   ansible.builtin.template:
+    mode: '0644'
     src: archivist.nomad.j2
     dest: "{{ nomad_jobs_dir }}/archivist.nomad"
   become: yes
@@ -518,12 +784,14 @@
 
 - name: Create router job file from template
   ansible.builtin.template:
+    mode: '0644'
     src: ../../jobs/router.nomad.j2
     dest: "{{ nomad_jobs_dir }}/router.nomad"
   become: yes
 
 - name: Create expert job files from template for verified models
   ansible.builtin.template:
+    mode: '0644'
     src: ../../jobs/expert.nomad.j2
     dest: "{{ nomad_jobs_dir }}/expert-{{ current_expert }}.nomad"
   loop: "{{ verified_experts | default([]) }}"
@@ -574,6 +842,7 @@
 
 - name: Copy test runner Nomad job template
   ansible.builtin.copy:
+    mode: '0644'
     src: ../../jobs/test-runner.nomad.j2
     dest: "{{ nomad_jobs_dir }}/test-runner.nomad.j2"
   become: yes
@@ -691,6 +960,7 @@
 
     - name: "Archivist : Save Archivist allocations to temp file"
       ansible.builtin.copy:
+        mode: '0644'
         content: "{{ arch_allocs.stdout }}"
         dest: "/opt/arch_allocs.json"
 
@@ -806,6 +1076,7 @@
 
     - name: "Router : Save Router allocations to temp file"
       ansible.builtin.copy:
+        mode: '0644'
         content: "{{ router_allocs.stdout }}"
         dest: "/opt/router_allocs.json"
 
@@ -1011,6 +1282,7 @@
 
     - name: "Pipecat App : Save Pipecat App allocations to temp file"
       ansible.builtin.copy:
+        mode: '0644'
         content: "{{ pipecat_allocs.stdout }}"
         dest: "/opt/pipecat_allocs.json"
 


### PR DESCRIPTION
Fix missing pipecatapp modules and directories in Ansible deployment

The `ansible/roles/pipecatapp/tasks/main.yaml` playbook was failing to copy numerous recently added modules (e.g., `services/`, `utils/`, `miniray/`, etc.) from the `pipecatapp/` directory.

This commit updates the Ansible playbook to explicitly include all missing directories and files from the `pipecatapp/` source into the deployment target, and additionally resolves several YAML syntax and `ansible-lint` issues (like `risky-file-permissions` by adding explicit `mode` directives to all `copy` and `template` tasks).

---
*PR created automatically by Jules for task [12232837328712943757](https://jules.google.com/task/12232837328712943757) started by @LokiMetaSmith*