### PR TITLE
Integrate backon library for retry logic and observability

### DIFF
--- a/pipecatapp/requirements.txt
+++ b/pipecatapp/requirements.txt
@@ -64,6 +64,8 @@ llmrouter-lib
 rank_bm25
 podman
 tenacity
+backon
+prometheus_client
 # Unlimited-OCR dependencies
 addict
 easydict

--- a/pipecatapp/utils/backon_utils.py
+++ b/pipecatapp/utils/backon_utils.py
@@ -1,0 +1,126 @@
+import logging
+import backon
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Transient error patterns migrated from retry_utils.py
+TRANSIENT_ERROR_MESSAGES = {
+    "connection refused",
+    "connection reset",
+    "connection timed out",
+    "temporary failure",
+    "service unavailable",
+    "resource temporarily unavailable",
+    "too many requests",
+    "rate limit",
+    "docker daemon",
+    "cannot connect to docker",
+    "no space left on device",
+}
+
+TRANSIENT_EXCEPTION_TYPES = (
+    TimeoutError,
+    ConnectionError,
+    OSError,
+    # Many libraries have their own ClientError, but we'll stick to built-ins
+    # or handle them via predicate if needed.
+)
+
+def is_transient_error(exc: Exception) -> bool:
+    """Predicate to determine if an exception is transient."""
+    error_msg = str(exc).lower()
+    if any(pattern in error_msg for pattern in TRANSIENT_ERROR_MESSAGES):
+        return True
+
+    if isinstance(exc, TRANSIENT_EXCEPTION_TYPES):
+        return True
+
+    # Check for "clienterror" in type name as done in original retry_utils
+    if "clienterror" in type(exc).__name__.lower():
+        return True
+
+    return False
+
+# Backon retry condition for transient errors
+retry_if_transient = backon.retry_if_exception(is_transient_error)
+
+class MultiMetricsCollector(backon.MetricsCollector):
+    """Collector that dispatches to multiple backon metrics collectors."""
+    def __init__(self, collectors):
+        self.collectors = collectors
+
+    def emit_attempt(self, tries: int, elapsed: float, target_name: str, exception_type: str | None = None) -> None:
+        for c in self.collectors:
+            try:
+                c.emit_attempt(tries, elapsed, target_name, exception_type)
+            except Exception:
+                pass
+
+    def emit_success(self, tries: int, elapsed: float, target_name: str) -> None:
+        for c in self.collectors:
+            try:
+                c.emit_success(tries, elapsed, target_name)
+            except Exception:
+                pass
+
+    def emit_failure(self, tries: int, elapsed: float, target_name: str, exception_type: str) -> None:
+        for c in self.collectors:
+            try:
+                c.emit_failure(tries, elapsed, target_name, exception_type)
+            except Exception:
+                pass
+
+    def emit_circuit_breaker_open(self, breaker_name: str) -> None:
+        for c in self.collectors:
+            try:
+                c.emit_circuit_breaker_open(breaker_name)
+            except Exception:
+                pass
+
+    def emit_circuit_breaker_close(self, breaker_name: str) -> None:
+        for c in self.collectors:
+            try:
+                c.emit_circuit_breaker_close(breaker_name)
+            except Exception:
+                pass
+
+    def emit_hedge_request(self, target_name: str, hedge_count: int) -> None:
+        for c in self.collectors:
+            try:
+                c.emit_hedge_request(target_name, hedge_count)
+            except Exception:
+                pass
+
+def setup_backon_observability():
+    """Initializes backon metrics with Prometheus and OpenTelemetry."""
+    collectors = []
+    try:
+        from backon import PrometheusMetrics, OTelMetrics, set_metrics_collector
+
+        # Try to set up Prometheus
+        try:
+            collectors.append(PrometheusMetrics())
+            logger.info("Backon Prometheus metrics initialized")
+        except Exception as e:
+            logger.warning(f"Failed to initialize Backon Prometheus metrics: {e}")
+
+        # Try to set up OpenTelemetry
+        try:
+            collectors.append(OTelMetrics(meter_name="pipecatapp.backon"))
+            logger.info("Backon OpenTelemetry metrics initialized")
+        except Exception as e:
+            logger.warning(f"Failed to initialize Backon OpenTelemetry metrics: {e}")
+
+        if collectors:
+            if len(collectors) == 1:
+                set_metrics_collector(collectors[0])
+            else:
+                set_metrics_collector(MultiMetricsCollector(collectors))
+            logger.info(f"Backon observability enabled with {len(collectors)} collectors")
+
+    except ImportError as e:
+        logger.warning(f"Backon observability dependencies missing: {e}")
+
+# Default setup
+setup_backon_observability()

