### PR TITLE
Fix Nomad CA/CLI certificate extensions for Python 3.13 compatibility

### DIFF
--- a/ansible/roles/nomad/tasks/tls.yaml
+++ b/ansible/roles/nomad/tasks/tls.yaml
@@ -23,9 +23,28 @@
   delegate_to: localhost
   run_once: true
 
+- name: Generate OpenSSL config for Nomad CA
+  become: false
+  ansible.builtin.copy:
+    dest: "{{ nomad_temp_cert_dir }}/ca.cnf"
+    content: |
+      [req]
+      distinguished_name = req_distinguished_name
+      x509_extensions = v3_ca
+      prompt = no
+      [req_distinguished_name]
+      CN = Nomad CA
+      [v3_ca]
+      keyUsage = critical, keyCertSign, cRLSign
+      basicConstraints = critical, CA:TRUE
+      subjectKeyIdentifier = hash
+      authorityKeyIdentifier = keyid:always,issuer
+  delegate_to: localhost
+  run_once: true
+
 - name: Generate Nomad CA certificate
   become: false
-  ansible.builtin.command: "openssl req -new -x509 -days 3650 -key {{ nomad_temp_cert_dir }}/ca.key -out {{ nomad_temp_cert_dir }}/ca.pem -subj '/CN=Nomad CA'"
+  ansible.builtin.command: "openssl req -new -x509 -days 3650 -key {{ nomad_temp_cert_dir }}/ca.key -out {{ nomad_temp_cert_dir }}/ca.pem -config {{ nomad_temp_cert_dir }}/ca.cnf"
   args:
     creates: "{{ nomad_temp_cert_dir }}/ca.pem"
   delegate_to: localhost
@@ -47,9 +66,22 @@
   delegate_to: localhost
   run_once: true
 
+- name: Generate OpenSSL config for Nomad CLI
+  become: false
+  ansible.builtin.copy:
+    dest: "{{ nomad_temp_cert_dir }}/cli.cnf"
+    content: |
+      [v3_cli]
+      keyUsage = critical, digitalSignature, keyEncipherment
+      extendedKeyUsage = clientAuth
+      subjectKeyIdentifier = hash
+      authorityKeyIdentifier = keyid,issuer
+  delegate_to: localhost
+  run_once: true
+
 - name: Sign CLI certificates for Nomad nodes
   become: false
-  ansible.builtin.command: "openssl x509 -req -in {{ nomad_temp_cert_dir }}/cli.csr -CA {{ nomad_temp_cert_dir }}/ca.pem -CAkey {{ nomad_temp_cert_dir }}/ca.key -CAcreateserial -out {{ nomad_temp_cert_dir }}/cli.pem -days 365"
+  ansible.builtin.command: "openssl x509 -req -in {{ nomad_temp_cert_dir }}/cli.csr -CA {{ nomad_temp_cert_dir }}/ca.pem -CAkey {{ nomad_temp_cert_dir }}/ca.key -CAcreateserial -out {{ nomad_temp_cert_dir }}/cli.pem -days 365 -extfile {{ nomad_temp_cert_dir }}/cli.cnf -extensions v3_cli"
   args:
     creates: "{{ nomad_temp_cert_dir }}/cli.pem"
   delegate_to: localhost


### PR DESCRIPTION
Fixes SSL verification failures in the Nomad API by ensuring CA and CLI certificates are generated with mandatory X509v3 extensions. This prevents 'CERTIFICATE_VERIFY_FAILED: CA cert does not include key usage extension' errors during cluster bootstrap on systems using modern Python versions.

---
*PR created automatically by Jules for task [8193222446044720226](https://jules.google.com/task/8193222446044720226) started by @LokiMetaSmith*