### PR TITLE
feat: Add LangChainToolAdapter and mark TODO complete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -153,7 +153,7 @@ These structural suggestions are targeted for a future major release to signific
 ### Integrate LangChain (Tandem/Hybrid Approach)
 
 - [x] **Phase 1: Build a `LangChainToolAdapter`:**
-  - [ ] Create a wrapper class in `pipecatapp/tools/` capable of ingesting any LangChain `BaseTool` and exposing it through the standard methods expected by our `ToolExecutorNode` and UI approval queue (`TwinService._request_approval`).
+  - [x] Create a wrapper class in `pipecatapp/tools/` capable of ingesting any LangChain `BaseTool` and exposing it through the standard methods expected by our `ToolExecutorNode` and UI approval queue (`TwinService._request_approval`).
 - [x] **Phase 2: RAG Internals Enhancement:**
   - [ ] Update `RAG_Tool.add_document()` to utilize LangChain's `DocumentLoaders` (e.g., `DirectoryLoader`, `PyMuPDFLoader`) and `RecursiveCharacterTextSplitter` internally, maintaining the tool's external API.
 - [x] **Phase 3: Create LangChain Memory Wrappers:**

--- a/pipecatapp/tools/langchain_adapter_tool.py
+++ b/pipecatapp/tools/langchain_adapter_tool.py
@@ -1,0 +1,53 @@
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger("LangChainToolAdapter")
+
+class LangChainToolAdapter:
+    """
+    Adapter class capable of ingesting any LangChain BaseTool and exposing it
+    through the standard methods expected by our ToolExecutorNode.
+    """
+    def __init__(self, langchain_tool: Any):
+        self.langchain_tool = langchain_tool
+        self.name = getattr(langchain_tool, "name", "langchain_tool")
+        self.description = getattr(langchain_tool, "description", "")
+
+        # Convert LangChain args_schema (pydantic) to JSON Schema if available
+        if hasattr(langchain_tool, "args_schema") and langchain_tool.args_schema:
+            try:
+                self.input_schema = langchain_tool.args_schema.model_json_schema()
+            except Exception:
+                try:
+                    self.input_schema = langchain_tool.args_schema.schema()
+                except Exception:
+                    self.input_schema = {
+                        "type": "object",
+                        "properties": {
+                            "tool_input": {
+                                "type": "string",
+                                "description": "Input for the tool"
+                            }
+                        }
+                    }
+        else:
+            self.input_schema = {
+                "type": "object",
+                "properties": {
+                    "tool_input": {
+                        "type": "string",
+                        "description": "Input for the tool"
+                    }
+                }
+            }
+
+    def run(self, **kwargs) -> Any:
+        try:
+            # LangChain tools usually accept either single string or kwargs
+            if len(kwargs) == 1 and "tool_input" in kwargs and not hasattr(self.langchain_tool, "args_schema"):
+                return self.langchain_tool.invoke(kwargs["tool_input"])
+            return self.langchain_tool.invoke(kwargs)
+        except Exception as e:
+            logger.error(f"Error executing LangChain tool {self.name}: {e}")
+            return f"Error executing LangChain tool {self.name}: {str(e)}"

--- a/tests/unit/test_langchain_adapter_tool.py
+++ b/tests/unit/test_langchain_adapter_tool.py
@@ -1,0 +1,51 @@
+import pytest
+from pydantic import BaseModel, Field
+import sys
+import os
+
+# Ensure the parent dir is in sys.path so we can import pipecatapp
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from pipecatapp.tools.langchain_adapter_tool import LangChainToolAdapter
+
+class MockLangchainSchema(BaseModel):
+    query: str = Field(description="Search query")
+
+class MockLangChainTool:
+    def __init__(self):
+        self.name = "mock_tool"
+        self.description = "A mock tool"
+        self.args_schema = MockLangchainSchema
+
+    def invoke(self, kwargs):
+        return f"Mock result for {kwargs.get('query')}"
+
+def test_langchain_adapter_schema():
+    lc_tool = MockLangChainTool()
+    adapter = LangChainToolAdapter(lc_tool)
+
+    assert adapter.name == "mock_tool"
+    assert adapter.description == "A mock tool"
+    assert "query" in adapter.input_schema["properties"]
+
+def test_langchain_adapter_run():
+    lc_tool = MockLangChainTool()
+    adapter = LangChainToolAdapter(lc_tool)
+
+    result = adapter.run(query="hello")
+    assert result == "Mock result for hello"
+
+class MockLangChainToolNoSchema:
+    def __init__(self):
+        self.name = "mock_tool_no_schema"
+        self.description = "A mock tool with no schema"
+
+    def invoke(self, input_str):
+        return f"Mock result string for {input_str}"
+
+def test_langchain_adapter_run_no_schema():
+    lc_tool = MockLangChainToolNoSchema()
+    adapter = LangChainToolAdapter(lc_tool)
+
+    result = adapter.run(tool_input="hello string")
+    assert result == "Mock result string for hello string"


### PR DESCRIPTION
Implemented the `LangChainToolAdapter` to fulfill the pending task in `TODO.md` regarding exposing LangChain `BaseTool` items via the standard Pipecat tools interface.

This adapter seamlessly wraps LangChain tools, translating their Pydantic schemas (v1/v2 compatible) into the standard JSON schemas expected by our orchestrator and `ToolExecutorNode`.

Also added unit tests for schema parsing and invoke functionality, and marked the task as complete in the central TODO tracker.

---
*PR created automatically by Jules for task [7219659173776653248](https://jules.google.com/task/7219659173776653248) started by @LokiMetaSmith*