### PR TITLE
Integrate Programming Agent Skills from my-skills

### DIFF
--- a/pipecatapp/agent_factory.py
+++ b/pipecatapp/agent_factory.py
@@ -49,6 +49,7 @@ from tools.polyphony_tool import PolyphonyTool
 from tools.skill_builder_tool import SkillBuilderTool
 from tools.dynamic_skill_tool import DynamicSkillTool
 from tools.ast_editor_tool import ASTEditorTool
+from tools.set_operational_mode_tool import SetOperationalModeTool
 
 # Tools that are supported by the Tool Server and can be proxied
 REMOTE_SUPPORTED_TOOLS = [
@@ -135,6 +136,7 @@ def create_tools(config: dict, twin_service=None, runner=None) -> dict:
         "polyphony": PolyphonyTool(),
         "skill_builder": SkillBuilderTool(),
         "ast_editor": ASTEditorTool(root_dir="/opt/pipecatapp"),
+        "set_operational_mode": SetOperationalModeTool(),
     }
 
     # Inject memory client into SwarmTool if available (for Map-Reduce)

--- a/pipecatapp/tests/test_new_skills.py
+++ b/pipecatapp/tests/test_new_skills.py
@@ -1,0 +1,70 @@
+import pytest
+import sys
+import os
+from unittest.mock import MagicMock
+
+# Mock heavy dependencies
+sys.modules['extism'] = MagicMock()
+sys.modules['torch'] = MagicMock()
+sys.modules['fitz'] = MagicMock()
+sys.modules['cv2'] = MagicMock()
+sys.modules['numpy'] = MagicMock()
+sys.modules['PIL'] = MagicMock()
+sys.modules['paramiko'] = MagicMock()
+sys.modules['llm_sandbox'] = MagicMock()
+sys.modules['playwright'] = MagicMock()
+sys.modules['playwright.async_api'] = MagicMock()
+sys.modules['sentence_transformers'] = MagicMock()
+sys.modules['langchain_community'] = MagicMock()
+sys.modules['langchain'] = MagicMock()
+sys.modules['langchain_openai'] = MagicMock()
+sys.modules['langchain_core'] = MagicMock()
+sys.modules['faiss'] = MagicMock()
+sys.modules['chromadb'] = MagicMock()
+sys.modules['git'] = MagicMock()
+sys.modules['docker'] = MagicMock()
+sys.modules['atproto'] = MagicMock()
+
+from pipecatapp.skill_library import SkillLibrary
+from pipecatapp.tools.set_operational_mode_tool import SetOperationalModeTool
+from pipecatapp.tools.project_mapper_tool import ProjectMapperTool
+
+@pytest.fixture
+def skill_lib(tmp_path):
+    db_path = tmp_path / "test_skills.sqlite"
+    lib = SkillLibrary(db_path=str(db_path))
+    return lib
+
+def test_skill_ingestion_and_retrieval(skill_lib):
+    skill_lib.save_skill("test_skill", "test desc", "test content")
+    skill = skill_lib.get_skill("test_skill")
+    assert skill["name"] == "test_skill"
+    assert skill["description"] == "test desc"
+    assert skill["content"] == "test content"
+
+def test_set_operational_mode_tool(skill_lib, tmp_path):
+    db_path = tmp_path / "test_skills.sqlite"
+    skill_lib.save_skill("backpass", "backpass desc", "backpass content")
+
+    tool = SetOperationalModeTool(db_path=str(db_path))
+    result = tool.run("backpass")
+
+    assert "MODE ACTIVATED: backpass" in result
+    assert "backpass content" in result
+
+def test_set_operational_mode_not_found(skill_lib, tmp_path):
+    db_path = tmp_path / "test_skills.sqlite"
+    tool = SetOperationalModeTool(db_path=str(db_path))
+    result = tool.run("nonexistent")
+    assert "Error: Mode 'nonexistent' not found" in result
+
+def test_project_mapper_scan(tmp_path):
+    # Create a dummy file
+    (tmp_path / "dummy.py").write_text("import os\ndef hello(): pass")
+
+    mapper = ProjectMapperTool(root_dir=str(tmp_path))
+    result = mapper.scan(".")
+
+    assert "root" in result
+    assert "map_data" in result
+    assert any(item["path"].endswith("dummy.py") for item in result["map_data"])

--- a/pipecatapp/tools/project_mapper_tool.py
+++ b/pipecatapp/tools/project_mapper_tool.py
@@ -1,132 +1,58 @@
 import os
-import re
-import fnmatch
-import subprocess
-import shutil
-from typing import Optional, List
-from pipecatapp.utils.command_runner import CommandRunner
+import json
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+from pipecatapp.tools.repo_map_impl.pipeline import extract_all
+from pipecatapp.tools.repo_map_impl.config import RepoMapConfig, load_config
+from pipecatapp.tools.repo_map_impl.discover import discover_files
+from pipecatapp.tools.repo_map_impl.render.json_out import render_json
 
 class ProjectMapperTool:
     """
     A tool to scan the codebase and generate a high-level map of the project structure,
-    including file paths and rough dependency inferences.
+    now using the upgraded repo-map implementation for richer metadata and deterministic results.
     """
     def __init__(self, root_dir: str = "/app"):
-        self.root_dir = root_dir
-        self.ignore_patterns = [
-            ".git", "__pycache__", "node_modules", "venv", ".idea", ".vscode",
-            "dist", "build", "*.egg-info", "htmlcov", ".coverage", ".pytest_cache"
-        ]
+        self.root_dir = os.path.realpath(root_dir)
 
-    def _is_ignored(self, path: str) -> bool:
-        for pattern in self.ignore_patterns:
-            if fnmatch.fnmatch(os.path.basename(path), pattern):
-                return True
-        return False
-
-    def scan(self, sub_path: str = ".") -> dict:
+    def scan(self, sub_path: str = ".") -> Dict[str, Any]:
         """
         Scans the codebase starting from root_dir/sub_path.
-        Returns a dictionary representing the file structure and imports.
+        Returns a dictionary representing the file structure and intelligence catalog.
         """
-        # Resolve absolute paths to prevent traversal
-        root_abs = os.path.realpath(self.root_dir)
-        start_dir = os.path.realpath(os.path.join(root_abs, sub_path))
+        target_dir = os.path.realpath(os.path.join(self.root_dir, sub_path))
 
         # Security check: Ensure we don't break out of the allowed root
         try:
-            common = os.path.commonpath([root_abs, start_dir])
+            common = os.path.commonpath([self.root_dir, target_dir])
         except ValueError:
-            # Can happen on Windows if paths are on different drives
             common = ""
 
-        if common != root_abs:
+        if common != self.root_dir:
             raise ValueError(f"Access denied: {sub_path} is outside the allowed root {self.root_dir}")
 
-        project_map = {
-            "root": start_dir,
-            "files": [],
-            "structure": {}
-        }
-
-        # Optimization: Use git ls-files if available to avoid slow os.walk
-        git_files = self._list_files_git(start_dir)
-        if git_files is not None:
-            for rel_path in git_files:
-                full_path = os.path.join(start_dir, rel_path)
-                # Still check ignores in case git tracks files we want to skip
-                if self._is_ignored(full_path):
-                    continue
-
-                file_info = {
-                    "path": rel_path,
-                    "type": self._guess_type(rel_path),
-                    "imports": self._extract_imports(full_path)
-                }
-                project_map["files"].append(file_info)
-            return project_map
-
-        # Fallback to os.walk
-        for root, dirs, files in os.walk(start_dir):
-            # Modify dirs in-place to skip ignored directories
-            dirs[:] = [d for d in dirs if not self._is_ignored(os.path.join(root, d))]
-
-            for file in files:
-                if self._is_ignored(file):
-                    continue
-
-                full_path = os.path.join(root, file)
-                rel_path = os.path.relpath(full_path, start_dir)
-
-                file_info = {
-                    "path": rel_path,
-                    "type": self._guess_type(file),
-                    "imports": self._extract_imports(full_path)
-                }
-                project_map["files"].append(file_info)
-
-        return project_map
-
-    def _list_files_git(self, start_dir: str) -> Optional[List[str]]:
-        """Lists files using git ls-files if possible. Returns None if not a git repo."""
-        if not shutil.which("git"):
-            return None
+        target_path = Path(target_dir)
 
         try:
