### PR TITLE
feat: Add log-vectorizer-mcp tool for semantic log search

### DIFF
--- a/tools/log-vectorizer-mcp/README.md
+++ b/tools/log-vectorizer-mcp/README.md
@@ -1,0 +1,70 @@
+# Log Vectorizer MCP Tool
+
+A standalone Model Context Protocol (MCP) tool designed to help AI agents manage and query large log files without exhausting their context window limits.
+
+This tool reads massive log files, chunks them intelligently using regex to keep multi-line stack traces intact, and vectorizes the text using a local embedding endpoint (e.g., Ollama or llama.cpp). The chunks are stored in a lightweight, easily transportable JSON Lines (`.jsonl`) database. Agents can then perform semantic searches to find relevant historical errors or context.
+
+## Installation
+
+This tool requires its own isolated environment to prevent dependency conflicts.
+
+```bash
+cd tools/log-vectorizer-mcp
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+The tool uses environment variables for configuration, allowing you to seamlessly integrate it with your local inference setup.
+
+| Variable | Description | Default Value |
+| --- | --- | --- |
+| `LOCAL_EMBED_URL` | The HTTP endpoint for your local embedding model. | `http://localhost:11434/api/embeddings` |
+| `EMBEDDING_MODEL` | The name of the embedding model to use. | `nomic-embed-text` |
+| `DATABASE_FILE` | The path where the `.jsonl` database will be stored. | `/tmp/log_vectors.jsonl` |
+
+## Usage
+
+You can start the MCP server using standard MCP clients (like Claude Desktop or custom agents) that communicate over standard input/output (`stdio`).
+
+```bash
+python server.py
+```
+
+### Exposed MCP Tools
+
+The server exposes the following tools to the agent:
+
+#### 1. `ingest_log_file(filepath: str)`
+Reads a large log file and parses it line-by-line. It groups lines into chunks based on common timestamp patterns (ISO8601, Apache, Syslog, etc.), ensuring that multi-line entries (like Python stack traces) remain together. It then generates an embedding for each chunk and appends it to the `.jsonl` database.
+- **Agents should use this:** When new logs are generated or when investigating a pipeline failure.
+
+#### 2. `search_logs(query: str, top_k: int = 3)`
+Performs a semantic similarity search (using cosine similarity) over the vectorized log chunks in the database. Returns the most relevant log entries matching the query.
+- **Agents should use this:** To find historical errors, specific stack traces, or context without needing to read the entire multi-megabyte log file.
+
+## Agent Configuration (MCP Clients)
+
+To allow an AI agent (like Jules or Claude Desktop) to use this tool, you must register it in the agent's MCP configuration file (e.g., `mcp.json` or `claude_desktop_config.json`).
+
+Add the following entry under the `mcpServers` object to instruct the agent on how to launch the server via `stdio`. Be sure to update the `/path/to/repo` paths to match your actual system paths:
+
+```json
+{
+  "mcpServers": {
+    "log-vectorizer": {
+      "command": "/path/to/repo/tools/log-vectorizer-mcp/venv/bin/python",
+      "args": ["/path/to/repo/tools/log-vectorizer-mcp/server.py"],
+      "env": {
+        "LOCAL_EMBED_URL": "http://localhost:11434/api/embeddings",
+        "EMBEDDING_MODEL": "nomic-embed-text",
+        "DATABASE_FILE": "/tmp/log_vectors.jsonl"
+      }
+    }
+  }
+}
+```
+
+Once configured, the agent will automatically discover the `ingest_log_file` and `search_logs` tools. It can then autonomously decide to vectorize logs and search them to provide context without exceeding its token limits.

--- a/tools/log-vectorizer-mcp/requirements.txt
+++ b/tools/log-vectorizer-mcp/requirements.txt
@@ -1,0 +1,2 @@
+mcp
+httpx

