### PR TITLE
fix: correct YAML syntax error in nomad playbook

### DIFF
--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -340,7 +340,7 @@
     state: present
   become: yes
   check_mode: no
-  ignore_errors: "{{ ansible_virtualization_type | default(\'\') in [\'docker\', \'containerd\'] }}"
+  ignore_errors: "{{ ansible_virtualization_type | default('') in ['docker', 'containerd'] }}"
 
 - name: Ensure br_netfilter module is loaded on boot
   ansible.builtin.copy:


### PR DESCRIPTION
Fixes a `YAML parsing failed: While parsing a quoted scalar found unknown escape character.` error in `ansible/roles/nomad/tasks/main.yaml` around line 343.

The `ignore_errors` field incorrectly used backslashes to escape single quotes inside a double-quoted string (`\'\'`). This PR removes the backslashes (`''`), which corrects the YAML syntax and allows the playbook to run successfully.

---
*PR created automatically by Jules for task [6866172740513686665](https://jules.google.com/task/6866172740513686665) started by @LokiMetaSmith*