### PR TITLE
Add Unit Tests for LangChain Memory Wrappers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -157,8 +157,8 @@ These structural suggestions are targeted for a future major release to signific
 - [x] **Phase 2: RAG Internals Enhancement:**
   - [x] Update `RAG_Tool.add_document()` to utilize LangChain's `DocumentLoaders` (e.g., `DirectoryLoader`, `PyMuPDFLoader`) and `RecursiveCharacterTextSplitter` internally, maintaining the tool's external API.
 - [x] **Phase 3: Create LangChain Memory Wrappers:**
-  - [ ] Implement `PMMChatMessageHistory` (inheriting from `BaseChatMessageHistory`) that reads/writes to our deterministic `pmm_memory.db` ledger.
-  - [ ] Implement `PipecatVectorStore` (inheriting from `VectorStore`) wrapping our custom `memory.py` FAISS/SQLite setup.
+  - [x] Implement `PMMChatMessageHistory` (inheriting from `BaseChatMessageHistory`) that reads/writes to our deterministic `pmm_memory.db` ledger.
+  - [x] Implement `PipecatVectorStore` (inheriting from `VectorStore`) wrapping our custom `memory.py` FAISS/SQLite setup.
 - [x] **Phase 4: Build a `LangGraphNode` for the Workflow Engine:**
   - [ ] Create a custom node for `pipecatapp/workflow/nodes/` that compiles and executes a specialized LangGraph (e.g., a complex agentic research loop) as a single step within our hardware-aware, orchestrator-driven DAG.
 

--- a/tests/unit/test_langchain_wrappers.py
+++ b/tests/unit/test_langchain_wrappers.py
@@ -1,0 +1,106 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from pipecatapp.langchain_memory_wrappers import PMMChatMessageHistory, PipecatVectorStore
+from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
+
+@pytest.fixture
+def mock_pmm_memory():
+    memory = MagicMock()
+    return memory
+
+def test_pmm_chat_message_history_get_messages(mock_pmm_memory):
+    # Setup mock events returning from oldest to newest
+    mock_events = [
+        {"kind": "system_message", "content": "You are a helpful assistant.", "meta": {"session_id": "test_session"}},
+        {"kind": "user_message", "content": "Hello", "meta": {"session_id": "test_session"}},
+        {"kind": "assistant_message", "content": "Hi there!", "meta": {"session_id": "test_session"}},
+        {"kind": "user_message", "content": "Ignore this", "meta": {"session_id": "other_session"}}
+    ]
+    mock_pmm_memory.get_events_sync.return_value = mock_events
+
+    history = PMMChatMessageHistory(pmm_memory=mock_pmm_memory, session_id="test_session")
+    messages = history.messages
+
+    assert len(messages) == 3
+    assert isinstance(messages[0], SystemMessage)
+    assert messages[0].content == "You are a helpful assistant."
+
+    assert isinstance(messages[1], HumanMessage)
+    assert messages[1].content == "Hello"
+
+    assert isinstance(messages[2], AIMessage)
+    assert messages[2].content == "Hi there!"
+
+    mock_pmm_memory.get_events_sync.assert_called_once_with(limit=50)
+
+def test_pmm_chat_message_history_add_messages(mock_pmm_memory):
+    history = PMMChatMessageHistory(pmm_memory=mock_pmm_memory, session_id="test_session")
+
+    history.add_message(HumanMessage(content="My human message"))
+    mock_pmm_memory.add_event_sync.assert_called_with(
+        kind="user_message",
+        content="My human message",
+        meta={"session_id": "test_session"}
+    )
+
+    history.add_message(AIMessage(content="My AI response"))
+    mock_pmm_memory.add_event_sync.assert_called_with(
+        kind="assistant_message",
+        content="My AI response",
+        meta={"session_id": "test_session"}
+    )
+
+@pytest.fixture
+def mock_memory_store():
+    store = MagicMock()
+    store.index.ntotal = 10
+    return store
+
+def test_pipecat_vector_store_add_texts(mock_memory_store):
+    vector_store = PipecatVectorStore(memory_store=mock_memory_store)
+
+    texts = ["first text", "second text"]
+    metadatas = [{"source": "doc1", "summary": "sum1"}, {"source": "doc2"}]
+
+    ids = vector_store.add_texts(texts=texts, metadatas=metadatas)
+
+    assert len(ids) == 2
+    assert mock_memory_store.add.call_count == 2
+    assert mock_memory_store.add_memory.call_count == 2
+
+    mock_memory_store.add.assert_any_call("first text")
+    mock_memory_store.add.assert_any_call("second text")
+
+    # Check that metadatas were passed correctly to add_memory
+    mock_memory_store.add_memory.assert_any_call(
+        source="doc1",
+        raw_text="first text",
+        summary="sum1",
+        entities=None,
+        topics=None
+    )
+
+    mock_memory_store.add_memory.assert_any_call(
+        source="doc2",
+        raw_text="second text",
+        summary=None,
+        entities=None,
+        topics=None
+    )
+
+def test_pipecat_vector_store_similarity_search(mock_memory_store):
+    mock_memory_store.search.return_value = ["result 1", "result 2"]
+
+    vector_store = PipecatVectorStore(memory_store=mock_memory_store)
+    results = vector_store.similarity_search("query text", k=2)
+
+    assert len(results) == 2
+    assert results[0].page_content == "result 1"
+    assert results[1].page_content == "result 2"
+
+    mock_memory_store.search.assert_called_once_with("query text", k=2)
+
+def test_pipecat_vector_store_from_texts():
+    with pytest.raises(NotImplementedError):
+        PipecatVectorStore.from_texts(["text"], embedding=None)


### PR DESCRIPTION
This PR adds missing unit tests for the LangChain Memory Wrappers feature (`PMMChatMessageHistory` and `PipecatVectorStore`). The feature was previously implemented in the codebase but lacked test coverage and the `TODO.md` was out of date. The TODO has now been marked as completed after verifying the feature with the new tests.

---
*PR created automatically by Jules for task [14399681989602272474](https://jules.google.com/task/14399681989602272474) started by @LokiMetaSmith*