### PR TITLE
Fix intermittent apt-get update failure in ansible playbook

### DIFF
--- a/ansible/roles/clamav/tasks/main.yaml
+++ b/ansible/roles/clamav/tasks/main.yaml
@@ -6,6 +6,9 @@
       - clamav-freshclam
     state: present
     update_cache: yes
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 15
+    cache_valid_time: 3600
   become: yes
 
 - name: Ensure freshclam is running and enabled

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -21,6 +21,8 @@
 - name: Update apt cache
   apt:
     update_cache: yes
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 15
     cache_valid_time: 3600
 
 - name: Upgrade all packages to the latest version

--- a/ansible/roles/heretic_tool/tasks/main.yaml
+++ b/ansible/roles/heretic_tool/tasks/main.yaml
@@ -1,6 +1,9 @@
 - name: Update apt cache
   ansible.builtin.apt:
     update_cache: yes
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 15
+    cache_valid_time: 3600
   become: yes
 
 - name: Placeholder for GPU dependencies

--- a/ansible/roles/librarian/tasks/main.yml
+++ b/ansible/roles/librarian/tasks/main.yml
@@ -8,6 +8,9 @@
       - unzip
     state: present
     update_cache: yes
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 15
+    cache_valid_time: 3600
 
 - name: Create Librarian directory
   file:

--- a/ansible/roles/llxprt_code/tasks/main.yaml
+++ b/ansible/roles/llxprt_code/tasks/main.yaml
@@ -33,6 +33,9 @@
 - name: Update apt cache and install Node.js
   ansible.builtin.apt:
     update_cache: yes
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 15
+    cache_valid_time: 3600
     name: nodejs
     state: latest
   become: yes

--- a/ansible/roles/magic_mirror/tasks/main.yaml
+++ b/ansible/roles/magic_mirror/tasks/main.yaml
@@ -21,6 +21,9 @@
           - libwayland-client0
         state: present
         update_cache: yes
+        update_cache_retries: 10
+        update_cache_retry_max_delay: 15
+        cache_valid_time: 3600
 
     - name: Determine correct libasound package
       ansible.builtin.set_fact:

--- a/ansible/roles/nanochat/tasks/main.yaml
+++ b/ansible/roles/nanochat/tasks/main.yaml
@@ -9,6 +9,9 @@
       - python3-dev
     state: present
     update_cache: yes
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 15
+    cache_valid_time: 3600
   become: yes
 
 - name: Install uv

--- a/ansible/roles/power_manager/tasks/main.yaml
+++ b/ansible/roles/power_manager/tasks/main.yaml
@@ -11,6 +11,9 @@
       - python3-bpfcc # This provides the bcc Python library
     state: present
     update_cache: yes
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 15
+    cache_valid_time: 3600
 
 
 - name: Create directory for the power agent

--- a/ansible/roles/system_deps/tasks/main.yaml
+++ b/ansible/roles/system_deps/tasks/main.yaml
@@ -1,6 +1,8 @@
 - name: Update apt cache
   ansible.builtin.apt:
     update_cache: yes
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 15
     cache_valid_time: 3600
   become: yes
   register: apt_update_result

--- a/ansible/roles/term_everything/tasks/main.yml
+++ b/ansible/roles/term_everything/tasks/main.yml
@@ -4,6 +4,9 @@
     name: podman
     state: present
     update_cache: yes
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 15
+    cache_valid_time: 3600
 
 - name: Get latest commit hash from term.everything remote repo
   ansible.builtin.command:

--- a/ansible/roles/unified_fs/tasks/main.yml
+++ b/ansible/roles/unified_fs/tasks/main.yml
@@ -3,6 +3,9 @@
     name: fuse
     state: present
     update_cache: yes
+    update_cache_retries: 10
+    update_cache_retry_max_delay: 15
+    cache_valid_time: 3600
 
 - name: Create mount directory
   file:


### PR DESCRIPTION
In many roles, `ansible.builtin.apt` was used with `update_cache: yes`, which causes intermittent failure when running many roles sequentially in the bootstrap script due to apt lock contention and transient network issues. This commit increases the number of retries (`update_cache_retries: 10`) and adds a cache validation time (`cache_valid_time: 3600`) to significantly improve robustness during execution.

---
*PR created automatically by Jules for task [13512152220588695116](https://jules.google.com/task/13512152220588695116) started by @LokiMetaSmith*