### PR TITLE
fix: use python3.12 for initial virtual environment creation

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -644,7 +644,12 @@ setup_venv() {
             # Clear hashed executable paths (like python3)
             hash -r 2>/dev/null || true
         fi
-        python3 -m venv "$VENV_DIR"
+
+        if command -v python3.12 >/dev/null 2>&1; then
+            python3.12 -m venv "$VENV_DIR"
+        else
+            python3 -m venv "$VENV_DIR"
+        fi
     fi
 }
 


### PR DESCRIPTION
The `misaki` package used in the `pipecatapp` environment is strictly incompatible with Python 3.13+. While `ansible/roles/pipecatapp/tasks/main.yaml` dynamically uses `{{ ansible_playbook_python }} -m venv` to create the application's venv, if `ansible_playbook_python` points to a 3.13 executable, compilation errors (such as `thinc` failing) occur. This happens because `bootstrap.sh` previously used `python3 -m venv` to create the initial Ansible virtual environment, and on systems where `python3` defaults to 3.13, `ansible_playbook_python` inherits this version. 

This commit updates `bootstrap.sh` to explicitly search for and use `python3.12` to create the initial environment when available, ensuring the playbook and subsequent app dependencies use the compatible 3.12 interpreter.

---
*PR created automatically by Jules for task [1354961514150366055](https://jules.google.com/task/1354961514150366055) started by @LokiMetaSmith*