### PR TITLE
⚡ Refactor ExternalLLMClient to use aiohttp for async compatibility

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,36 @@
+import asyncio
+import time
+import sys
+
+# add path
+import os
+sys.path.insert(0, os.path.abspath('.'))
+
+from pipecatapp.llm_clients import ExternalLLMClient
+from unittest.mock import patch, MagicMock
+
+async def main():
+    client = ExternalLLMClient("http://fake.url", "fake_key", "fake_model")
+
+    # We will mock requests.post to simulate a delay of 0.1s
+    with patch('requests.post') as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"choices": [{"message": {"content": "Hello"}}]}
+
+        def fake_post(*args, **kwargs):
+            time.sleep(0.1)
+            return mock_response
+
+        mock_post.side_effect = fake_post
+
+        start_time = time.time()
+        # run 10 concurrent requests
+        tasks = [client.process_text("test") for _ in range(10)]
+        results = await asyncio.gather(*tasks)
+        end_time = time.time()
+
+        print(f"Time taken for 10 requests: {end_time - start_time:.2f} seconds")
+        print(f"Results: {results[0]}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/benchmark_async.py
+++ b/benchmark_async.py
@@ -1,0 +1,42 @@
+import asyncio
+import time
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from pipecatapp.llm_clients import ExternalLLMClient
+from unittest.mock import patch, MagicMock, AsyncMock
+
+async def main():
+    client = ExternalLLMClient("http://fake.url", "fake_key", "fake_model")
+
+    # We will mock aiohttp.ClientSession.post to simulate a delay of 0.1s
+    with patch('aiohttp.ClientSession.post') as mock_post:
+
+        class AsyncContextManagerMock:
+            async def __aenter__(self):
+                await asyncio.sleep(0.1)
+                mock_resp = MagicMock()
+                mock_resp.json = AsyncMock(return_value={"choices": [{"message": {"content": "Hello"}}]})
+                return mock_resp
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+        # side_effect returning a new instance on each call
+        mock_post.side_effect = lambda *args, **kwargs: AsyncContextManagerMock()
+
+        start_time = time.time()
+        # run 10 concurrent requests
+        tasks = [client.process_text("test") for _ in range(10)]
+        results = await asyncio.gather(*tasks)
+        end_time = time.time()
+
+        print(f"Time taken for 10 requests: {end_time - start_time:.2f} seconds")
+        print(f"Results: {results[0]}")
+
+    if client._session:
+        await client._session.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pipecatapp/llm_clients.py
+++ b/pipecatapp/llm_clients.py
@@ -1,5 +1,6 @@
 import logging
-import requests
+import aiohttp
+import asyncio
 
 class ExternalLLMClient:
     """A generic client for interacting with OpenAI-compatible LLM APIs.
@@ -26,6 +27,7 @@ class ExternalLLMClient:
         self.base_url = base_url
         self.api_key = api_key
         self.model = model
+        self._session = None
 
     async def process_text(self, prompt: str) -> str:
         """Sends a prompt to the external LLM and returns the response.
@@ -54,18 +56,16 @@ class ExternalLLMClient:
         }
 
         try:
-            # Note: The 'requests' library is synchronous.
-            # For a fully async application, 'aiohttp' would be a better choice,
-            # but for simplicity and compatibility with the existing codebase,
-            # we will use 'requests' here. Pipecat can handle running this
-            # synchronous code in a separate thread.
-            response = requests.post(f"{self.base_url}/chat/completions", headers=headers, json=data)
-            response.raise_for_status()
+            if not self._session:
+                self._session = aiohttp.ClientSession()
 
-            response_json = response.json()
+            async with self._session.post(f"{self.base_url}/chat/completions", headers=headers, json=data) as response:
+                response.raise_for_status()
+                response_json = await response.json()
+
             content = response_json.get("choices", [{}])[0].get("message", {}).get("content", "")
             return content.strip()
-        except requests.exceptions.RequestException as e:
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             logging.error(f"Error calling external LLM API for model {self.model}: {e}")
             return f"Error: Could not connect to the external model {self.model}."
         except (KeyError, IndexError) as e:


### PR DESCRIPTION
💡 **What:** Refactored `ExternalLLMClient.process_text` to use `aiohttp.ClientSession` with a lazy initialization pattern, replacing the synchronous `requests.post` call.
🎯 **Why:** `requests` is a blocking I/O library. When used inside an `async def` method, it blocks the entire event loop, preventing other asynchronous tasks from executing concurrently.
📊 **Measured Improvement:** We benchmarked 10 concurrent requests with an artificial 100ms response delay. 
* Baseline (with `requests`): 1.01 seconds (requests executed sequentially blocking the loop).
* Improved (with `aiohttp`): 0.11 seconds (requests executed concurrently yielding to the loop).
This translates to a ~10x speedup in wall-clock time for concurrent workloads on a single thread.

---
*PR created automatically by Jules for task [12681372528929614653](https://jules.google.com/task/12681372528929614653) started by @LokiMetaSmith*