### PR TITLE
docs: mark vision model failover TODO as complete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -206,7 +206,7 @@ This section tracks identified placeholder files, corrupted binaries, and code t
   - `ansible/roles/bootstrap_agent/handlers/main.yaml` is currently empty.
 
 - [x] **Reconcile Stale Artifacts:**
-  - `pipecatapp/app.py` contains code and TODOs (e.g., vision model failover). Determine if these changes should be merged or if the artifact should be regenerated.
+  - [x] `pipecatapp/app.py` contains code and TODOs (e.g., vision model failover). Determine if these changes should be merged or if the artifact should be regenerated.
 - [x] **Vision Model Failover**: Implement failover or selection logic for vision models (see `pipecatapp/app.py`).
 - [x] **Refactor Vision Role**: The `vision` role is currently minimal (only installs `libgl1`) and does not deploy Frigate as implied by the `frigate_port` variable. It needs to be refactored to actually deploy the service.
 - [x] **Review Hardcoded Network References:**


### PR DESCRIPTION
Updates the `TODO.md` file by ticking off the item regarding vision model failover in `pipecatapp/app.py`. The actual failover logic between `YOLOv8Detector` and `MoondreamDetector` is already fully implemented, and no `TODO` comments remain in the file.

---
*PR created automatically by Jules for task [3961816590749848442](https://jules.google.com/task/3961816590749848442) started by @LokiMetaSmith*