--- a/tests/unit/test_backon_integration.py
+++ b/tests/unit/test_backon_integration.py
@@ -1,0 +1,82 @@
+import pytest
+import backon
+import asyncio
+from pipecatapp.utils.backon_utils import is_transient_error, retry_if_transient
+
+def test_is_transient_error():
+    # Test message-based detection
+    assert is_transient_error(Exception("Connection refused")) is True
+    assert is_transient_error(Exception("Something went wrong")) is False
+    assert is_transient_error(Exception("Rate limit exceeded")) is True
+    assert is_transient_error(Exception("No space left on device")) is True
+
+    # Test type-based detection
+    assert is_transient_error(TimeoutError("Timeout")) is True
+    assert is_transient_error(ConnectionError("Conn error")) is True
+
+    # Test "clienterror" type name detection
+    class MyClientError(Exception):
+        pass
+    assert is_transient_error(MyClientError("client error")) is True
+
+@pytest.mark.asyncio
+async def test_backon_retry_with_transient_predicate():
+    attempts = 0
+
+    async def failing_func():
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise Exception("Connection refused")
+        return "success"
+
+    result = await backon.retry(
+        failing_func,
+        backon.constant,
+        exception=Exception,
+        max_tries=3,
+        interval=0.01,
+        condition=retry_if_transient
+    )
+
+    assert result == "success"
+    assert attempts == 3
+
+@pytest.mark.asyncio
+async def test_backon_no_retry_on_non_transient():
+    attempts = 0
+
+    async def critical_failure_func():
+        nonlocal attempts
+        attempts += 1
+        raise Exception("Critical permanent error")
+
+    with pytest.raises(Exception, match="Critical permanent error"):
+        await backon.retry(
+            critical_failure_func,
+            backon.constant,
+            exception=Exception,
+            max_tries=3,
+            interval=0.01,
+            condition=retry_if_transient
+        )
+
+    # Should only attempt once because it's not a transient error according to our predicate
+    assert attempts == 1
+
+@pytest.mark.asyncio
+async def test_backon_retrying_context_manager():
+    attempts = 0
+
+    async def failing_func():
+        nonlocal attempts
+        attempts += 1
+        if attempts < 2:
+            raise Exception("connection reset")
+        return "ok"
+
+    async with backon.Retrying(backon.constant, exception=Exception, interval=0.01, condition=retry_if_transient) as r:
+        result = await r.async_call(failing_func)
+
+    assert result == "ok"
+    assert attempts == 2


### PR DESCRIPTION
This change integrates the `backon` library into the project to provide advanced retry and backoff capabilities for new use cases. 

Key changes:
1.  **Dependency Update:** Added `backon` and `prometheus_client` to `pipecatapp/requirements.txt`.
2.  **Centralized Utility:** Created `pipecatapp/utils/backon_utils.py` which:
    *   Migrates transient error patterns from the existing `retry_utils.py`.
    *   Exposes a `retry_if_transient` predicate for use with `backon`.
    *   Sets up a `MultiMetricsCollector` to dispatch retry metrics to both Prometheus and OpenTelemetry.
3.  **Verification:** Added `tests/unit/test_backon_integration.py` to ensure the library and the custom predicates work as expected.

Existing retry logic in `retry_utils.py` remains untouched as requested, allowing `backon` to be adopted incrementally.

---
*PR created automatically by Jules for task [9827178281323760875](https://jules.google.com/task/9827178281323760875) started by @LokiMetaSmith*