### PR TITLE
Integrate WASM evaluator and P2P Weight Sharing logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ venv/
 # Dynamically generated parameter files
 group_vars/all/resource_tuning.yaml
 .ansible_venv
+
+# P2P Sync Tool Artifacts
+poc/p2p_sync/node_*/
+poc/p2p_sync/syncthing_bin*

--- a/pipecatapp/tools/__init__.py
+++ b/pipecatapp/tools/__init__.py
@@ -1,0 +1,2 @@
+from .wasm_tool import WasmTool
+from .p2p_sync_tool import P2PSyncTool

--- a/pipecatapp/tools/p2p_sync_tool.py
+++ b/pipecatapp/tools/p2p_sync_tool.py
@@ -1,0 +1,281 @@
+import os
+import time
+import platform
+import tarfile
+import zipfile
+import stat
+import subprocess
+import requests
+import xml.etree.ElementTree as ET
+import logging
+from typing import Dict, Any, Optional
+
+class P2PSyncTool:
+    """A tool to manage P2P file synchronization (like .gguf models) using Syncthing."""
+
+    def __init__(self, base_dir: Optional[str] = None, name: str = "agent_node", gui_port: int = 8384, listen_port: int = 22000):
+        self.name_tool = "p2p_sync_tool"
+
+        if base_dir is None:
+            # Use a default temp/storage dir for the agent if none provided
+            self.base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.sync_data"))
+        else:
+            self.base_dir = base_dir
+
+        self.name = name
+        self.gui_port = gui_port
+        self.listen_port = listen_port
+        self.home_dir = os.path.abspath(os.path.join(self.base_dir, f"node_{name}"))
+        self.config_file = os.path.join(self.home_dir, "config.xml")
+        self.api_url = f"http://127.0.0.1:{self.gui_port}"
+        self.api_key = None
+        self.device_id = None
+        self.process = None
+
+        is_windows = platform.system() == "Windows"
+        bin_name = "syncthing.exe" if is_windows else "syncthing_bin"
+        self.syncthing_bin = os.path.abspath(os.path.join(os.path.dirname(__file__), bin_name))
+
+        os.makedirs(self.home_dir, exist_ok=True)
+
+    def _ensure_binary_exists(self):
+        if os.path.exists(self.syncthing_bin) and os.path.getsize(self.syncthing_bin) > 5000000:
+            return
+
+        logging.info(f"[{self.name}] Downloading Syncthing binary for {platform.system()} {platform.machine()}...")
+        version = "v1.27.6"
+        os_name = platform.system().lower()
+        arch = platform.machine().lower()
+
+        if os_name == "darwin":
+            os_name = "macos"
+
+        if arch in ["x86_64", "amd64"]:
+            arch = "amd64"
+        elif arch in ["arm64", "aarch64"]:
+            arch = "arm64"
+
+        ext = "zip" if os_name == "windows" else "tar.gz"
+        filename = f"syncthing-{os_name}-{arch}-{version}.{ext}"
+        url = f"https://github.com/syncthing/syncthing/releases/download/{version}/{filename}"
+
+        download_path = os.path.join(os.path.dirname(__file__), filename)
+
+        with requests.get(url, stream=True) as r:
+            r.raise_for_status()
+            with open(download_path, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+
+        if ext == "zip":
+            with zipfile.ZipFile(download_path, 'r') as zip_ref:
+                for member in zip_ref.namelist():
+                    if member.endswith('syncthing.exe'):
+                        with open(self.syncthing_bin, 'wb') as outfile:
+                            outfile.write(zip_ref.read(member))
+                        break
+        else:
+            with tarfile.open(download_path, 'r:gz') as tar_ref:
+                for member in tar_ref.getmembers():
+                    if member.isfile() and member.name.endswith('/syncthing') and member.size > 1000000:
+                        f = tar_ref.extractfile(member)
+                        if f:
+                            with open(self.syncthing_bin, 'wb') as outfile:
+                                outfile.write(f.read())
+                        break
+
+        st = os.stat(self.syncthing_bin)
+        os.chmod(self.syncthing_bin, st.st_mode | stat.S_IEXEC)
+        os.remove(download_path)
+        logging.info(f"[{self.name}] Binary downloaded and extracted successfully.")
+
+    def _modify_config_ports(self):
+        tree = ET.parse(self.config_file)
+        root = tree.getroot()
+        gui = root.find("gui")
+        address = gui.find("address")
+        address.text = f"127.0.0.1:{self.gui_port}"
+        gui.set("enabled", "true")
+        gui.set("tls", "false")
+        options = root.find("options")
+        listen = options.find("listenAddress")
+        listen.text = f"tcp://127.0.0.1:{self.listen_port}"
+        options.find("natEnabled").text = "false"
+        options.find("globalAnnounceEnabled").text = "false"
+        options.find("localAnnounceEnabled").text = "false"
+        tree.write(self.config_file)
+
+    def _get_api_key(self):
+        tree = ET.parse(self.config_file)
+        return tree.getroot().find("gui").find("apikey").text
+
+    def _get_device_id(self):
+        tree = ET.parse(self.config_file)
+        for device in tree.getroot().findall("device"):
+             return device.attrib["id"]
+        return None
+
+    def initialize_and_start(self) -> str:
+        """Downloads binary if missing, generates config, and starts the daemon."""
+        try:
+            self._ensure_binary_exists()
+
+            # Generate config if it doesn't exist
+            if not os.path.exists(self.config_file):
+                subprocess.run([self.syncthing_bin, "generate", "--home", self.home_dir], capture_output=True)
+                self._modify_config_ports()
+
+            self.api_key = self._get_api_key()
+            self.device_id = self._get_device_id()
+
+            self.process = subprocess.Popen(
+                [self.syncthing_bin, "--home", self.home_dir, "--no-browser", "--gui-apikey", self.api_key],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL
+            )
+
+            for _ in range(15):
+                try:
+                    res = requests.get(f"{self.api_url}/rest/system/ping", headers={"X-API-Key": self.api_key})
+                    if res.status_code == 200:
+                        status = requests.get(f"{self.api_url}/rest/system/status", headers={"X-API-Key": self.api_key}).json()
+                        self.device_id = status["myID"]
+                        return f"Syncthing started successfully. Device ID: {self.device_id}"
+                except requests.ConnectionError:
+                    pass
+                time.sleep(1)
+
+            return f"Error: Failed to start Syncthing on port {self.gui_port}."
+        except Exception as e:
+            logging.error(f"Failed to start Syncthing: {e}")
+            return f"Error initializing Syncthing: {e}"
+
+    def stop(self) -> str:
+        """Stops the Syncthing daemon."""
+        if self.process:
+            self.process.terminate()
+            self.process.wait()
+            self.process = None
+            return "Syncthing stopped."
+        return "Syncthing is not running."
+
+    def get_config(self):
+        res = requests.get(f"{self.api_url}/rest/config", headers={"X-API-Key": self.api_key})
+        return res.json()
+
+    def set_config(self, config):
+        res = requests.put(f"{self.api_url}/rest/config", headers={"X-API-Key": self.api_key}, json=config)
+        return res.status_code == 200
+
+    def add_peer(self, peer_device_id: str, address: str) -> str:
+        """Adds a peer node to synchronize with."""
+        if not self.process:
+            return "Error: Syncthing daemon is not running."
+
+        try:
+            config = self.get_config()
+            for dev in config["devices"]:
+                if dev["deviceID"] == peer_device_id:
+                    return f"Peer {peer_device_id} already exists."
+
+            config["devices"].append({
+                "deviceID": peer_device_id,
+                "name": "Peer",
+                "addresses": [f"tcp://{address}"],
+                "compression": "metadata",
+                "certName": "",
+                "introducer": False,
+                "skipIntroductionRemovals": False,
+                "introducedBy": "",
+                "paused": False,
+                "allowedNetworks": [],
+                "autoAcceptFolders": True,
+                "maxSendKbps": 0,
+                "maxRecvKbps": 0,
+                "ignoredFolders": [],
+                "maxRequestKiB": 0,
+                "untrusted": False,
+                "remoteGUIPort": 0
+            })
+            self.set_config(config)
+            return f"Added peer device {peer_device_id} at {address}."
+        except Exception as e:
+            return f"Error adding peer: {e}"
+
+    def share_folder(self, folder_id: str, path: str, peer_device_id: str, folder_type: str = "sendreceive") -> str:
+        """Shares a folder with a specific peer device."""
+        if not self.process:
+            return "Error: Syncthing daemon is not running."
+
+        try:
+            config = self.get_config()
+            os.makedirs(path, exist_ok=True)
+            folder = {
+                "id": folder_id,
+                "label": "Models",
+                "filesystemType": "basic",
+                "path": path,
+                "type": folder_type,
+                "devices": [{"deviceID": self.device_id}, {"deviceID": peer_device_id}],
+                "rescanIntervalS": 5,
+                "fsync": True,
+                "copiers": 0,
+                "pullerMaxPendingKiB": 0,
+                "hashers": 0,
+                "order": "random",
+                "ignorePerms": False,
+                "shortID": "",
+                "autoNormalize": True,
+                "pullerPauseS": 0,
+                "maxConflicts": -1,
+                "disableSparseFiles": False,
+                "disableTempIndexes": False,
+                "paused": False,
+                "weakHashThresholdPct": 25,
+                "markerName": ".stfolder",
+                "copyOwnershipFromParent": False,
+                "modTimeWindowS": 0,
+                "maxConcurrentWrites": 2,
+                "disableFsync": False,
+                "blockPullOrder": "standard",
+                "copyRangeMethod": "standard",
+                "caseSensitiveFS": False,
+                "syncOwnership": False,
+                "sendOwnership": False,
+                "syncXattrs": False,
+                "sendXattrs": False,
+                "xattrFilter": {
+                    "maxSingleEntrySize": 1024,
+                    "maxTotalSize": 4096
+                }
+            }
+
+            for i, f in enumerate(config["folders"]):
+                if f["id"] == folder_id:
+                    config["folders"][i] = folder
+                    self.set_config(config)
+                    return f"Updated shared folder '{folder_id}' at {path}."
+
+            config["folders"].append(folder)
+            self.set_config(config)
+            return f"Shared folder '{folder_id}' at {path}."
+        except Exception as e:
+            return f"Error sharing folder: {e}"
+
+    def check_sync_status(self, peer_device_id: str, folder_id: str) -> str:
+        """Returns the completion percentage of a synced folder with a peer."""
+        if not self.process:
+            return "Error: Syncthing daemon is not running."
+
+        try:
+            res = requests.get(
+                f"{self.api_url}/rest/db/completion",
+                headers={"X-API-Key": self.api_key},
+                params={"device": peer_device_id, "folder": folder_id}
+            )
+            if res.status_code == 200:
+                completion = res.json()["completion"]
+                return f"Sync completion for '{folder_id}' with peer {peer_device_id}: {completion:.2f}%"
+            return f"Error: Could not retrieve status (Status Code: {res.status_code})"
+        except Exception as e:
+            return f"Error checking sync status: {e}"

--- a/pipecatapp/tools/wasm_tool.py
+++ b/pipecatapp/tools/wasm_tool.py
@@ -1,0 +1,88 @@
+import extism
+import json
+import os
+import logging
+from typing import Optional, Dict, Any
+
+class WasmTool:
+    """A tool to execute lightweight WASM plugins using Extism."""
+
+    def __init__(self, wasm_path: Optional[str] = None):
+        self.name = "wasm_tool"
+
+        # Default to the text processor if no path is provided
+        if wasm_path is None:
+            # We assume the poc is compiled and present, otherwise this tool requires a valid path.
+            # In a real deployment, the wasm module should be copied to a permanent location.
+            project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+            self.wasm_path = os.path.join(project_root, "poc/wasm_tool_bridge/text_processor/target/wasm32-wasip1/release/text_processor.wasm")
+        else:
+            self.wasm_path = wasm_path
+
+    def process_text(self, action: str, text: str) -> str:
+        """
+        Processes text using a WASM plugin.
+
+        Args:
+            action (str): The action to perform (e.g., 'uppercase', 'lowercase', 'reverse').
+            text (str): The text to process.
+        """
+        if not os.path.exists(self.wasm_path):
+            return f"Error: WASM module not found at {self.wasm_path}. Please ensure it is compiled."
+
+        try:
+            manifest = {"wasm": [{"path": self.wasm_path}]}
+            plugin = extism.Plugin(manifest, wasi=True)
+
+            input_data = json.dumps({
+                "action": action,
+                "text": text
+            })
+
+            result = plugin.call("process_text", input_data)
+
+            # The extism call returns bytes, we decode it and load as json
+            if isinstance(result, bytes):
+                result_str = result.decode('utf-8')
+            else:
+                result_str = result
+
+            parsed_result = json.loads(result_str)
+            return parsed_result.get("result", str(parsed_result))
+
+        except Exception as e:
+            logging.error(f"Failed to execute WASM plugin: {e}")
+            return f"Error executing WASM plugin: {e}"
+
+    def execute_custom(self, function_name: str, input_payload: Dict[str, Any]) -> str:
+        """
+        Executes a custom function on the WASM plugin.
+
+        Args:
+            function_name (str): The name of the exported WASM function to call.
+            input_payload (dict): The input data to pass to the function as JSON.
+        """
+        if not os.path.exists(self.wasm_path):
+            return f"Error: WASM module not found at {self.wasm_path}."
+
+        try:
+            manifest = {"wasm": [{"path": self.wasm_path}]}
+            plugin = extism.Plugin(manifest, wasi=True)
+
+            input_data = json.dumps(input_payload)
+            result = plugin.call(function_name, input_data)
+
+            if isinstance(result, bytes):
+                result_str = result.decode('utf-8')
+            else:
+                result_str = result
+
+            try:
+                parsed_result = json.loads(result_str)
+                return str(parsed_result)
+            except json.JSONDecodeError:
+                return result_str
+
+        except Exception as e:
+            logging.error(f"Failed to execute custom WASM function '{function_name}': {e}")
+            return f"Error executing custom WASM function '{function_name}': {e}"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,3 +38,4 @@ mypy
 pytest-cov
 mcp
 opencv-python-headless
+extism

--- a/tests/unit/test_p2p_sync_tool.py
+++ b/tests/unit/test_p2p_sync_tool.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import json
+from pipecatapp.tools.p2p_sync_tool import P2PSyncTool
+
+class TestP2PSyncTool(unittest.TestCase):
+
+    @patch('os.makedirs')
+    @patch('os.path.exists')
+    @patch('os.path.getsize')
+    @patch('subprocess.Popen')
+    @patch('subprocess.run')
+    @patch('requests.get')
+    def test_initialize_and_start(self, mock_get, mock_run, mock_popen, mock_getsize, mock_exists, mock_makedirs):
+        mock_exists.return_value = True
+        mock_getsize.return_value = 6000000  # Assume binary exists and is valid size
+
+        # Mock API key extraction
+        with patch('xml.etree.ElementTree.parse') as mock_parse:
+            mock_tree = MagicMock()
+            mock_root = MagicMock()
+            mock_gui = MagicMock()
+            mock_apikey = MagicMock()
+            mock_apikey.text = "dummy_api_key"
+
+            mock_device = MagicMock()
+            mock_device.attrib = {"id": "dummy_device_id"}
+
+            mock_gui.find.return_value = mock_apikey
+            mock_root.find.return_value = mock_gui
+            mock_root.findall.return_value = [mock_device]
+            mock_tree.getroot.return_value = mock_root
+            mock_parse.return_value = mock_tree
+
+            # Mock network responses
+            mock_ping_res = MagicMock()
+            mock_ping_res.status_code = 200
+
+            mock_status_res = MagicMock()
+            mock_status_res.json.return_value = {"myID": "dummy_device_id"}
+
+            mock_get.side_effect = [mock_ping_res, mock_status_res]
+
+            tool = P2PSyncTool(name="test_node")
+            result = tool.initialize_and_start()
+
+            self.assertIn("Syncthing started successfully", result)
+            self.assertIn("dummy_device_id", result)
+
+    @patch('requests.get')
+    def test_check_sync_status(self, mock_get):
+        # Setup mocks
+        mock_res = MagicMock()
+        mock_res.status_code = 200
+        mock_res.json.return_value = {"completion": 99.5}
+        mock_get.return_value = mock_res
+
+        tool = P2PSyncTool()
+        tool.process = MagicMock() # Simulate running
+        tool.api_key = "dummy"
+
+        result = tool.check_sync_status("peer_id", "folder123")
+
+        self.assertIn("99.50%", result)
+        mock_get.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_wasm_tool.py
+++ b/tests/unit/test_wasm_tool.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import json
+from pipecatapp.tools.wasm_tool import WasmTool
+
+class TestWasmTool(unittest.TestCase):
+
+    @patch('os.path.exists')
+    @patch('extism.Plugin')
+    def test_process_text_success(self, mock_plugin_class, mock_exists):
+        # Setup mocks
+        mock_exists.return_value = True
+        mock_plugin = MagicMock()
+        mock_plugin_class.return_value = mock_plugin
+
+        # Simulate WASM returning reversed string in json bytes format
+        mock_plugin.call.return_value = b'{"result": "!dlroW olleH"}'
+
+        tool = WasmTool(wasm_path="/dummy/path.wasm")
+        result = tool.process_text("reverse", "Hello World!")
+
+        self.assertEqual(result, "!dlroW olleH")
+
+        # Verify call arguments
+        mock_plugin.call.assert_called_once()
+        args, _ = mock_plugin.call.call_args
+        self.assertEqual(args[0], "process_text")
+        parsed_input = json.loads(args[1])
+        self.assertEqual(parsed_input["action"], "reverse")
+        self.assertEqual(parsed_input["text"], "Hello World!")
+
+    @patch('os.path.exists')
+    def test_process_text_missing_file(self, mock_exists):
+        mock_exists.return_value = False
+
+        tool = WasmTool(wasm_path="/missing.wasm")
+        result = tool.process_text("reverse", "text")
+
+        self.assertIn("Error: WASM module not found", result)
+
+    @patch('os.path.exists')
+    @patch('extism.Plugin')
+    def test_execute_custom_success(self, mock_plugin_class, mock_exists):
+        mock_exists.return_value = True
+        mock_plugin = MagicMock()
+        mock_plugin_class.return_value = mock_plugin
+        mock_plugin.call.return_value = b'{"status": "success", "value": 42}'
+
+        tool = WasmTool(wasm_path="/dummy/path.wasm")
+        result = tool.execute_custom("compute_magic", {"input": 10})
+
+        # Should return stringified dict
+        self.assertIn("success", result)
+        self.assertIn("42", result)
+
+        mock_plugin.call.assert_called_once_with("compute_magic", '{"input": 10}')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Formalizes the standalone WASM Evaluator (`poc/wasm_tool_bridge/`) and P2P Weight Sharing (`poc/p2p_sync/`) scripts into reusable Python tools for the Pipecat agent platform. This completes the TODO items for Evaluate WASM and P2P Weight Sharing.

---
*PR created automatically by Jules for task [4869614545963287222](https://jules.google.com/task/4869614545963287222) started by @LokiMetaSmith*