### PR TITLE
refactor: replace shutil.copytree with tar snapshotting in evaluators

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -242,7 +242,7 @@ This section tracks identified placeholder files, corrupted binaries, and code t
 - [x] **Optimize Fast Path Security Redaction:** Enhanced `security.py` with LRU caching (`@lru_cache`), streaming redaction for large texts (`redact_sensitive_data_stream`), and optional cache disable for unique/large inputs. Maintains original fast-path regex optimization.
 
 - [x] **Optimize ExperimentTool Sandbox Creation:**
-  - [ ] Replaced `shutil.copytree` with `tar` snapshotting to reduce syscall overhead.
+  - [x] Replaced `shutil.copytree` with `tar` snapshotting to reduce syscall overhead.
 - [x] **Optimize ProjectMapperTool Scanning:**
   - [ ] Implemented `git ls-files` strategy for faster file listing in git repositories.
 - [x] **Review Codebase for I/O Inefficiencies:**

--- a/prompt_engineering/create_evaluator.py
+++ b/prompt_engineering/create_evaluator.py
@@ -56,7 +56,9 @@ async def evaluate_code(candidate_code: str) -> dict:
     try:
         # 1. Setup temporary directory
         logging.info(f"Creating temporary directory: {{temp_dir}}")
-        shutil.copytree(APP_SOURCE_DIR, temp_dir)
+        os.makedirs(temp_dir, exist_ok=True)
+        import subprocess
+        subprocess.run(["sh", "-c", "tar -cf - -C \"$1\" . | tar -xf - -C \"$2\"", "--", APP_SOURCE_DIR, temp_dir], check=True)
         with open(os.path.join(temp_dir, TARGET_CODE_FILE), "w") as f:
             f.write(candidate_code)
 

--- a/prompt_engineering/evaluator.py
+++ b/prompt_engineering/evaluator.py
@@ -138,7 +138,9 @@ async def evaluate_code(candidate_code: str) -> dict:
     try:
         # 1. Setup temporary directory with candidate code
         logging.info(f"Creating temporary directory: {temp_dir}")
-        shutil.copytree(APP_SOURCE_DIR, temp_dir)
+        os.makedirs(temp_dir, exist_ok=True)
+        import subprocess
+        subprocess.run(["sh", "-c", "tar -cf - -C \"$1\" . | tar -xf - -C \"$2\"", "--", APP_SOURCE_DIR, temp_dir], check=True)
         with open(os.path.join(temp_dir, "app.py"), "w") as f:
             f.write(actual_code)
 


### PR DESCRIPTION
Replaced `shutil.copytree` with `tar` snapshotting in `prompt_engineering/evaluator.py` and `prompt_engineering/create_evaluator.py` to reduce syscall overhead. Checked off the corresponding task in `TODO.md`. The subprocess call utilizes secure positional arguments (`sh -c`) to prevent shell injection and properly handle paths with spaces.

---
*PR created automatically by Jules for task [17377461922322226134](https://jules.google.com/task/17377461922322226134) started by @LokiMetaSmith*