### PR TITLE
Fix hardcoded Python path for virtualenv creation in Ansible playbooks

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -127,7 +127,7 @@
   ansible.builtin.pip:
     requirements: "{{ pipecat_app_dir }}/requirements.txt"
     virtualenv: "{{ pipecat_app_dir }}/venv"
-    virtualenv_command: /usr/bin/python3.12 -m venv
+    virtualenv_command: "{{ ansible_playbook_python }} -m venv"
   become: yes
   become_user: "{{ target_user }}"
   tags:

--- a/ansible/roles/python_deps/tasks/main.yaml
+++ b/ansible/roles/python_deps/tasks/main.yaml
@@ -1,6 +1,6 @@
 - name: Create a virtual environment for the application
   ansible.builtin.command:
-    cmd: "/usr/bin/python3.12 -m venv /opt/pipecatapp/venv"
+    cmd: "{{ ansible_playbook_python }} -m venv /opt/pipecatapp/venv"
     creates: "/opt/pipecatapp/venv/bin/pip"
   become: yes
   tags:


### PR DESCRIPTION
The playbooks for `pipecatapp` and `python_deps` were failing on some nodes because the `virtualenv_command` hardcoded `/usr/bin/python3.12`, which was either missing from the target's system paths or causing path resolution errors when Ansible was running from within an isolated `.venv`.

This commit refactors these files to use `{{ ansible_playbook_python }}` dynamically. This correctly maps the `venv` creation to use the active Python binary driving the playbook, satisfying the package dependency constraints securely without throwing "No such file or directory" exceptions during cluster bootstrap operations.

---
*PR created automatically by Jules for task [8031631538048453003](https://jules.google.com/task/8031631538048453003) started by @LokiMetaSmith*