--- a/tools/log-vectorizer-mcp/server.py
+++ b/tools/log-vectorizer-mcp/server.py
@@ -1,0 +1,136 @@
+import json
+import math
+import os
+import re
+import httpx
+from typing import List
+from mcp.server import Server
+import mcp.types as types
+
+# Initialize the MCP Server
+app = Server("log-vectorizer-mcp")
+
+# Configuration via environment variables with defaults
+LOCAL_EMBED_URL = os.environ.get("LOCAL_EMBED_URL", "http://localhost:11434/api/embeddings")
+EMBEDDING_MODEL = os.environ.get("EMBEDDING_MODEL", "nomic-embed-text")
+DATABASE_FILE = os.environ.get("DATABASE_FILE", "/tmp/log_vectors.jsonl")
+
+# Common timestamp patterns: ISO8601, Apache, Syslog, Python logging default
+TIMESTAMP_PATTERN = re.compile(
+    r"^(?:"
+    r"\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}"  # e.g. 2023-10-25 12:30:45 or 2023-10-25T12:30:45
+    r"|\[\d{2}/[A-Za-z]{3}/\d{4}:\d{2}:\d{2}:\d{2}" # e.g. [25/Oct/2023:12:30:45
+    r"|[A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}" # e.g. Oct 25 12:30:45
+    r")"
+)
+
+def get_local_embedding(text: str) -> List[float]:
+    """Generates embeddings using a local HTTP endpoint."""
+    payload = {
+        "model": EMBEDDING_MODEL,
+        "prompt": text
+    }
+    with httpx.Client() as client:
+        response = client.post(LOCAL_EMBED_URL, json=payload, timeout=60.0)
+        response.raise_for_status()
+        return response.json().get("embedding", [])
+
+def cosine_similarity(v1: List[float], v2: List[float]) -> float:
+    """Basic dot product for vector comparison."""
+    dot_product = sum(a * b for a, b in zip(v1, v2))
+    mag1 = math.sqrt(sum(a * a for a in v1))
+    mag2 = math.sqrt(sum(b * b for b in v2))
+    if mag1 == 0 or mag2 == 0:
+        return 0.0
+    return dot_product / (mag1 * mag2)
+
+@app.tool()
+async def ingest_log_file(filepath: str) -> str:
+    """
+    Reads a large log file, chunks it based on timestamps (keeping stack traces intact),
+    vectorizes it, and saves it to a text-based JSONL database.
+    """
+    buffer = []
+    chunk_count = 0
+
+    try:
+        with open(filepath, 'r', encoding='utf-8', errors='replace') as file, open(DATABASE_FILE, 'a', encoding='utf-8') as db:
+            for line in file:
+                # If we hit a new timestamp and the buffer is not empty, process the buffer
+                if TIMESTAMP_PATTERN.match(line) and buffer:
+                    chunk_text = "".join(buffer).strip()
+                    if chunk_text:
+                        vector = get_local_embedding(chunk_text)
+
+                        db_entry = {
+                            "source": filepath,
+                            "text": chunk_text,
+                            "vector": vector
+                        }
+                        db.write(json.dumps(db_entry) + "\n")
+                        chunk_count += 1
+
+                    # Reset buffer for the new log entry
+                    buffer = [line]
+                else:
+                    # Either it's the first line, or it's a continuation (like a stack trace)
+                    buffer.append(line)
+
+            # Handle the final buffer
+            if buffer:
+                chunk_text = "".join(buffer).strip()
+                if chunk_text:
+                    vector = get_local_embedding(chunk_text)
+                    db_entry = {"source": filepath, "text": chunk_text, "vector": vector}
+                    db.write(json.dumps(db_entry) + "\n")
+                    chunk_count += 1
+
+        return f"Successfully ingested {filepath}. Created {chunk_count} vectorized text chunks in {DATABASE_FILE}."
+    except Exception as e:
+        return f"Error ingesting log: {str(e)}"
+
+@app.tool()
+async def search_logs(query: str, top_k: int = 3) -> str:
+    """
+    Performs a semantic search over the vectorized log database.
+    Agents should use this to find historical errors, stack traces, or context.
+    """
+    try:
+        query_vector = get_local_embedding(query)
+    except Exception as e:
+        return f"Error generating embedding for query: {str(e)}"
+
+    results = []
+
+    try:
+        if not os.path.exists(DATABASE_FILE):
+            return f"Log database not found at {DATABASE_FILE}. Please run ingest_log_file first."
+
+        with open(DATABASE_FILE, 'r', encoding='utf-8') as db:
+            for line in db:
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                    score = cosine_similarity(query_vector, record.get("vector", []))
+                    results.append((score, record.get("text", "")))
+                except json.JSONDecodeError:
+                    continue
+
+        if not results:
+            return "No log entries found in the database."
+
+        # Sort by highest similarity
+        results.sort(key=lambda x: x[0], reverse=True)
+        top_results = results[:top_k]
+
+        formatted_output = f"Top {len(top_results)} relevant log chunks for query: '{query}'\n" + "-"*40 + "\n"
+        for i, (score, text) in enumerate(top_results):
+            formatted_output += f"--- Result {i+1} (Relevance: {score:.2f}) ---\n{text}\n\n"
+
+        return formatted_output
+    except Exception as e:
+        return f"Error searching logs: {str(e)}"
+
+if __name__ == "__main__":
+    app.run(transport="stdio")


### PR DESCRIPTION
This PR introduces a standalone MCP tool (`tools/log-vectorizer-mcp/`) that reads large log files, chunks them based on timestamps (keeping multi-line stack traces together), vectorizes the chunks using a local inference endpoint (e.g., Ollama), and stores them in a queryable `.jsonl` database. This tool is designed to provide agents with a semantic search capability for historical logs without exceeding their context window limits.

---
*PR created automatically by Jules for task [8950573049582242904](https://jules.google.com/task/8950573049582242904) started by @LokiMetaSmith*