### PR TITLE
feat: implement missing bootstrap agent handler

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -203,7 +203,7 @@ This section tracks actionable ideas derived from the `docs/analysis/GNUTELLA_AN
 This section tracks identified placeholder files, corrupted binaries, and code that needs to be fixed or removed.
 
 - [x] **Remove or Implement Empty Handler:**
-  - [ ] `ansible/roles/bootstrap_agent/handlers/main.yaml` is currently empty.
+  - [x] `ansible/roles/bootstrap_agent/handlers/main.yaml` is currently empty.
 
 - [x] **Reconcile Stale Artifacts:**
   - [ ] `pipecatapp/app.py` contains code and TODOs (e.g., vision model failover). Determine if these changes should be merged or if the artifact should be regenerated.

--- a/ansible/roles/bootstrap_agent/handlers/main.yaml
+++ b/ansible/roles/bootstrap_agent/handlers/main.yaml
@@ -1,0 +1,6 @@
+---
+# handlers file for bootstrap_agent
+- name: Restart nomad
+  ansible.builtin.systemd:
+    name: nomad
+    state: restarted


### PR DESCRIPTION
This PR resolves an empty handler issue tracked in `TODO.md`.

Changes:
1. Implemented `Restart nomad` handler in `ansible/roles/bootstrap_agent/handlers/main.yaml`.
2. Updated `TODO.md` file to mark the item "Remove or Implement Empty Handler" as completed.

---
*PR created automatically by Jules for task [5760493630722638179](https://jules.google.com/task/5760493630722638179) started by @LokiMetaSmith*