### PR TITLE
Fix python3.12-dev package name on Ubuntu 24.04 and mtac_pipeline import issue

### DIFF
--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -39,7 +39,6 @@
       - curl
       - python3-full
       - python3-dev
-      - python3.12-dev
       - build-essential
       - portaudio19-dev
       - python3-pip

--- a/pipecatapp/tools/mtac_tool.py
+++ b/pipecatapp/tools/mtac_tool.py
@@ -3,7 +3,7 @@ import json
 import asyncio
 
 # Dynamically import the pipeline orchestrator to prevent circular imports if it gets complex later
-from mtac_pipeline import MTACPipelineOrchestrator
+from pipecatapp.mtac_pipeline import MTACPipelineOrchestrator
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixed the `bootstrap.sh` script failure caused by an Ansible task attempting to install `python3.12-dev` on Ubuntu 24.04. Since Ubuntu 24.04 provides the Python 3.12 headers via the generic `python3-dev` package (which is already in the install list), attempting to install the explicitly versioned package was causing a package resolution failure.

Additionally, corrected an import in `pipecatapp/tools/mtac_tool.py` that was missing the `pipecatapp.` prefix. This was discovered when running the `agent_preflight.sh` tests, as it resulted in a `ModuleNotFoundError` during `pytest` collection.

---
*PR created automatically by Jules for task [3215438835922100751](https://jules.google.com/task/3215438835922100751) started by @LokiMetaSmith*