### PR TITLE
feat: Add Model Training as Code (MTaC) framework and agent tool

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -380,6 +380,34 @@ This section tracks actionable ideas derived from the `docs/analysis/POLLEN_COMP
 
 - [x] Investigate and fix `test_load_playbooks_from_manifest` failure in `tests/unit/test_provisioning.py` caused by `yaml` mocking issues.
 
+## Model Training as Code (MTaC) Integration
+
+
+
+This section tracks the integration of Aleph Alpha's "Model Training as Code" (MTaC) concepts into our workflow.
+
+- [x] **Pipeline Orchestrator Framework:**
+
+  - [x] Created `pipecatapp/mtac_pipeline.py` to programmatically generate Nomad job definitions for ML training stages (e.g., `sft`, `rl`, `eval`).
+
+  - [x] Implemented asynchronous dispatch and monitoring of these jobs against the Nomad API.
+
+  - [x] Integrated mock/dummy training stages to simulate execution and state tracking.
+
+- [x] **Agent Tool Integration:**
+
+  - [x] Created `pipecatapp/tools/mtac_tool.py` exposing the orchestrator as a tool.
+
+  - [x] Added `MTACTool` to the `agent_factory.py` so agents can autonomously launch training stages or full pipelines.
+
+- [ ] **Real ML Backends (Next Steps):**
+
+  - [ ] Replace mock batch jobs with actual containerized ML workloads (e.g., Unsloth or Torchtune).
+
+  - [ ] Integrate ML result metrics and telemetry streaming into the cluster dashboard.
+
+
+
 ## Future Model Integrations
 
 - [x] **Orthrus Integration:** Track upstream support in `llama.cpp` or native `vLLM` for "Orthrus" (dual-view diffusion decoding model, e.g., `chiennv/Orthrus-Qwen3-8B`). Once supported by our core inference engines, integrate it into `group_vars/models.yaml` to take advantage of its memory-efficient parallel token generation for complex reasoning tasks.

--- a/pipecatapp/agent_factory.py
+++ b/pipecatapp/agent_factory.py
@@ -34,6 +34,7 @@ from tools.autoresearch_tool import AutoresearchTool
 from tools.submit_solution_tool import SubmitSolutionTool
 from tools.container_registry_tool import ContainerRegistryTool
 from tools.search_tool import SearchTool
+from tools.mtac_tool import MTACTool
 from tools.openclaw_tool import OpenClawTool
 from tools.atproto_tool import ATProtoTool
 from tools.scheduler_tool import SchedulerTool
@@ -114,6 +115,7 @@ def create_tools(config: dict, twin_service=None, runner=None) -> dict:
         "submit_solution": SubmitSolutionTool(),
         "container_registry": ContainerRegistryTool(),
         "search": SearchTool(root_dir="/opt/pipecatapp"),
+        "mtac": MTACTool(),
         "openclaw": OpenClawTool(
             gateway_url=config.get("openclaw_gateway_url", "ws://openclaw.service.consul:18789")
         ),

--- a/pipecatapp/mtac_pipeline.py
+++ b/pipecatapp/mtac_pipeline.py
@@ -1,0 +1,162 @@
+import os
+import requests
+import urllib.parse
+import json
+import asyncio
+import logging
+import uuid
+import time
+from typing import Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+class MTACPipelineOrchestrator:
+    """
+    Model Training as Code Pipeline Orchestrator.
+    Handles generating and dispatching Nomad jobs for model training stages.
+    """
+    def __init__(self):
+        cluster_ip = os.getenv("CLUSTER_IP", "127.0.0.1")
+        self.nomad_addr = os.getenv("NOMAD_ADDR", f"http://{cluster_ip}:4646")
+
+    def _generate_mock_job_def(self, stage: str, job_id: str, config: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Generates a mock Nomad job definition for a given stage.
+        """
+        job = {
+            "Job": {
+                "ID": job_id,
+                "Name": f"mtac-{stage}-{job_id.split(\"-\")[2][:8]}",
+                "Type": "batch",
+                "Datacenters": ["dc1"],
+                "TaskGroups": [
+                    {
+                        "Name": "trainer",
+                        "Tasks": [
+                            {
+                                "Name": f"{stage}-task",
+                                "Driver": "raw_exec",
+                                "Config": {
+                                    "command": "/bin/sh",
+                                    "args": [
+                                        "-c",
+                                        f"echo 'Starting mock {stage} with config: {json.dumps(config)}'; sleep 5; echo 'Finished mock {stage}'"
+                                    ]
+                                },
+                                "Resources": {
+                                    "CPU": 100,
+                                    "MemoryMB": 64
+                                }
+                            }
+                        ],
+                        "RestartPolicy": {
+                            "Attempts": 0,
+                            "Mode": "fail"
+                        }
+                    }
+                ]
+            }
+        }
+        return job
+
+    async def _dispatch_job(self, job_def: Dict[str, Any]) -> str:
+        """
+        Submits the job definition to Nomad and returns the eval ID.
+        """
+        url = f"{self.nomad_addr}/v1/jobs"
+        try:
+            # Run requests in thread to avoid blocking asyncio loop
+            response = await asyncio.to_thread(requests.post, url, json=job_def, timeout=10.0)
+            response.raise_for_status()
+            data = response.json()
+            return data.get("EvalID", "")
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Request failed: {e}")
+            raise
+
+    async def _wait_for_job_completion(self, job_id: str, timeout: int = 300) -> bool:
+        """
+        Polls the Nomad API until the batch job is dead/complete.
+        Returns True if successful, False if failed or timeout.
+        """
+        url = f"{self.nomad_addr}/v1/job/{job_id}/allocations"
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            try:
+                response = await asyncio.to_thread(requests.get, url, timeout=5.0)
+                if response.status_code == 200:
+                    allocs = response.json()
+                    if not allocs:
+                        await asyncio.sleep(2)
+                        continue
+
+                    # Check the latest allocation
+                    alloc = allocs[0]
+                    client_status = alloc.get("ClientStatus")
+                    if client_status in ["complete", "failed", "lost"]:
+                        logger.info(f"Job {job_id} reached terminal state: {client_status}")
+                        return client_status == "complete"
+            except Exception as e:
+                logger.warning(f"Error polling Nomad API for job {job_id}: {e}")
+
+            await asyncio.sleep(2)
+
+        logger.error(f"Timeout waiting for job {job_id} to complete")
+        return False
+
+    async def run_stage(self, stage: str, config: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Runs a specific training pipeline stage.
+        """
+        job_id = f"mtac-{stage}-{str(uuid.uuid4())}"
+        job_def = self._generate_mock_job_def(stage, job_id, config)
+
+        logger.info(f"Dispatching MTaC stage: {stage} with Job ID: {job_id}")
+
+        try:
+            await self._dispatch_job(job_def)
+            success = await self._wait_for_job_completion(job_id)
+
+            return {
+                "stage": stage,
+                "job_id": job_id,
+                "status": "success" if success else "failed",
+                "message": f"Stage {stage} {'completed successfully' if success else 'failed or timed out'}."
+            }
+        except Exception as e:
+            logger.error(f"Failed to dispatch or monitor job {job_id}: {e}")
+            return {
+                "stage": stage,
+                "job_id": job_id,
+                "status": "error",
+                "message": str(e)
+            }
+
+    async def run_full_pipeline(self, pipeline_config: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Orchestrates an end-to-end pipeline (SFT -> RL -> Eval).
+        """
+        results = {}
+
+        # SFT Stage
+        sft_config = pipeline_config.get("sft", {})
+        sft_result = await self.run_stage("sft", sft_config)
+        results["sft"] = sft_result
+        if sft_result["status"] != "success":
+            return {"status": "failed", "stage_results": results}
+
+        # RL Stage
+        rl_config = pipeline_config.get("rl", {})
+        rl_result = await self.run_stage("rl", rl_config)
+        results["rl"] = rl_result
+        if rl_result["status"] != "success":
+            return {"status": "failed", "stage_results": results}
+
+        # Eval Stage
+        eval_config = pipeline_config.get("eval", {})
+        eval_result = await self.run_stage("eval", eval_config)
+        results["eval"] = eval_result
+
+        overall_status = "success" if eval_result["status"] == "success" else "failed"
+        return {"status": overall_status, "stage_results": results}

--- a/pipecatapp/tools/__init__.py
+++ b/pipecatapp/tools/__init__.py
@@ -1,2 +1,3 @@
 from .wasm_tool import WasmTool
 from .p2p_sync_tool import P2PSyncTool
+from .mtac_tool import MTACTool

--- a/pipecatapp/tools/mtac_tool.py
+++ b/pipecatapp/tools/mtac_tool.py
@@ -1,0 +1,64 @@
+import logging
+import json
+import asyncio
+
+# Dynamically import the pipeline orchestrator to prevent circular imports if it gets complex later
+from pipecatapp.mtac_pipeline import MTACPipelineOrchestrator
+
+logger = logging.getLogger(__name__)
+
+class MTACTool:
+    """
+    A tool that allows the agent to orchestrate Model Training as Code (MTaC) runs.
+    It can launch individual training stages or a full end-to-end training pipeline via the cluster orchestration.
+    """
+
+    def __init__(self):
+        self.name = "mtac"
+        self.description = (
+            "Launch Model Training as Code (MTaC) jobs on the cluster. "
+            "Allows you to run specific model training stages like 'sft' (Supervised Fine Tuning), "
+            "'rl' (Reinforcement Learning), 'eval' (Evaluation), or a 'full_pipeline'. "
+            "Pass a JSON configuration string for the given stage."
+        )
+        self.input_schema = {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "type": "string",
+                    "description": "The pipeline stage to run. Supported values: 'sft', 'rl', 'eval', or 'full_pipeline'."
+                },
+                "config": {
+                    "type": "string",
+                    "description": "A JSON string representing the configuration for the chosen stage. Example: '{\"learning_rate\": 1e-4}'."
+                }
+            },
+            "required": ["stage"]
+        }
+        self.orchestrator = MTACPipelineOrchestrator()
+
+    async def run(self, stage: str, config: str = "{}") -> str:
+        """
+        Executes the requested MTaC pipeline stage.
+        """
+        try:
+            parsed_config = json.loads(config)
+        except json.JSONDecodeError:
+            return "Error: Invalid JSON string provided for the `config` argument."
+
+        supported_stages = ["sft", "rl", "eval", "full_pipeline"]
+        if stage not in supported_stages:
+            return f"Error: Unsupported stage '{stage}'. Must be one of {supported_stages}."
+
+        logger.info(f"Agent triggered MTaC tool for stage '{stage}' with config: {parsed_config}")
+
+        try:
+            if stage == "full_pipeline":
+                result = await self.orchestrator.run_full_pipeline(parsed_config)
+            else:
+                result = await self.orchestrator.run_stage(stage, parsed_config)
+
+            return f"MTaC execution complete.\nResult:\n{json.dumps(result, indent=2)}"
+        except Exception as e:
+            logger.error(f"MTaC tool execution failed: {e}")
+            return f"Error during MTaC execution: {str(e)}"


### PR DESCRIPTION
Added the `MTACPipelineOrchestrator` for generating and dispatching Nomad jobs for model training, added the `MTACTool` for agents, and updated the `TODO.md`.

---
*PR created automatically by Jules for task [14693928581021024044](https://jules.google.com/task/14693928581021024044) started by @LokiMetaSmith*