### PR TITLE
Fix Python 3.13 compatibility issue with misaki during pipecatapp deployment

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -127,7 +127,7 @@
   ansible.builtin.pip:
     requirements: "{{ pipecat_app_dir }}/requirements.txt"
     virtualenv: "{{ pipecat_app_dir }}/venv"
-    virtualenv_command: python3 -m venv
+    virtualenv_command: python3.12 -m venv
   become: yes
   tags:
     - deploy_app

--- a/ansible/roles/pipecatapp/templates/start_pipecatapp.sh.j2
+++ b/ansible/roles/pipecatapp/templates/start_pipecatapp.sh.j2
@@ -122,7 +122,7 @@ try_create_venv() {
     fi
 
     set +e
-    python3 -m venv "$venv_path" 2>&1 | tee -a "$LOG_FILE"
+    python3.12 -m venv "$venv_path" 2>&1 | tee -a "$LOG_FILE"
     local ret=$?
     set -e
 
@@ -142,10 +142,10 @@ USING_CONTAINER_VENV=0
 
 check_venv_valid() {
     local venv_path=$1
-    if [ -d "$venv_path" ] && [ -f "$venv_path/bin/python3" ] && [ -f "$venv_path/bin/activate" ]; then
+    if [ -d "$venv_path" ] && [ -f "$venv_path/bin/python3.12" ] && [ -f "$venv_path/bin/activate" ]; then
         # Check mismatch
-        local current_ver=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-        local venv_ver=$("$venv_path/bin/python3" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "invalid")
+        local current_ver=$(python3.12 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+        local venv_ver=$("$venv_path/bin/python3.12" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "invalid")
 
         if [ "$current_ver" != "$venv_ver" ]; then
             log_msg "Virtual environment at $venv_path version mismatch (System: $current_ver, Venv: $venv_ver)."
@@ -232,17 +232,17 @@ fi
 # Pre-flight import check to catch missing dependencies early
 log_msg "Running pre-flight import check..."
 # We use the python from the active venv
-if ! python3 -c "import sys; sys.path.append('$(dirname "$APP_DIR")'); import pipecatapp.app; print('Pre-flight import check passed.')" 2>&1 | tee -a "$LOG_FILE" >&2; then
+if ! python3.12 -c "import sys; sys.path.append('$(dirname "$APP_DIR")'); import pipecatapp.app; print('Pre-flight import check passed.')" 2>&1 | tee -a "$LOG_FILE" >&2; then
     log_msg "CRITICAL: Pre-flight import check failed. This usually indicates missing dependencies or syntax errors."
 fi
 
 {% if pipecat_deployment_style == 'raw_exec' %}
 # For raw_exec, we explicitly manage our own log file via redirection.
-PYTHON_EXEC="$(dirname "$ACTIVATE")/python3"
+PYTHON_EXEC="$(dirname "$ACTIVATE")/python3.12"
 exec "$PYTHON_EXEC" -u "$APP_DIR/app.py" >> "$LOG_FILE" 2>&1
 {% else %}
 # For Docker, we want logs to stdout/stderr (for `docker logs`) AND to the file (for debugging).
 # We use process substitution to pipe to tee.
 # Note: We rely on the active venv here.
-exec python3 -u "$APP_DIR/app.py" 2>&1 | tee -a "$LOG_FILE"
+exec python3.12 -u "$APP_DIR/app.py" 2>&1 | tee -a "$LOG_FILE"
 {% endif %}

--- a/ansible/roles/python_deps/tasks/main.yaml
+++ b/ansible/roles/python_deps/tasks/main.yaml
@@ -1,6 +1,6 @@
 - name: Create a virtual environment for the application
   ansible.builtin.command:
-    cmd: "python3 -m venv /opt/pipecatapp/venv"
+    cmd: "python3.12 -m venv /opt/pipecatapp/venv"
     creates: "/opt/pipecatapp/venv/bin/pip"
   become: yes
   tags:


### PR DESCRIPTION
Fixes Ansible provisioning failure where `pipecatapp` Python dependencies could not be installed due to the `misaki` package being incompatible with Python 3.13. Virtual environments are now explicitly created using Python 3.12.

---
*PR created automatically by Jules for task [17647205752859724913](https://jules.google.com/task/17647205752859724913) started by @LokiMetaSmith*