### PR TITLE
fix: remove hardcoded python3.12-dev dependency from system_deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ group_vars/all/resource_tuning.yaml
 # P2P Sync Tool Artifacts
 poc/p2p_sync/node_*/
 poc/p2p_sync/syncthing_bin*
+test_venv/

--- a/ansible/roles/system_deps/tasks/main.yaml
+++ b/ansible/roles/system_deps/tasks/main.yaml
@@ -66,7 +66,6 @@
       - python3
       - python3-dev
       - python3-full
-      - python3.12-dev
       - python3-pip
       - python3-venv
       - python3-virtualenv


### PR DESCRIPTION
Removed `python3.12-dev` from the `system_deps` ansible playbook to fix bootstrap failures on minimal instances where `python3.12-dev` is not natively available in standard repos.

This allows `ansible/roles/system_deps/tasks/main.yaml` to successfully execute `apt-get install` using just `python3-dev` natively matching the OS python.

---
*PR created automatically by Jules for task [8919918086765263465](https://jules.google.com/task/8919918086765263465) started by @LokiMetaSmith*