### PR TITLE
Fix Ansible syntax errors in monitoring role

### DIFF
--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -56,8 +56,7 @@
     - "{{ grafana_port }}"
     - "{{ node_exporter_port }}"
     - "{{ mqtt_exporter_metrics_port }}"
-  changed_
-      when: false
+  changed_when: false
   ignore_errors: yes
 
 - name: Deploy Node Exporter
@@ -248,10 +247,8 @@
         cmd: /usr/local/bin/nomad job status mqtt-exporter
       register: pre_mqtt_exporter_job_status
       ignore_errors: yes
-      failed_
-      when: false
-      changed_
-      when: false
+      failed_when: false
+      changed_when: false
       environment:
         NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"


### PR DESCRIPTION
Corrected malformed Ansible task attributes in `ansible/roles/monitoring/tasks/main.yml`. The keywords `changed_when` and `failed_when` were incorrectly written as `changed_` and `failed_` with trailing underscores, followed by an indented `when: false`, which caused YAML parsing failures. These have been consolidated into the correct single-line format.

---
*PR created automatically by Jules for task [10055347669187264751](https://jules.google.com/task/10055347669187264751) started by @LokiMetaSmith*