### PR TITLE
Fix Nomad TLS certificate verification and handler consistency

### DIFF
--- a/ansible/roles/nomad/handlers/restart_nomad_handler_tasks.yaml
+++ b/ansible/roles/nomad/handlers/restart_nomad_handler_tasks.yaml
@@ -19,7 +19,7 @@
 
 - name: Wait for Nomad API to be ready after restart
   ansible.builtin.uri:
-    url: "{{ 'https' if nomad_cli_cert_stat_handler.stat.exists else 'http' }}://{{ advertise_ip }}:4646/v1/agent/self"
+    url: "{{ 'https' if nomad_cli_cert_stat_handler.stat.exists else 'http' }}://{{ cluster_ip }}:{{ nomad_http_port }}/v1/agent/self"
     validate_certs: "{{ 'yes' if nomad_cli_cert_stat_handler.stat.exists else 'no' }}"
     ca_path: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat_handler.stat.exists else omit }}"
     client_cert: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.cert.pem') if nomad_cli_cert_stat_handler.stat.exists else omit }}"

--- a/ansible/roles/nomad/tasks/tls.yaml
+++ b/ansible/roles/nomad/tasks/tls.yaml
@@ -33,16 +33,18 @@
 - name: Force regeneration of certificates if CA is invalid or missing extensions
   become: false
   ansible.builtin.file:
-    path: "{{ nomad_temp_cert_dir }}/{{ item }}"
+    path: "{{ nomad_temp_cert_dir }}"
     state: absent
-  loop:
-    - ca.pem
-    - ca.key
-    - cli.pem
-    - cli.key
-    - cli.csr
-    - cli.cnf
-    - ca.cnf
+  when: ca_cert_validity is defined and ca_cert_validity.rc != 0
+  delegate_to: localhost
+  run_once: true
+
+- name: Ensure local certs directory exists after force purge
+  become: false
+  ansible.builtin.file:
+    path: "{{ nomad_temp_cert_dir }}"
+    state: directory
+    mode: '0755'
   when: ca_cert_validity is defined and ca_cert_validity.rc != 0
   delegate_to: localhost
   run_once: true


### PR DESCRIPTION
Resolved the `CERTIFICATE_VERIFY_FAILED` error during Nomad deployment. 

The issue was caused by two factors:
1. Existing leaf certificates were not regenerated when the CA certificate was updated to include required extensions for Python 3.13/TLS 1.3, leading to a chain of trust failure.
2. The Nomad restart handler used inconsistent variables (`advertise_ip` and hardcoded port 4646) for readiness checks.

Changes:
- Modified `ansible/roles/nomad/tasks/tls.yaml` to delete the entire temporary certificate directory if the CA certificate is found to be invalid or missing extensions. This ensures all signed certificates are recreated together.
- Updated `ansible/roles/nomad/handlers/restart_nomad_handler_tasks.yaml` to use `cluster_ip` and `nomad_http_port` for the API readiness check, matching the main deployment tasks.

Verified the fix by running the Nomad deployment and confirming successful SSL-verified connectivity to the Nomad API.

---
*PR created automatically by Jules for task [16343005349177897857](https://jules.google.com/task/16343005349177897857) started by @LokiMetaSmith*