-            # Check if inside git repo
-            CommandRunner.run(["git", "rev-parse", "--is-inside-work-tree"],
-                           cwd=start_dir, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            config = load_config(target_path)
+            # Override with defaults if needed
+            paths = discover_files(target_path, extra_exclude_globs=config.exclude_globs)
+            files = extract_all(target_path, paths, enrich_python_files=True)
 
-            # git ls-files returns paths relative to cwd
-            res = CommandRunner.run(["git", "ls-files"], cwd=start_dir, check=True, capture_output=True, text=True)
-            files = res.stdout.splitlines()
-            return files
-        except Exception:
-            return None
+            json_str = render_json(files)
+            json_data = json.loads(json_str)
 
-    def _guess_type(self, filename: str) -> str:
-        if filename.endswith(".py"): return "python"
-        if filename.endswith(".js") or filename.endswith(".ts"): return "javascript"
-        if filename.endswith(".yaml") or filename.endswith(".yml"): return "yaml"
-        if filename.endswith(".md"): return "markdown"
-        return "unknown"
+            return {
+                "root": target_dir,
+                "map_data": json_data
+            }
+        except Exception as e:
+            return {
+                "root": target_dir,
+                "error": f"Failed to generate repo map: {str(e)}"
+            }
 
-    def _extract_imports(self, filepath: str) -> list:
-        imports = []
-        try:
-            with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
-                content = f.read()
-
-            if filepath.endswith(".py"):
-                # Simple regex for python imports
-                imports.extend(re.findall(r'^import\s+(\w+)', content, re.MULTILINE))
-                imports.extend(re.findall(r'^from\s+(\w+)', content, re.MULTILINE))
-            elif filepath.endswith(".js") or filepath.endswith(".ts"):
-                # Simple regex for JS imports
-                imports.extend(re.findall(r'import\s+.*\s+from\s+[\'"](.+)[\'"]', content))
-                imports.extend(re.findall(r'require\s*\(\s*[\'"](.+)[\'"]\s*\)', content))
-
-        except Exception:
-            pass # Ignore read errors
-
-        return list(set(imports))
+    def run(self, sub_path: str = ".") -> Dict[str, Any]:
+        """Standard tool execution method."""
+        return self.scan(sub_path)

--- a/pipecatapp/tools/repo_map_impl/__init__.py
+++ b/pipecatapp/tools/repo_map_impl/__init__.py
@@ -1,0 +1,2 @@
+"""repo-map: fast deterministic repository maps for agent comprehension."""
+__version__ = "0.1.0"

--- a/pipecatapp/tools/repo_map_impl/cache.py
+++ b/pipecatapp/tools/repo_map_impl/cache.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class TagCache:
+    def __init__(self, cache_dir: Path):
+        self.cache_dir = cache_dir
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _key_path(self, file_path: Path) -> Path:
+        safe = str(file_path).replace("/", "_").replace(":", "_")
+        return self.cache_dir / f"{safe}.json"
+
+    def get(self, file_path: Path) -> dict | None:
+        path = self._key_path(file_path)
+        if not path.is_file():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        try:
+            mtime = file_path.stat().st_mtime
+        except OSError:
+            return None
+        if data.get("mtime") != mtime:
+            return None
+        return data.get("payload")
+
+    def set(self, file_path: Path, payload: dict) -> None:
+        try:
+            mtime = file_path.stat().st_mtime
+        except OSError:
+            return
+        path = self._key_path(file_path)
+        path.write_text(
+            json.dumps({"mtime": mtime, "payload": payload}, ensure_ascii=False),
+            encoding="utf-8",
+        )

--- a/pipecatapp/tools/repo_map_impl/cli.py
+++ b/pipecatapp/tools/repo_map_impl/cli.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from pipecatapp.tools.repo_map_impl import __version__
+from pipecatapp.tools.repo_map_impl.config import load_config
+from pipecatapp.tools.repo_map_impl.pipeline import generate_budget_map, generate_full_map
+from pipecatapp.tools.repo_map_impl.render.json_out import render_json
+from pipecatapp.tools.repo_map_impl.discover import discover_files
+from pipecatapp.tools.repo_map_impl.pipeline import extract_all
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="repo-map",
+        description="Generate fast deterministic repository maps for AI agents (L0 comprehension).",
+    )
+    parser.add_argument(
+        "target",
+        nargs="?",
+        default=".",
+        help="Repository root to analyze (default: current directory)",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Generate full map (tree + catalog sections)",
+    )
+    parser.add_argument(
+        "--budget",
+        type=int,
+        metavar="N",
+        help="Generate token-budget-focused map (approximate tokens)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        help="Output file path (default: <target>/.repo-map.md for --full)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON symbol index instead of markdown",
+    )
+    parser.add_argument(
+        "--enrich-python",
+        action="store_true",
+        help="Use Python AST for richer imports/docstrings on .py files",
+    )
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        default=None,
+        help="Cap number of source files processed",
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable .repo-map-cache tag cache",
+    )
+    parser.add_argument(
+        "--focus",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Boost ranking for file paths (repeatable, used with --budget)",
+    )
+    parser.add_argument(
+        "--tree-detail",
+        action="store_true",
+        help="Include per-file symbols in the tree section even for large repos",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+
+    args = parser.parse_args(argv)
+    target = Path(args.target).resolve()
+
+    if not target.is_dir():
+        print(f"Error: not a directory: {target}", file=sys.stderr)
+        return 1
+
+    if not args.full and args.budget is None and not args.json:
+        args.full = True
+
+    config = load_config(target)
+
+    if args.json:
+        paths = discover_files(
+            target, max_files=args.max_files, extra_exclude_globs=config.exclude_globs
+        )
+        files = extract_all(
+            target,
+            paths,
+            use_cache=not args.no_cache,
+            enrich_python_files=args.enrich_python,
+        )
+        content = render_json(files)
+    elif args.budget is not None:
+        content = generate_budget_map(
+            target,
+            args.budget,
+            focus_files=args.focus or None,
+            max_files=args.max_files,
+            enrich_python_files=args.enrich_python,
+        )
+    else:
+        content = generate_full_map(
+            target,
+            max_files=args.max_files,
+            enrich_python_files=args.enrich_python,
+            config=config,
+            tree_detail=args.tree_detail,
+        )
+
+    if args.output:
+        out_path = Path(args.output)
+        if not out_path.is_absolute():
+            out_path = target / out_path
+    elif args.budget is not None and not args.json:
+        out_path = None
+    elif args.json:
+        out_path = target / ".repo-map.json"
+    else:
+        out_path = target / ".repo-map.md"
+
+    if out_path is None:
+        sys.stdout.write(content)
+        if not content.endswith("\n"):
+            sys.stdout.write("\n")
+    else:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(content, encoding="utf-8")
+        print(f"Wrote {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipecatapp/tools/repo_map_impl/config.py
+++ b/pipecatapp/tools/repo_map_impl/config.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class RepoMapConfig:
+    exclude_globs: list[str] = field(default_factory=list)
+    categories: dict[str, list[str]] = field(default_factory=dict)
+    compact_tree_threshold: int | None = None
+
+
+def load_config(root: Path) -> RepoMapConfig:
+    for name in ("repo-map.yaml", "repo-map.yml"):
+        path = root / name
+        if not path.is_file():
+            continue
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError):
+            return RepoMapConfig()
+        threshold = data.get("compact_tree_threshold")
+        return RepoMapConfig(
+            exclude_globs=list(data.get("exclude_globs") or []),
+            categories=dict(data.get("categories") or {}),
+            compact_tree_threshold=int(threshold) if threshold is not None else None,
+        )
+    return RepoMapConfig()

--- a/pipecatapp/tools/repo_map_impl/discover.py
+++ b/pipecatapp/tools/repo_map_impl/discover.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pathspec
+
+from pipecatapp.tools.repo_map_impl.languages import SOURCE_GLOBS, lang_for_path, supported_extensions
+
+DEFAULT_DIR_EXCLUDES = {
+    ".git", ".hg", ".svn", "node_modules", "vendor", "dist", "build", "out",
+    "target", ".venv", "venv", "__pycache__", ".pytest_cache", ".mypy_cache",
+    ".repo-map-cache", ".tox", "eggs", ".eggs",
+}
+
+
+def _load_gitignore_spec(root: Path) -> pathspec.PathSpec | None:
+    gi = root / ".gitignore"
+    if not gi.is_file():
+        return None
+    try:
+        lines = gi.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+    return pathspec.PathSpec.from_lines("gitwildmatch", lines)
+
+
+def _is_ignored(rel: str, spec: pathspec.PathSpec | None) -> bool:
+    parts = Path(rel).parts
+    if parts and parts[0] in DEFAULT_DIR_EXCLUDES:
+        return True
+    for part in parts:
+        if part in DEFAULT_DIR_EXCLUDES:
+            return True
+    if spec and spec.match_file(rel):
+        return True
+    return False
+
+
+def discover_files(
+    root: Path,
+    *,
+    max_files: int | None = None,
+    extra_exclude_globs: list[str] | None = None,
+) -> list[Path]:
+    root = root.resolve()
+    spec = _load_gitignore_spec(root)
+    if extra_exclude_globs:
+        extra = pathspec.PathSpec.from_lines("gitwildmatch", extra_exclude_globs)
+        combined = list(spec.patterns if spec else []) + list(extra.patterns)
+        spec = pathspec.PathSpec.from_lines("gitwildmatch", combined)
+
+    files: list[Path] = []
+    exts = supported_extensions()
+
+    if (root / ".git").is_dir():
+        try:
+            result = subprocess.run(
+                ["git", "ls-files", "-z", "--", *SOURCE_GLOBS],
+                cwd=root,
+                capture_output=True,
+                check=True,
+            )
+            for raw in result.stdout.split(b"\0"):
+                if not raw:
+                    continue
+                rel = raw.decode("utf-8", errors="replace")
+                if _is_ignored(rel, spec):
+                    continue
+                p = root / rel
+                if p.is_file() and p.suffix.lower() in exts:
+                    files.append(p)
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            files = []
+
+    if not files:
+        for path in root.rglob("*"):
+            if not path.is_file() or path.suffix.lower() not in exts:
+                continue
+            try:
+                rel = str(path.relative_to(root))
+            except ValueError:
+                continue
+            if _is_ignored(rel, spec):
+                continue
+            if lang_for_path(path) is None:
+                continue
+            files.append(path)
+
+    files.sort()
+    if max_files is not None and len(files) > max_files:
+        files = files[:max_files]
+    return files

--- a/pipecatapp/tools/repo_map_impl/extract/python_ast.py
+++ b/pipecatapp/tools/repo_map_impl/extract/python_ast.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from pipecatapp.tools.repo_map_impl.model import ClassInfo, FileSymbols, FunctionInfo, ImportInfo, MethodInfo
+
+
+def _get_name(node: ast.expr) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_get_name(node.value)}.{node.attr}"
+    return str(node)
+
+
+def enrich_python(fs: FileSymbols, file_path: Path) -> FileSymbols:
+    if fs.language != "python" or fs.error:
+        return fs
+    try:
+        content = file_path.read_text(encoding="utf-8")
+        tree = ast.parse(content, filename=str(file_path))
+    except Exception as e:
+        fs.error = str(e)
+        return fs
+
+    fs.docstring = ast.get_docstring(tree) or ""
+    fs.classes = []
+    fs.functions = []
+    fs.imports = []
+    fs.exports = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                fs.imports.append(ImportInfo(module=alias.name, alias=alias.asname))
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                fs.imports.append(
+                    ImportInfo(from_module=module, name=alias.name, alias=alias.asname)
+                )
+
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            methods = []
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef):
+                    methods.append(
+                        MethodInfo(
+                            name=item.name,
+                            params=[a.arg for a in item.args.args],
+                            is_public=not item.name.startswith("_"),
+                        )
+                    )
+            cls = ClassInfo(
+                name=node.name,
+                methods=methods,
+                bases=[_get_name(b) for b in node.bases],
+                docstring=ast.get_docstring(node) or "",
+                is_public=not node.name.startswith("_"),
+            )
+            fs.classes.append(cls)
+            if cls.is_public:
+                fs.exports.append(node.name)
+        elif isinstance(node, ast.FunctionDef):
+            fn = FunctionInfo(
+                name=node.name,
+                params=[a.arg for a in node.args.args],
+                docstring=ast.get_docstring(node) or "",
+                is_public=not node.name.startswith("_"),
+            )
+            fs.functions.append(fn)
+            if fn.is_public:
+                fs.exports.append(node.name)
+
+    return fs

