### PR TITLE
Fix python3.12 executable path in ansible tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ venv/
 
 # Dynamically generated parameter files
 group_vars/all/resource_tuning.yaml
+.ansible_venv

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -127,7 +127,7 @@
   ansible.builtin.pip:
     requirements: "{{ pipecat_app_dir }}/requirements.txt"
     virtualenv: "{{ pipecat_app_dir }}/venv"
-    virtualenv_command: python3.12 -m venv
+    virtualenv_command: /usr/bin/python3.12 -m venv
   become: yes
   tags:
     - deploy_app

--- a/ansible/roles/python_deps/tasks/main.yaml
+++ b/ansible/roles/python_deps/tasks/main.yaml
@@ -1,6 +1,6 @@
 - name: Create a virtual environment for the application
   ansible.builtin.command:
-    cmd: "python3.12 -m venv /opt/pipecatapp/venv"
+    cmd: "/usr/bin/python3.12 -m venv /opt/pipecatapp/venv"
     creates: "/opt/pipecatapp/venv/bin/pip"
   become: yes
   tags:


### PR DESCRIPTION
Fixes the `Failed to find required executable "python3.12"` issue in Ansible's `pip` module by providing the absolute path `/usr/bin/python3.12` instead of just `python3.12`. This ensures that virtual environments are correctly created during the `ansible-playbook` execution even when the PATH isn't correctly inherited across privilege boundaries.

---
*PR created automatically by Jules for task [13585793603961353630](https://jules.google.com/task/13585793603961353630) started by @LokiMetaSmith*