### PR TITLE
Fix Consul SSL verification error in seed_models playbook

### DIFF
--- a/ansible/roles/seed_models/tasks/main.yaml
+++ b/ansible/roles/seed_models/tasks/main.yaml
@@ -98,6 +98,9 @@
 - name: Store LLM model CIDs in Consul
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/llm/{{ item.item.filename }}"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -147,6 +150,9 @@
 - name: Store vLLM model CIDs in Consul
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/vllm/{{ item.item.repo_id.split('/')[-1] }}"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -215,6 +221,9 @@
 - name: Store STT (URL) CIDs in Consul
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/stt/{{ item.item[0].key }}/{{ item.item[1].filename }}"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -234,6 +243,9 @@
 - name: Store STT (Hub) CIDs in Consul
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/stt/{{ item.item[0].key }}/{{ item.item[1].name }}"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -279,6 +291,9 @@
 - name: Store TTS model CIDs in Consul
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/tts/{{ item.item.filename }}"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -346,6 +361,9 @@
 - name: Store Vision (URL) CIDs in Consul
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/vision/{{ item.item.filename }}"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -365,6 +383,9 @@
 - name: Store Vision (Hub) CIDs in Consul
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/vision/{{ item.item.name }}"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -414,6 +435,9 @@
 - name: Store Embedding model CIDs in Consul
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/embedding/{{ item.item.name }}"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -433,6 +457,9 @@
 - name: Store Reference Data CID in Consul
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/reference_data/main"
+    client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
+    client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
+    validate_certs: false
     method: PUT
     body: "{{ reference_data_ipfs_cid.stdout }}"
     headers:


### PR DESCRIPTION
Fixes `[SSL: CERTIFICATE_VERIFY_FAILED]` error by adding missing mTLS parameters (`validate_certs: false`, `client_cert`, `client_key`) to all Consul API calls in `seed_models/tasks/main.yaml`.

---
*PR created automatically by Jules for task [6663689571163069722](https://jules.google.com/task/6663689571163069722) started by @LokiMetaSmith*