--- a/pipecatapp/tools/repo_map_impl/extract/tree_sitter.py
+++ b/pipecatapp/tools/repo_map_impl/extract/tree_sitter.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Callable
+
+from tree_sitter import Language, Parser, Query, QueryCursor
+
+from pipecatapp.tools.repo_map_impl.languages import lang_for_path
+from pipecatapp.tools.repo_map_impl.model import FileSymbols, Symbol
+
+QUERIES_DIR = Path(__file__).resolve().parent.parent / "queries"
+
+# lang_id -> (module_name, language_factory_attr)
+GRAMMAR_SPECS: dict[str, tuple[str, str]] = {
+    "python": ("tree_sitter_python", "language"),
+    "go": ("tree_sitter_go", "language"),
+    "rust": ("tree_sitter_rust", "language"),
+    "javascript": ("tree_sitter_javascript", "language"),
+    "typescript": ("tree_sitter_typescript", "language_typescript"),
+    "tsx": ("tree_sitter_typescript", "language_tsx"),
+    "swift": ("tree_sitter_swift", "language"),
+}
+
+_parser_cache: dict[str, Parser] = {}
+_language_cache: dict[str, Language] = {}
+
+
+def _load_language(lang: str) -> Language | None:
+    if lang in _language_cache:
+        return _language_cache[lang]
+    spec = GRAMMAR_SPECS.get(lang)
+    if not spec:
+        return None
+    mod_name, attr = spec
+    try:
+        mod = importlib.import_module(mod_name)
+        factory: Callable = getattr(mod, attr)
+        language = Language(factory())
+        _language_cache[lang] = language
+        return language
+    except Exception:
+        return None
+
+
+def _get_parser(lang: str) -> Parser | None:
+    if lang in _parser_cache:
+        return _parser_cache[lang]
+    language = _load_language(lang)
+    if not language:
+        return None
+    parser = Parser(language)
+    _parser_cache[lang] = parser
+    return parser
+
+
+def _query_path(lang: str) -> Path | None:
+    path = QUERIES_DIR / f"{lang}-tags.scm"
+    return path if path.is_file() and path.stat().st_size > 20 else None
+
+
+def _kind_from_capture(capture: str) -> tuple[str, str]:
+    if capture.startswith("name."):
+        capture = capture[5:]
+    if ".definition." in capture or capture.startswith("definition."):
+        role = "definition"
+        if "definition." in capture:
+            kind = capture.split("definition.", 1)[-1].split(".")[0]
+        else:
+            kind = capture.split(".")[-1]
+        return role, kind
+    if ".reference." in capture or capture.startswith("reference."):
+        return "reference", capture.split(".")[-1]
+    if "definition" in capture:
+        return "definition", capture.split(".")[-1]
+    if "reference" in capture:
+        return "reference", capture.split(".")[-1]
+    return "definition", "symbol"
+
+
+def extract_tags(file_path: Path, repo_root: Path) -> FileSymbols:
+    lang = lang_for_path(file_path)
+    rel = str(file_path.relative_to(repo_root))
+    if not lang:
+        return FileSymbols(path=rel, language="unknown")
+
+    query_path = _query_path(lang)
+    if not query_path:
+        return FileSymbols(path=rel, language=lang, error=f"no tags query for {lang}")
+
+    parser = _get_parser(lang)
+    language = _load_language(lang)
+    if not parser or not language:
+        return FileSymbols(path=rel, language=lang, error=f"grammar not installed for {lang}")
+
+    try:
+        code = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return FileSymbols(path=rel, language=lang, error=str(e))
+
+    try:
+        query = Query(language, query_path.read_text(encoding="utf-8"))
+        tree = parser.parse(code.encode("utf-8"))
+        root = tree.root_node
+        captures = QueryCursor(query).captures(root)
+    except Exception as e:
+        return FileSymbols(path=rel, language=lang, error=str(e))
+
+    symbols: list[Symbol] = []
+    for capture_name, nodes in captures.items():
+        if "name" not in capture_name:
+            continue
+        role, kind = _kind_from_capture(capture_name)
+        for node in nodes:
+            name = code.encode("utf-8")[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+            line = node.start_point[0] + 1
+            symbols.append(Symbol(name=name, kind=kind, line=line, role=role))
+
+    seen: set[tuple[str, int, str]] = set()
+    unique: list[Symbol] = []
+    for s in symbols:
+        key = (s.name, s.line, s.role)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(s)
+
+    fs = FileSymbols(path=rel, language=lang, symbols=unique)
+    fs.exports = sorted({s.name for s in unique if s.role == "definition" and not s.name.startswith("_")})
+    return fs
+
+
+def file_symbols_to_cache_payload(fs: FileSymbols) -> dict:
+    return {
+        "path": fs.path,
+        "language": fs.language,
+        "symbols": [
+            {"name": s.name, "kind": s.kind, "line": s.line, "role": s.role} for s in fs.symbols
+        ],
+        "exports": fs.exports,
+        "error": fs.error,
+    }
+
+
+def file_symbols_from_cache(payload: dict) -> FileSymbols:
+    fs = FileSymbols(
+        path=payload["path"],
+        language=payload.get("language", "unknown"),
+        exports=list(payload.get("exports") or []),
+        error=payload.get("error"),
+    )
+    for s in payload.get("symbols") or []:
+        fs.symbols.append(
+            Symbol(
+                name=s["name"],
+                kind=s.get("kind", "symbol"),
+                line=int(s.get("line", 0)),
+                role=s.get("role", "definition"),
+            )
+        )
+    return fs

--- a/pipecatapp/tools/repo_map_impl/languages.py
+++ b/pipecatapp/tools/repo_map_impl/languages.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+EXTENSION_TO_LANG: dict[str, str] = {
+    ".py": "python",
+    ".pyw": "python",
+    ".go": "go",
+    ".rs": "rust",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".swift": "swift",
+}
+
+SOURCE_GLOBS = tuple(f"*{ext}" for ext in EXTENSION_TO_LANG)
+
+
+def lang_for_path(path: Path) -> str | None:
+    return EXTENSION_TO_LANG.get(path.suffix.lower())
+
+
+def supported_extensions() -> frozenset[str]:
+    return frozenset(EXTENSION_TO_LANG)

--- a/pipecatapp/tools/repo_map_impl/model.py
+++ b/pipecatapp/tools/repo_map_impl/model.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Symbol:
+    name: str
+    kind: str
+    line: int
+    role: str = "definition"
+
+
+@dataclass
+class MethodInfo:
+    name: str
+    params: list[str] = field(default_factory=list)
+    is_public: bool = True
+
+
+@dataclass
+class ClassInfo:
+    name: str
+    methods: list[MethodInfo] = field(default_factory=list)
+    bases: list[str] = field(default_factory=list)
+    docstring: str = ""
+    is_public: bool = True
+
+
+@dataclass
+class FunctionInfo:
+    name: str
+    params: list[str] = field(default_factory=list)
+    docstring: str = ""
+    is_public: bool = True
+
+
+@dataclass
+class ImportInfo:
+    module: str = ""
+    name: str = ""
+    from_module: str = ""
+    alias: str | None = None
+
+
+@dataclass
+class FileSymbols:
+    path: str
+    language: str
+    symbols: list[Symbol] = field(default_factory=list)
+    classes: list[ClassInfo] = field(default_factory=list)
+    functions: list[FunctionInfo] = field(default_factory=list)
+    exports: list[str] = field(default_factory=list)
+    imports: list[ImportInfo] = field(default_factory=list)
+    docstring: str = ""
+    error: str | None = None
+
+    def tree_classes(self) -> list[str]:
+        if self.classes:
+            out = []
+            for cls in self.classes:
+                pub = [m.name for m in cls.methods if m.is_public][:3]
+                if pub:
+                    more = len([m for m in cls.methods if m.is_public]) > 3
+                    out.append(f"{cls.name} ({', '.join(pub)}{'...' if more else ''})")
+                else:
+                    out.append(cls.name)
+            return out
+        return [s.name for s in self.symbols if s.role == "definition" and "class" in s.kind]
+
+    def tree_functions(self) -> list[str]:
+        if self.functions:
+            return [f.name for f in self.functions if f.is_public]
+        funcs = []
+        for s in self.symbols:
+            if s.role != "definition":
+                continue
+            kind = s.kind
+            if kind in ("call", "reference"):
+                continue
+            if "function" in kind or "method" in kind:
+                if "class" not in kind:
+                    funcs.append(s.name)
+        return funcs

--- a/pipecatapp/tools/repo_map_impl/pipeline.py
+++ b/pipecatapp/tools/repo_map_impl/pipeline.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pipecatapp.tools.repo_map_impl.cache import TagCache
+from pipecatapp.tools.repo_map_impl.config import RepoMapConfig, load_config
+from pipecatapp.tools.repo_map_impl.discover import discover_files
+from pipecatapp.tools.repo_map_impl.extract.python_ast import enrich_python
+from pipecatapp.tools.repo_map_impl.extract.tree_sitter import (
+    extract_tags,
+    file_symbols_from_cache,
+    file_symbols_to_cache_payload,
+)
+from pipecatapp.tools.repo_map_impl.model import FileSymbols
+from pipecatapp.tools.repo_map_impl.rank import format_file_brief, select_budget_map
+from pipecatapp.tools.repo_map_impl.render.catalog import render_catalog_section
+from pipecatapp.tools.repo_map_impl.render.file_index import render_file_index
+from pipecatapp.tools.repo_map_impl.render.json_out import render_json
+from pipecatapp.tools.repo_map_impl.render.navigation import (
+    compact_tree_threshold,
+    compute_section_lines,
+    render_agent_guide,
+)
+from pipecatapp.tools.repo_map_impl.render.tree import render_aider_section
+
+
+def _cache_dir(root: Path) -> Path:
+    return root / ".repo-map-cache"
+
+
+def extract_all(
+    root: Path,
+    file_paths: list[Path],
+    *,
+    use_cache: bool = True,
+    enrich_python_files: bool = False,
+) -> list[FileSymbols]:
+    cache = TagCache(_cache_dir(root)) if use_cache else None
+    results: list[FileSymbols] = []
+
+    for path in file_paths:
+        cached = None
+        if cache:
+            cached = cache.get(path)
+        if cached:
+            fs = file_symbols_from_cache(cached)
+        else:
+            fs = extract_tags(path, root)
+            if cache and not fs.error:
+                cache.set(path, file_symbols_to_cache_payload(fs))
+
+        if enrich_python_files and fs.language == "python":
+            fs = enrich_python(fs, path)
+
+        results.append(fs)
+
+    return results
+
+
+def generate_full_map(
+    root: Path,
+    *,
+    max_files: int | None = None,
+    enrich_python_files: bool = False,
+    config: RepoMapConfig | None = None,
+    tree_detail: bool = False,
+) -> str:
+    root = root.resolve()
+    config = config or load_config(root)
+    paths = discover_files(root, max_files=max_files, extra_exclude_globs=config.exclude_globs)
+    files = extract_all(root, paths, enrich_python_files=enrich_python_files)
+
+    threshold = compact_tree_threshold(config)
+    use_compact_tree = len(files) > threshold and not tree_detail
+
+    file_index = render_file_index(files, config)
+    catalog = render_catalog_section(
+        files,
+        config,
+        include_file_index=True,
+        file_index_text=file_index,
+    )
+    tree = render_aider_section(root.name, files, compact=use_compact_tree)
+
+    # Catalog before tree: agents grep symbol detail first; tree is layout appendix.
+    body = "\n\n".join([catalog, tree])
+    total_lines = body.count("\n") + 1
+
+    section_lines = compute_section_lines(
+        body,
+        {
+            "Code intelligence catalog": "<!-- repo-map:section=catalog -->",
+            "Directory tree": "<!-- repo-map:section=tree -->",
+        },
+    )
+
+    guide_stub = render_agent_guide(
+        root.name,
+        files,
+        section_lines={},
+        compact_tree=use_compact_tree,
+        total_lines=total_lines,
+    )
+    # First line of `body` in the full document (1-based).
+    body_start_line = len(guide_stub.splitlines()) + 2
+    adjusted = {
+        name: (start + body_start_line - 1, end + body_start_line - 1)
+        for name, (start, end) in section_lines.items()
+    }
+    full_line_count = body_start_line - 1 + total_lines
+    guide = render_agent_guide(
+        root.name,
+        files,
+        section_lines=adjusted,
+        compact_tree=use_compact_tree,
+        total_lines=full_line_count,
+    )
+
+    return guide + "\n\n" + body
+
+
+def generate_budget_map(
+    root: Path,
+    budget: int,
+    *,
+    focus_files: list[str] | None = None,
+    max_files: int | None = None,
+    enrich_python_files: bool = False,
+    config: RepoMapConfig | None = None,
+) -> str:
+    root = root.resolve()
+    config = config or load_config(root)
+    paths = discover_files(root, max_files=max_files, extra_exclude_globs=config.exclude_globs)
+    files = extract_all(root, paths, enrich_python_files=enrich_python_files)
+
+    header = (
+        "<!-- repo-map-format: 1 (focused) -->\n"
+        "<!-- AGENTS: This is a ranked subset. Use grep on .repo-map.md --full for exhaustive index. -->\n\n"
+    )
+    return header + select_budget_map(
+        files,
+        budget,
+        focus_files=focus_files,
+        format_file=format_file_brief,
+    )

--- a/pipecatapp/tools/repo_map_impl/queries/ATTRIBUTION.md
+++ b/pipecatapp/tools/repo_map_impl/queries/ATTRIBUTION.md
@@ -1,0 +1,5 @@
+# Tag queries
+
+The `*-tags.scm` files in this directory are derived from the
+[Aider](https://github.com/Aider-AI/aider) project (Apache-2.0), under
+`aider/queries/tree-sitter-language-pack/` and `aider/queries/tree-sitter-languages/`.

--- a/pipecatapp/tools/repo_map_impl/queries/go-tags.scm
+++ b/pipecatapp/tools/repo_map_impl/queries/go-tags.scm
@@ -1,0 +1,42 @@
+(
+  (comment)* @doc
+  .
+  (function_declaration
+    name: (identifier) @name.definition.function) @definition.function
+  (#strip! @doc "^//\\s*")
+  (#set-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (method_declaration
+    name: (field_identifier) @name.definition.method) @definition.method
+  (#strip! @doc "^//\\s*")
+  (#set-adjacent! @doc @definition.method)
+)
+
+(call_expression
+  function: [
+    (identifier) @name.reference.call
+    (parenthesized_expression (identifier) @name.reference.call)
+    (selector_expression field: (field_identifier) @name.reference.call)
+    (parenthesized_expression (selector_expression field: (field_identifier) @name.reference.call))
+  ]) @reference.call
+
+(type_spec
+  name: (type_identifier) @name.definition.type) @definition.type
+
+(type_identifier) @name.reference.type @reference.type
+
+(package_clause "package" (package_identifier) @name.definition.module)
+
+(type_declaration (type_spec name: (type_identifier) @name.definition.interface type: (interface_type)))
+
+(type_declaration (type_spec name: (type_identifier) @name.definition.class type: (struct_type)))
+
+(import_declaration (import_spec) @name.reference.module)
+
+(var_declaration (var_spec name: (identifier) @name.definition.variable))
+
+(const_declaration (const_spec name: (identifier) @name.definition.constant))

--- a/pipecatapp/tools/repo_map_impl/queries/javascript-tags.scm
+++ b/pipecatapp/tools/repo_map_impl/queries/javascript-tags.scm
@@ -1,0 +1,88 @@
+(
+  (comment)* @doc
+  .
+  (method_definition
+    name: (property_identifier) @name.definition.method) @definition.method
+  (#not-eq? @name.definition.method "constructor")
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.method)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (class
+      name: (_) @name.definition.class)
+    (class_declaration
+      name: (_) @name.definition.class)
+  ] @definition.class
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.class)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (function_expression
+      name: (identifier) @name.definition.function)
+    (function_declaration
+      name: (identifier) @name.definition.function)
+    (generator_function
+      name: (identifier) @name.definition.function)
+    (generator_function_declaration
+      name: (identifier) @name.definition.function)
+  ] @definition.function
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name.definition.function
+      value: [(arrow_function) (function_expression)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (variable_declaration
+    (variable_declarator
+      name: (identifier) @name.definition.function
+      value: [(arrow_function) (function_expression)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(assignment_expression
+  left: [
+    (identifier) @name.definition.function
+    (member_expression
+      property: (property_identifier) @name.definition.function)
+  ]
+  right: [(arrow_function) (function_expression)]
+) @definition.function
+
+(pair
+  key: (property_identifier) @name.definition.function
+  value: [(arrow_function) (function_expression)]) @definition.function
+
+(
+  (call_expression
+    function: (identifier) @name.reference.call) @reference.call
+  (#not-match? @name.reference.call "^(require)$")
+)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @name.reference.call)
+  arguments: (_) @reference.call)
+
+(new_expression
+  constructor: (_) @name.reference.class) @reference.class

--- a/pipecatapp/tools/repo_map_impl/queries/python-tags.scm
+++ b/pipecatapp/tools/repo_map_impl/queries/python-tags.scm
@@ -1,0 +1,14 @@
+(module (expression_statement (assignment left: (identifier) @name.definition.constant) @definition.constant))
+
+(class_definition
+  name: (identifier) @name.definition.class) @definition.class
+
+(function_definition
+  name: (identifier) @name.definition.function) @definition.function
+
+(call
+  function: [
+      (identifier) @name.reference.call
+      (attribute
+        attribute: (identifier) @name.reference.call)
+  ]) @reference.call

--- a/pipecatapp/tools/repo_map_impl/queries/rust-tags.scm
+++ b/pipecatapp/tools/repo_map_impl/queries/rust-tags.scm
@@ -1,0 +1,60 @@
+; ADT definitions
+
+(struct_item
+    name: (type_identifier) @name.definition.class) @definition.class
+
+(enum_item
+    name: (type_identifier) @name.definition.class) @definition.class
+
+(union_item
+    name: (type_identifier) @name.definition.class) @definition.class
+
+; type aliases
+
+(type_item
+    name: (type_identifier) @name.definition.class) @definition.class
+
+; method definitions
+
+(declaration_list
+    (function_item
+        name: (identifier) @name.definition.method) @definition.method)
+
+; function definitions
+
+(function_item
+    name: (identifier) @name.definition.function) @definition.function
+
+; trait definitions
+(trait_item
+    name: (type_identifier) @name.definition.interface) @definition.interface
+
+; module definitions
+(mod_item
+    name: (identifier) @name.definition.module) @definition.module
+
+; macro definitions
+
+(macro_definition
+    name: (identifier) @name.definition.macro) @definition.macro
+
+; references
+
+(call_expression
+    function: (identifier) @name.reference.call) @reference.call
+
+(call_expression
+    function: (field_expression
+        field: (field_identifier) @name.reference.call)) @reference.call
+
+(macro_invocation
+    macro: (identifier) @name.reference.call) @reference.call
+
+; implementations
+
+(impl_item
+    trait: (type_identifier) @name.reference.implementation) @reference.implementation
+
+(impl_item
+    type: (type_identifier) @name.reference.implementation
+    !trait) @reference.implementation

--- a/pipecatapp/tools/repo_map_impl/queries/swift-tags.scm
+++ b/pipecatapp/tools/repo_map_impl/queries/swift-tags.scm
@@ -1,0 +1,51 @@
+(class_declaration
+  name: (type_identifier) @name.definition.class) @definition.class
+
+(protocol_declaration
+  name: (type_identifier) @name.definition.interface) @definition.interface
+
+(class_declaration
+    (class_body
+        [
+            (function_declaration
+                name: (simple_identifier) @name.definition.method
+            )
+            (subscript_declaration
+                (parameter (simple_identifier) @name.definition.method)
+            )
+            (init_declaration "init" @name.definition.method)
+            (deinit_declaration "deinit" @name.definition.method)
+        ]
+    )
+) @definition.method
+
+(protocol_declaration
+    (protocol_body
+        [
+            (protocol_function_declaration
+                name: (simple_identifier) @name.definition.method
+            )
+            (subscript_declaration
+                (parameter (simple_identifier) @name.definition.method)
+            )
+            (init_declaration "init" @name.definition.method)
+        ]
+    )
+) @definition.method
+
+(class_declaration
+    (class_body
+        [
+            (property_declaration
+                (pattern (simple_identifier) @name.definition.property)
+            )
+        ]
+    )
+) @definition.property
+
+(property_declaration
+    (pattern (simple_identifier) @name.definition.property)
+) @definition.property
+
+(function_declaration
+    name: (simple_identifier) @name.definition.function) @definition.function

--- a/pipecatapp/tools/repo_map_impl/queries/tsx-tags.scm
+++ b/pipecatapp/tools/repo_map_impl/queries/tsx-tags.scm
@@ -1,0 +1,88 @@
+(
+  (comment)* @doc
+  .
+  (method_definition
+    name: (property_identifier) @name.definition.method) @definition.method
+  (#not-eq? @name.definition.method "constructor")
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.method)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (class
+      name: (_) @name.definition.class)
+    (class_declaration
+      name: (_) @name.definition.class)
+  ] @definition.class
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.class)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (function_expression
+      name: (identifier) @name.definition.function)
+    (function_declaration
+      name: (identifier) @name.definition.function)
+    (generator_function
+      name: (identifier) @name.definition.function)
+    (generator_function_declaration
+      name: (identifier) @name.definition.function)
+  ] @definition.function
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name.definition.function
+      value: [(arrow_function) (function_expression)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (variable_declaration
+    (variable_declarator
+      name: (identifier) @name.definition.function
+      value: [(arrow_function) (function_expression)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(assignment_expression
+  left: [
+    (identifier) @name.definition.function
+    (member_expression
+      property: (property_identifier) @name.definition.function)
+  ]
+  right: [(arrow_function) (function_expression)]
+) @definition.function
+
+(pair
+  key: (property_identifier) @name.definition.function
+  value: [(arrow_function) (function_expression)]) @definition.function
+
+(
+  (call_expression
+    function: (identifier) @name.reference.call) @reference.call
+  (#not-match? @name.reference.call "^(require)$")
+)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @name.reference.call)
+  arguments: (_) @reference.call)
+
+(new_expression
+  constructor: (_) @name.reference.class) @reference.class

--- a/pipecatapp/tools/repo_map_impl/queries/typescript-tags.scm
+++ b/pipecatapp/tools/repo_map_impl/queries/typescript-tags.scm
@@ -1,0 +1,41 @@
+(function_signature
+  name: (identifier) @name.definition.function) @definition.function
+
+(method_signature
+  name: (property_identifier) @name.definition.method) @definition.method
+
+(abstract_method_signature
+  name: (property_identifier) @name.definition.method) @definition.method
+
+(abstract_class_declaration
+  name: (type_identifier) @name.definition.class) @definition.class
+
+(module
+  name: (identifier) @name.definition.module) @definition.module
+
+(interface_declaration
+  name: (type_identifier) @name.definition.interface) @definition.interface
+
+(type_annotation
+  (type_identifier) @name.reference.type) @reference.type
+
+(new_expression
+  constructor: (identifier) @name.reference.class) @reference.class
+
+(function_declaration
+  name: (identifier) @name.definition.function) @definition.function
+
+(method_definition
+  name: (property_identifier) @name.definition.method) @definition.method
+
+(class_declaration
+  name: (type_identifier) @name.definition.class) @definition.class
+
+(interface_declaration
+  name: (type_identifier) @name.definition.class) @definition.class
+
+(type_alias_declaration
+  name: (type_identifier) @name.definition.type) @definition.type
+
+(enum_declaration
+  name: (identifier) @name.definition.enum) @definition.enum

--- a/pipecatapp/tools/repo_map_impl/rank.py
+++ b/pipecatapp/tools/repo_map_impl/rank.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from pipecatapp.tools.repo_map_impl.model import FileSymbols
+
+
+def estimate_tokens(text: str) -> int:
+    return max(1, len(text) // 4)
+
+
+def build_reference_graph(files: list[FileSymbols]) -> dict[str, set[str]]:
+    """file_path -> set of file_paths it references (by symbol name heuristics)."""
+    defs_by_name: dict[str, set[str]] = defaultdict(set)
+    for fs in files:
+        for s in fs.symbols:
+            if s.role == "definition":
+                defs_by_name[s.name].add(fs.path)
+        for name in fs.exports:
+            defs_by_name[name].add(fs.path)
+
+    graph: dict[str, set[str]] = defaultdict(set)
+    for fs in files:
+        for s in fs.symbols:
+            if s.role != "reference":
+                continue
+            for target in defs_by_name.get(s.name, ()):
+                if target != fs.path:
+                    graph[fs.path].add(target)
+    return graph
+
+
+def pagerank(
+    graph: dict[str, set[str]],
+    *,
+    nodes: list[str],
+    personalization: dict[str, float] | None = None,
+    iterations: int = 20,
+    damping: float = 0.85,
+) -> dict[str, float]:
+    if not nodes:
+        return {}
+    scores = {n: 1.0 / len(nodes) for n in nodes}
+    out_weight = {n: max(len(graph.get(n, ())), 1) for n in nodes}
+
+    pers = personalization
+    if pers:
+        total = sum(pers.values()) or 1.0
+        pers = {k: v / total for k, v in pers.items()}
+
+    for _ in range(iterations):
+        new_scores: dict[str, float] = {}
+        for n in nodes:
+            rank = (1 - damping) / len(nodes)
+            if pers and n in pers:
+                rank = (1 - damping) * pers.get(n, 0)
+            incoming = 0.0
+            for src in nodes:
+                if n in graph.get(src, ()):
+                    incoming += scores[src] / out_weight[src]
+            new_scores[n] = rank + damping * incoming
+        scores = new_scores
+    return scores
+
+
+def select_budget_map(
+    files: list[FileSymbols],
+    budget: int,
+    *,
+    focus_files: list[str] | None = None,
+    format_file,
+) -> str:
+    """Return markdown fitting within approximate token budget."""
+    nodes = [f.path for f in files]
+    graph = build_reference_graph(files)
+    pers = None
+    if focus_files:
+        pers = {p: 2.0 for p in focus_files if p in nodes}
+    ranks = pagerank(graph, nodes=nodes, personalization=pers)
+    if not ranks:
+        ranks = {f.path: 1.0 for f in files}
+
+    by_path = {f.path: f for f in files}
+    ordered = sorted(files, key=lambda f: (-ranks.get(f.path, 0), f.path))
+
+    parts: list[str] = []
+    used = 0
+    header = "# Repository Map (focused)\n\n"
+    parts.append(header)
+    used += estimate_tokens(header)
+
+    for fs in ordered:
+        chunk = format_file(fs)
+        cost = estimate_tokens(chunk)
+        if used + cost > budget and parts:
+            break
+        parts.append(chunk)
+        used += cost
+
+    return "\n".join(parts)
+
+
+def format_file_brief(fs: FileSymbols) -> str:
+    lines = [f"## `{fs.path}` ({fs.language})"]
+    defs = [s for s in fs.symbols if s.role == "definition"]
+    if fs.classes:
+        for cls in fs.classes:
+            methods = ", ".join(m.name for m in cls.methods if m.is_public)[:80]
+            lines.append(f"- class `{cls.name}`" + (f" — {methods}" if methods else ""))
+    elif defs:
+        for s in defs[:12]:
+            lines.append(f"- {s.kind} `{s.name}` (L{s.line})")
+    if fs.exports:
+        lines.append(f"- exports: {', '.join(fs.exports[:8])}")
+    lines.append("")
+    return "\n".join(lines)

--- a/pipecatapp/tools/repo_map_impl/render/catalog.py
+++ b/pipecatapp/tools/repo_map_impl/render/catalog.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pipecatapp.tools.repo_map_impl.config import RepoMapConfig
+from pipecatapp.tools.repo_map_impl.model import FileSymbols
+
+
+def default_categorize(path: str) -> str:
+    lower = path.lower()
+    if "__main__" in path or "main.py" in path or "run.py" in path:
+        return "entry_points"
+    if "service" in lower:
+        return "services"
+    if "model" in lower:
+        return "models"
+    if "config" in lower or "settings" in lower:
+        return "configuration"
+    if "util" in lower or "helper" in lower:
+        return "utilities"
+    return "other"
+
+
+def categorize_files(
+    files: list[FileSymbols], config: RepoMapConfig | None = None
+) -> dict[str, list[FileSymbols]]:
+    categories: dict[str, list[FileSymbols]] = {
+        "entry_points": [],
+        "services": [],
+        "models": [],
+        "utilities": [],
+        "configuration": [],
+        "other": [],
+    }
+    custom = (config.categories if config else {}) or {}
+
+    for fs in files:
+        assigned = None
+        for cat, patterns in custom.items():
+            for pat in patterns:
+                if pat in fs.path:
+                    assigned = cat
+                    break
+            if assigned:
+                break
+        if not assigned:
+            assigned = default_categorize(fs.path)
+        categories.setdefault(assigned, []).append(fs)
+
+    return categories
+
+
+def render_catalog_section(
+    files: list[FileSymbols],
+    config: RepoMapConfig | None = None,
+    *,
+    include_file_index: bool = True,
+    file_index_text: str = "",
+) -> str:
+    categories = categorize_files(files, config)
+    lines = [
+        "<!-- repo-map:section=catalog -->",
+        "# Repository Code Intelligence Map (Sourcegraph Style)",
+        "",
+    ]
+    if include_file_index and file_index_text:
+        lines.append(file_index_text)
+        lines.append("---")
+        lines.append("")
+    lines.append("## Overview")
+    lines.append("")
+    lines.append(f"Total files analyzed: {len(files)}")
+    lines.append("")
+
+    for category, cat_files in categories.items():
+        if not cat_files:
+            continue
+        title = category.replace("_", " ").title()
+        lines.append(f"## {title}")
+        lines.append("")
+        for fs in sorted(cat_files, key=lambda f: f.path):
+            lines.append(f"### `{fs.path}`")
+            if fs.docstring:
+                lines.append(f"> {fs.docstring[:100]}...")
+            lines.append("")
+            if fs.exports:
+                lines.append(f"**Exports:** {', '.join(fs.exports[:8])}")
+                lines.append("")
+            if fs.classes:
+                lines.append("**Classes:**")
+                for cls in fs.classes:
+                    pub = [m.name for m in cls.methods if m.is_public]
+                    if cls.bases:
+                        lines.append(f"- `{cls.name}` (inherits: {', '.join(cls.bases)})")
+                    else:
+                        lines.append(f"- `{cls.name}`")
+                    if pub:
+                        lines.append(f"  - Methods: {', '.join(pub[:5])}")
+                lines.append("")
+            elif fs.symbols:
+                defs = [s for s in fs.symbols if s.role == "definition"][:15]
+                if defs:
+                    lines.append("**Definitions:**")
+                    for s in defs:
+                        lines.append(f"- `{s.name}` ({s.kind}, L{s.line})")
+                    lines.append("")
+            if fs.functions:
+                pub = [f for f in fs.functions if f.is_public][:5]
+                if pub:
+                    lines.append("**Functions:**")
+                    for fn in pub:
+                        params = ", ".join(fn.params[:3])
+                        lines.append(f"- `{fn.name}({params})`")
+                    lines.append("")
+            if fs.error:
+                lines.append(f"⚠️ _Error parsing file: {fs.error}_")
+                lines.append("")
+
+    return "\n".join(lines)

--- a/pipecatapp/tools/repo_map_impl/render/file_index.py
+++ b/pipecatapp/tools/repo_map_impl/render/file_index.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pipecatapp.tools.repo_map_impl.config import RepoMapConfig
+from pipecatapp.tools.repo_map_impl.model import FileSymbols
+from pipecatapp.tools.repo_map_impl.render.catalog import categorize_files
+
+
+def render_file_index(files: list[FileSymbols], config: RepoMapConfig | None = None) -> str:
+    """One path per line per category — cheap to grep, no symbol detail."""
+    categories = categorize_files(files, config)
+    lines = [
+        "## File path index",
+        "",
+        "Use `grep` on paths below, then open the matching `### \\`path\\`` section in this catalog.",
+        "",
+    ]
+
+    for category, cat_files in categories.items():
+        if not cat_files:
+            continue
+        title = category.replace("_", " ").title()
+        lines.append(f"### {title} ({len(cat_files)} files)")
+        for fs in sorted(cat_files, key=lambda f: f.path):
+            lines.append(f"- `{fs.path}`")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/pipecatapp/tools/repo_map_impl/render/json_out.py
+++ b/pipecatapp/tools/repo_map_impl/render/json_out.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+
+from pipecatapp.tools.repo_map_impl.model import FileSymbols
+
+
+def render_json(files: list[FileSymbols]) -> str:
+    payload = []
+    for fs in files:
+        payload.append(
+            {
+                "path": fs.path,
+                "language": fs.language,
+                "exports": fs.exports,
+                "symbols": [
+                    {"name": s.name, "kind": s.kind, "line": s.line, "role": s.role}
+                    for s in fs.symbols
+                ],
+                "error": fs.error,
+            }
+        )
+    return json.dumps(payload, indent=2, ensure_ascii=False)

--- a/pipecatapp/tools/repo_map_impl/render/navigation.py
+++ b/pipecatapp/tools/repo_map_impl/render/navigation.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+from pipecatapp.tools.repo_map_impl.config import RepoMapConfig
+from pipecatapp.tools.repo_map_impl.model import FileSymbols
+from pipecatapp.tools.repo_map_impl.render.catalog import categorize_files
+
+# Above this file count, full maps use a paths-only tree unless --tree-detail.
+DEFAULT_COMPACT_TREE_THRESHOLD = 100
+
+
+def compact_tree_threshold(config: RepoMapConfig | None) -> int:
+    if config and config.compact_tree_threshold is not None:
+        return config.compact_tree_threshold
+    return DEFAULT_COMPACT_TREE_THRESHOLD
+
+
+def render_agent_guide(
+    repo_name: str,
+    files: list[FileSymbols],
+    *,
+    section_lines: dict[str, tuple[int, int]],
+    compact_tree: bool,
+    total_lines: int,
+) -> str:
+    """Preamble agents must read before scanning the rest of the map."""
+    file_count = len(files)
+    large = file_count > compact_tree_threshold(None) or total_lines > 4000
+
+    lines = [
+        "<!-- repo-map-format: 1 -->",
+        "<!-- AGENTS: Read 'How agents should use this map' below. Do NOT load the entire file. -->",
+        "",
+        f"# Repository map: {repo_name}",
+        "",
+        "## How agents should use this map",
+        "",
+        "**Do not read this file end-to-end.** It is an index, not source code. Loading all "
+        f"~{total_lines:,} lines will waste context and can overflow the window.",
+        "",
+        "### Safe navigation (required)",
+        "",
+        "1. **Read only this section first** (the guide + quick index).",
+        "2. **Locate targets** with search tools — do not scroll the whole map:",
+        "   - `grep -n \"### \\`path/to/file\" .repo-map.md` — jump to a file entry in the catalog",
+        "   - `grep -n \"## Services\" .repo-map.md` — jump to a category",
+        "   - `grep -n \"class YourClass\" .repo-map.md` — find a symbol name",
+        "3. **Read a small line range** around matches (`read_file` with offset/limit, or `sed -n '1200,1250p'`).",
+        "4. **Open real source** under the repo for implementation detail — the map is not a substitute.",
+        "",
+        "### Which section to use",
+        "",
+        "| Section | When to use |",
+        "|---------|-------------|",
+        "| **Quick index** (below) | Pick a category or directory before searching |",
+        "| **Code intelligence catalog** | APIs, exports, classes, functions, docstrings |",
+        f"| **Directory tree** | Path layout only{' (compact: no per-file symbols)' if compact_tree else ''} |",
+        "",
+        "### If this map is too large",
+        "",
+    ]
+
+    if large:
+        lines.extend(
+            [
+                f"This map indexes **{file_count}** source files. Prefer a focused map instead of reading `--full`:",
+                "",
+                "```bash",
+                f"repo-map \"$PROJECT_ROOT\" --budget 8000",
+                f"repo-map \"$PROJECT_ROOT\" --budget 8000 --focus path/under/edit",
+                "```",
+                "",
+                "Use `--full` output only via **grep + partial reads**, or regenerate with `--budget`.",
+                "",
+            ]
+        )
+    else:
+        lines.append(
+            "Use grep + partial reads on this file, or `--budget` if you only need the most relevant symbols."
+        )
+        lines.append("")
+
+    lines.extend(["## Quick index", ""])
+
+    if section_lines:
+        lines.append("| Section | Start line | End line |")
+        lines.append("|---------|------------|----------|")
+        for name, (start, end) in section_lines.items():
+            lines.append(f"| {name} | {start} | {end} |")
+        lines.append("")
+
+    categories = categorize_files(files)
+    lines.append("### Categories (file counts)")
+    for cat, cat_files in sorted(categories.items(), key=lambda x: (-len(x[1]), x[0])):
+        if not cat_files:
+            continue
+        title = cat.replace("_", " ").title()
+        samples = ", ".join(f"`{f.path}`" for f in sorted(cat_files, key=lambda f: f.path)[:4])
+        more = len(cat_files) - 4
+        suffix = f" (+{more} more — grep catalog)" if more > 0 else ""
+        lines.append(f"- **{title}** ({len(cat_files)}): {samples}{suffix}")
+    lines.append("")
+
+    dir_counts: dict[str, int] = defaultdict(int)
+    for fs in files:
+        parts = Path(fs.path).parts
+        top = parts[0] if parts else "."
+        dir_counts[top] += 1
+
+    lines.append("### Top-level directories")
+    for name, count in sorted(dir_counts.items(), key=lambda x: (-x[1], x[0])):
+        lines.append(f"- `{name}/` — {count} files")
+    lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def compute_section_lines(full_text: str, markers: dict[str, str]) -> dict[str, tuple[int, int]]:
+    """Return 1-based inclusive line ranges for each marker comment in the document."""
+    line_list = full_text.splitlines()
+    positions: dict[str, int] = {}
+    for i, line in enumerate(line_list, start=1):
+        for key, token in markers.items():
+            if token in line:
+                positions[key] = i
+
+    ranges: dict[str, tuple[int, int]] = {}
+    ordered = sorted(positions.items(), key=lambda x: x[1])
+    for idx, (key, start) in enumerate(ordered):
+        end = (ordered[idx + 1][1] - 1) if idx + 1 < len(ordered) else len(line_list)
+        ranges[key] = (start, end)
+    return ranges

--- a/pipecatapp/tools/repo_map_impl/render/tree.py
+++ b/pipecatapp/tools/repo_map_impl/render/tree.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pipecatapp.tools.repo_map_impl.model import FileSymbols
+
+
+def build_tree(files: list[FileSymbols]) -> dict:
+    tree: dict = {}
+    for fs in files:
+        parts = Path(fs.path).parts
+        current = tree
+        for part in parts[:-1]:
+            current = current.setdefault(part, {})
+        leaf = {
+            "classes": fs.tree_classes(),
+            "functions": fs.tree_functions(),
+        }
+        if fs.error:
+            leaf["error"] = fs.error
+        current[parts[-1]] = leaf
+    return tree
+
+
+def format_tree_compact(tree: dict, prefix: str = "") -> str:
+    """Paths only — no per-file symbols (for large repos)."""
+    lines: list[str] = []
+    items = sorted(tree.items())
+    for i, (name, content) in enumerate(items):
+        is_last = i == len(items) - 1
+        current_prefix = "└── " if is_last else "├── "
+        if isinstance(content, dict) and (
+            "classes" in content or "functions" in content or "error" in content
+        ):
+            lines.append(f"{prefix}{current_prefix}{name}")
+        else:
+            lines.append(f"{prefix}{current_prefix}{name}/")
+            next_prefix = prefix + ("    " if is_last else "│   ")
+            lines.append(format_tree_compact(content, next_prefix))
+    return "\n".join(lines)
+
+
+def format_tree(tree: dict, prefix: str = "") -> str:
+    lines: list[str] = []
+    items = sorted(tree.items())
+    for i, (name, content) in enumerate(items):
+        is_last = i == len(items) - 1
+        current_prefix = "└── " if is_last else "├── "
+        if isinstance(content, dict) and ("classes" in content or "functions" in content or "error" in content):
+            lines.append(f"{prefix}{current_prefix}{name}")
+            branch = "    " if is_last else "│   "
+            for cls in content.get("classes") or []:
+                lines.append(f"{prefix}{branch}    class {cls}")
+            for func in content.get("functions") or []:
+                lines.append(f"{prefix}{branch}    def {func}()")
+            if content.get("error"):
+                lines.append(f"{prefix}{branch}    # Error: {content['error']}")
+        else:
+            lines.append(f"{prefix}{current_prefix}{name}/")
+            next_prefix = prefix + ("    " if is_last else "│   ")
+            lines.append(format_tree(content, next_prefix))
+    return "\n".join(lines)
+
+
+def render_aider_section(
+    repo_name: str,
+    files: list[FileSymbols],
+    *,
+    compact: bool = False,
+) -> str:
+    tree = build_tree(files)
+    tree_body = format_tree_compact(tree) if compact else format_tree(tree)
+    mode = "compact paths only" if compact else "with symbols"
+    out = [
+        "<!-- repo-map:section=tree -->",
+        "=" * 80,
+        f"REPOSITORY MAP (Aider Style — {mode})",
+        "=" * 80,
+        f"Repository: {repo_name}",
+        "",
+        f"Total source files: {len(files)}",
+        "",
+    ]
+    if compact:
+        out.append(
+            "_Symbol detail is in the Code Intelligence Catalog above. "
+            "Use grep on that section for classes/functions._"
+        )
+        out.append("")
+    out.extend([tree_body, "", "=" * 80])
+    return "\n".join(out)

--- a/pipecatapp/tools/set_operational_mode_tool.py
+++ b/pipecatapp/tools/set_operational_mode_tool.py
@@ -1,0 +1,53 @@
+from typing import Any, Optional
+import logging
+from pipecatapp.skill_library import SkillLibrary
+
+logger = logging.getLogger("SetOperationalModeTool")
+
+class SetOperationalModeTool:
+    """
+    Allows the agent to dynamically switch its operational mode by retrieving
+    procedural instructions from the Skill Library and incorporating them into its context.
+    """
+
+    name = "set_operational_mode"
+    description = (
+        "Activates a specific operational mode (e.g., 'backpass', 'renovate') by retrieving "
+        "its procedural guidelines from the Skill Library. Use this when you want to shift "
+        "your execution rhythm or follow a specific multi-phase process."
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "mode_name": {
+                "type": "string",
+                "description": "The name of the operational mode/skill to activate (e.g., 'backpass')."
+            }
+        },
+        "required": ["mode_name"]
+    }
+
+    def __init__(self, db_path="skills.sqlite"):
+        self.skill_lib = SkillLibrary(db_path=db_path)
+
+    def run(self, mode_name: str) -> str:
+        try:
+            skill = self.skill_lib.get_skill(mode_name)
+            if not skill:
+                available = self.skill_lib.search_skills("")
+                names = [s['name'] for s in available]
+                return f"Error: Mode '{mode_name}' not found. Available modes: {', '.join(names)}"
+
+            content = skill['content']
+            logger.info(f"Operational mode '{mode_name}' retrieved.")
+
+            # The agent is expected to read this and append it to its system prompt or active context.
+            return (
+                f"MODE ACTIVATED: {mode_name}\n\n"
+                "Please internalize the following procedural guidelines and follow them for the remainder of this task:\n\n"
+                f"{content}\n\n"
+                "You are now operating in this mode. Acknowledge and proceed with the first step of the rhythm."
+            )
+        except Exception as e:
+            logger.error(f"Error setting operational mode: {e}")
+            return f"Error activating mode '{mode_name}': {e}"

--- a/pipecatapp/utils/coverage_check.py
+++ b/pipecatapp/utils/coverage_check.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Coverage check for scaffold-setup-skill.
+
+Compares parameters documented in a generated setup skill against the
+ground-truth parameters found in the repo's config files.
+
+Usage:
+    python coverage_check.py <repo_root> <generated_skill_path>
+
+Exit codes:
+    0  All checks pass
+    1  Coverage failures (missing required params, below threshold)
+    2  Flow validation failures (dead ends, duplicate questions, broken depends_on)
+    3  Docs index failures (missing files)
+"""
+
+import sys
+import os
+import re
+from pathlib import Path
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class Param:
+    name: str
+    required: bool
+    source: str
+    has_default: bool = False
+    description: str = ""
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    details: list[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        status = "PASS" if self.passed else "FAIL"
+        lines = [f"[{status}] {self.name}"]
+        for detail in self.details:
+            lines.append(f"       {detail}")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Ground-truth extraction
+# ---------------------------------------------------------------------------
+
+def extract_env_example_params(repo_root: Path) -> list[Param]:
+    """Extract params from .env.example or .env.sample."""
+    params = []
+    for candidate in [".env.example", ".env.sample", ".env.template"]:
+        path = repo_root / candidate
+        if path.exists():
+            params.extend(_parse_env_file(path, candidate))
+            break
+    return params
+
+
+def _parse_env_file(path: Path, source: str) -> list[Param]:
+    params = []
+    lines = path.read_text().splitlines()
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            is_placeholder = not value or value.lower() in {
+                "changeme", "replace_me", "your-value-here", "your_value_here",
+                "<value>", "todo", "fixme", "xxx", "none", "null", "false", "true",
+            } or value.startswith("<") or "replace" in value.lower()
+            params.append(Param(
+                name=key,
+                required=is_placeholder,
+                source=source,
+                has_default=bool(value) and not is_placeholder,
+            ))
+    return params
+
+
+def extract_ci_secret_params(repo_root: Path) -> list[Param]:
+    """Extract secret params referenced in GitHub Actions workflows."""
+    params = []
+    workflows_dir = repo_root / ".github" / "workflows"
+    if not workflows_dir.exists():
+        return params
+    secret_pattern = re.compile(r"\$\{\{\s*secrets\.(\w+)\s*\}\}")
+    for wf_file in workflows_dir.glob("*.yml"):
+        content = wf_file.read_text()
+        for match in secret_pattern.finditer(content):
+            name = match.group(1)
+            if not any(p.name == name for p in params):
+                params.append(Param(
+                    name=name,
+                    required=True,
+                    source=str(wf_file.relative_to(repo_root)),
+                ))
+    return params
+
+
+# ---------------------------------------------------------------------------
+# Generated skill parsing
+# ---------------------------------------------------------------------------
+
+def extract_skill_params(skill_path: Path) -> set[str]:
+    """Extract param names documented in the generated skill."""
+    content = skill_path.read_text()
+    params = set()
+
+    # Match backtick-quoted ALL_CAPS identifiers: `PARAM_NAME`
+    params.update(re.findall(r"`([A-Z][A-Z0-9_]{2,})`", content))
+
+    # Match KEY=value patterns in code blocks
+    params.update(re.findall(r"^([A-Z][A-Z0-9_]{2,})=", content, re.MULTILINE))
+
+    # Match **`PARAM_NAME`** bold+backtick pattern (question headings)
+    params.update(re.findall(r"\*\*`([A-Z][A-Z0-9_]{2,})`\*\*", content))
+
+    # Filter out obvious false positives (single words, common markdown artifacts)
+    noise = {"README", "CLAUDE", "SKILL", "HTTP", "HTTPS", "TODO", "NOTE", "WARNING",
+             "FIXME", "URL", "API", "JWT", "SQL", "CSS", "HTML", "JSON", "YAML",
+             "TOML", "ENV", "DEV", "PROD", "TRUE", "FALSE", "NULL"}
+    return {p for p in params if p not in noise and "_" in p or len(p) > 6}
+
+
+def extract_skill_branches(skill_path: Path) -> list[str]:
+    """Extract question branch identifiers for flow validation."""
+    content = skill_path.read_text()
+    # Look for → arrows indicating branching
+    branches = re.findall(r"→\s*([a-z_-]+):", content)
+    return branches
+
+
+def extract_docs_index_paths(skill_path: Path) -> list[str]:
+    """Extract file paths from the docs index table."""
+    content = skill_path.read_text()
+    paths = []
+    in_docs_section = False
+    for line in content.splitlines():
+        if "Documentation index" in line or "Documentation Q&A" in line:
+            in_docs_section = True
+        if in_docs_section and line.startswith("|"):
+            cells = [c.strip() for c in line.strip("|").split("|")]
+            if len(cells) >= 2:
+                # Second column is typically the file path
+                candidate = cells[1].strip()
+                if candidate.endswith(".md") and "/" in candidate:
+                    paths.append(candidate)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+def check_required_coverage(
+    ground_truth: list[Param], skill_params: set[str]
+) -> CheckResult:
+    required = [p for p in ground_truth if p.required]
+    if not required:
+        return CheckResult("Required param coverage", True, ["No required params found in ground truth"])
+
+    missing = [p for p in required if p.name not in skill_params]
+    covered = len(required) - len(missing)
+    pct = covered / len(required) * 100
+
+    details = [f"Required params: {len(required)}, covered: {covered} ({pct:.0f}%)"]
+    if missing:
+        for p in missing:
+            details.append(f"  MISSING [{p.source}]: {p.name}")
+
+    return CheckResult("Required param coverage", len(missing) == 0, details)
+
+
+def check_optional_coverage(
+    ground_truth: list[Param], skill_params: set[str], threshold: float = 0.80
+) -> CheckResult:
+    optional = [p for p in ground_truth if not p.required]
+    if not optional:
+        return CheckResult("Optional param coverage", True, ["No optional params found"])
+
+    missing = [p for p in optional if p.name not in skill_params]
+    covered = len(optional) - len(missing)
+    pct = covered / len(optional) * 100
+    passed = pct >= threshold * 100
+
+    details = [f"Optional params: {len(optional)}, covered: {covered} ({pct:.0f}%), threshold: {threshold*100:.0f}%"]
+    if missing:
+        for p in missing[:10]:  # cap output
+            details.append(f"  MISSING [{p.source}]: {p.name}")
+        if len(missing) > 10:
+            details.append(f"  ... and {len(missing) - 10} more")
+
+    return CheckResult("Optional param coverage", passed, details)
+
+
+def check_undocumented_params(
+    ground_truth: list[Param], skill_params: set[str]
+) -> CheckResult:
+    """Warn about params in skill that have no ground-truth source."""
+    ground_truth_names = {p.name for p in ground_truth}
+    undocumented = skill_params - ground_truth_names
+
+    if not undocumented:
+        return CheckResult("No undocumented params", True, ["All skill params have a source"])
+
+    details = [f"Params in skill with no ground-truth source: {len(undocumented)}"]
+    for name in sorted(undocumented)[:10]:
+        details.append(f"  UNDOCUMENTED: {name}")
+
+    # Undocumented params are a warning, not a failure — they may be inferred from source code
+    return CheckResult("Undocumented params (informational)", True, details)
+
+
+def check_docs_index(repo_root: Path, skill_path: Path) -> CheckResult:
+    paths = extract_docs_index_paths(skill_path)
+    if not paths:
+        mkdocs = repo_root / "mkdocs.yml"
+        if mkdocs.exists():
+            return CheckResult("Docs index", False, ["mkdocs.yml found but no docs index in skill"])
+        return CheckResult("Docs index", True, ["No mkdocs.yml, docs index skipped"])
+
+    missing = []
+    for p in paths:
+        full = repo_root / p
+        if not full.exists():
+            missing.append(p)
+
+    details = [f"Index entries: {len(paths)}, missing files: {len(missing)}"]
+    for p in missing:
+        details.append(f"  MISSING FILE: {p}")
+
+    return CheckResult("Docs index file paths", len(missing) == 0, details)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <repo_root> <generated_skill_path>")
+        return 2
+
+    repo_root = Path(sys.argv[1]).resolve()
+    skill_path = Path(sys.argv[2]).resolve()
+
+    if not repo_root.is_dir():
+        print(f"Error: repo root not found: {repo_root}")
+        return 2
+    if not skill_path.exists():
+        print(f"Error: generated skill not found: {skill_path}")
+        return 2
+
+    print(f"Coverage check: {repo_root.name}")
+    print(f"Skill:          {skill_path.relative_to(repo_root) if skill_path.is_relative_to(repo_root) else skill_path}")
+    print()
+
+    # Gather ground truth
+    ground_truth = extract_env_example_params(repo_root)
+    ci_params = extract_ci_secret_params(repo_root)
+    # Merge CI params that aren't already in ground truth
+    gt_names = {p.name for p in ground_truth}
+    for p in ci_params:
+        if p.name not in gt_names:
+            ground_truth.append(p)
+
+    skill_params = extract_skill_params(skill_path)
+
+    # Run checks
+    results = [
+        check_required_coverage(ground_truth, skill_params),
+        check_optional_coverage(ground_truth, skill_params),
+        check_undocumented_params(ground_truth, skill_params),
+        check_docs_index(repo_root, skill_path),
+    ]
+
+    # Print results
+    any_failure = False
+    for result in results:
+        print(result)
+        print()
+        if not result.passed:
+            any_failure = True
+
+    # Summary
+    passed = sum(1 for r in results if r.passed)
+    print(f"Results: {passed}/{len(results)} checks passed")
+
+    return 1 if any_failure else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
I have integrated the programming skills and tools from the `my-skills` repository into the `pipecatapp` framework. This includes an upgraded `ProjectMapperTool` using `tree-sitter` for deep codebase analysis, and a new `SetOperationalModeTool` that allows agents to adopt the 'backpass' or 'renovate' rhythms by dynamically loading instructions from the `SkillLibrary`. The `scaffold-setup-skill` has also been adapted to persist generated skills directly to our internal database. All changes have been verified with unit tests.

---
*PR created automatically by Jules for task [13589311311175090779](https://jules.google.com/task/13589311311175090779) started by @LokiMetaSmith*