### PR TITLE
Fix Nomad startup failure due to missing host volumes

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -190,6 +190,9 @@
     - authentik/media
     - authentik/templates
     - authentik/certs
+    - ha-config
+    - apt_proxy
+    - pypi_proxy
   become: yes
 
 - name: Include Nomad TLS tasks
@@ -337,6 +340,7 @@
     state: present
   become: yes
   check_mode: no
+  ignore_errors: "{{ ansible_virtualization_type | default(\'\') in [\'docker\', \'containerd\'] }}"
 
 - name: Ensure br_netfilter module is loaded on boot
   ansible.builtin.copy:


### PR DESCRIPTION
Resolves a bug where the Nomad service failed to start during Ansible deployment due to missing host volume directories.

The Nomad service configurations expected `/opt/nomad/volumes/ha-config` (along with `apt_proxy` and `pypi_proxy` on clients) to exist, but the Ansible task responsible for creating subdirectories omitted them. This caused the nomad startup wrapper to crash with `client setup failed: node setup failed: failed to validate volume ha-config, err: stat /opt/nomad/volumes/ha-config: no such file or directory`. 

This patch synchronizes the directory creation task with the configured host volumes. It also makes the `br_netfilter` kernel module task more resilient for CI/CD container environments.

---
*PR created automatically by Jules for task [11437593591974711389](https://jules.google.com/task/11437593591974711389) started by @LokiMetaSmith*