### PR TITLE
Implement unit tests for LangGraphNode and update TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -160,7 +160,7 @@ These structural suggestions are targeted for a future major release to signific
   - [x] Implement `PMMChatMessageHistory` (inheriting from `BaseChatMessageHistory`) that reads/writes to our deterministic `pmm_memory.db` ledger.
   - [x] Implement `PipecatVectorStore` (inheriting from `VectorStore`) wrapping our custom `memory.py` FAISS/SQLite setup.
 - [x] **Phase 4: Build a `LangGraphNode` for the Workflow Engine:**
-  - [ ] Create a custom node for `pipecatapp/workflow/nodes/` that compiles and executes a specialized LangGraph (e.g., a complex agentic research loop) as a single step within our hardware-aware, orchestrator-driven DAG.
+  - [x] Create a custom node for `pipecatapp/workflow/nodes/` that compiles and executes a specialized LangGraph (e.g., a complex agentic research loop) as a single step within our hardware-aware, orchestrator-driven DAG.
 
 - [x] **Implement Graceful LLM Failover:** Enhance the `llama-expert.nomad` job to include a final, lightweight fallback model.
 - [x] **Re-evaluate Consul Connect Service Mesh:** Added `connect { sidecar_service {} }` blocks to redis.nomad and postgres.nomad jobs to enable Consul Connect sidecar for service mesh. Created feature documentation in job files. Full testing requires a feature branch with proper ACL tokens.

--- a/tests/unit/test_langchain_nodes.py
+++ b/tests/unit/test_langchain_nodes.py
@@ -1,0 +1,85 @@
+import pytest
+import sys
+from unittest.mock import MagicMock, AsyncMock
+
+# Mock langchain dependencies
+sys.modules["langchain_core"] = MagicMock()
+sys.modules["langchain_core.runnables"] = MagicMock()
+
+from pipecatapp.workflow.nodes.langchain_nodes import LangGraphNode
+from pipecatapp.workflow.context import WorkflowContext
+
+@pytest.fixture
+def mock_context():
+    context = MagicMock(spec=WorkflowContext)
+    context.global_inputs = {}
+    context.runner_id = "test_runner"
+    return context
+
+@pytest.mark.asyncio
+async def test_langgraph_node_execute_no_graph(mock_context):
+    node = LangGraphNode({"id": "test_langgraph"})
+
+    # Mock set_output
+    node.set_output = MagicMock()
+
+    await node.execute(mock_context)
+
+    node.set_output.assert_called_once_with(mock_context, "error", "No compiled_langgraph provided in global inputs.")
+
+@pytest.mark.asyncio
+async def test_langgraph_node_execute_ainvoke(mock_context):
+    node = LangGraphNode({"id": "test_langgraph", "inputs": [{"name": "input_var"}]})
+    node.set_output = MagicMock()
+    node.get_input = MagicMock(return_value="test_value")
+
+    # Mock compiled graph with ainvoke
+    mock_graph = MagicMock()
+    mock_graph.ainvoke = AsyncMock(return_value={"messages": [MagicMock(content="async response")]})
+    mock_context.global_inputs["compiled_langgraph"] = mock_graph
+
+    await node.execute(mock_context)
+
+    # Check ainvoke is called
+    mock_graph.ainvoke.assert_called_once()
+    assert not mock_graph.invoke.called
+
+    # Check outputs are set correctly
+    node.set_output.assert_any_call(mock_context, "response", "async response")
+    node.set_output.assert_any_call(mock_context, "full_state", {"messages": [mock_graph.ainvoke.return_value["messages"][0]]})
+
+@pytest.mark.asyncio
+async def test_langgraph_node_execute_invoke_fallback(mock_context):
+    node = LangGraphNode({"id": "test_langgraph"})
+    node.set_output = MagicMock()
+
+    # Mock compiled graph without ainvoke, only invoke
+    mock_graph = MagicMock()
+    del mock_graph.ainvoke
+    mock_graph.invoke = MagicMock(return_value={"messages": [MagicMock(content="sync response")]})
+
+    mock_context.global_inputs["compiled_langgraph"] = mock_graph
+    mock_context.global_inputs["user_text"] = "hello"
+    mock_context.global_inputs["tools_dict"] = {}
+
+    await node.execute(mock_context)
+
+    # Check invoke is called
+    mock_graph.invoke.assert_called_once()
+
+    # Check outputs are set correctly
+    node.set_output.assert_any_call(mock_context, "response", "sync response")
+
+@pytest.mark.asyncio
+async def test_langgraph_node_execute_error(mock_context):
+    node = LangGraphNode({"id": "test_langgraph"})
+    node.set_output = MagicMock()
+
+    mock_graph = MagicMock()
+    mock_graph.ainvoke = AsyncMock(side_effect=Exception("Test Error"))
+    mock_context.global_inputs["compiled_langgraph"] = mock_graph
+
+    await node.execute(mock_context)
+
+    # Check error is handled and output is set
+    node.set_output.assert_any_call(mock_context, "error", "LangGraph execution failed: Test Error")


### PR DESCRIPTION
Implemented comprehensive unit tests for `LangGraphNode` in `tests/unit/test_langchain_nodes.py`. Validated the asynchronous and synchronous invocation modes of a compiled LangGraph, along with fallback and error handling. Marked the corresponding task as completed in `TODO.md`.

---
*PR created automatically by Jules for task [10681002612372900939](https://jules.google.com/task/10681002612372900939) started by @LokiMetaSmith*