### PR TITLE
fix: Resolve multiple Ansible YAML syntax errors in monitoring and pi…

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -891,9 +891,8 @@
 
 - name: Handle docker specific tasks for pipecatapp
   block:
-    - name: Inspect pipecatapp:{{ pipecat_image_tag | default('local') }}
-      image
-      ansible.builtin.command: docker image inspect pipecatapp:{{ pipecat_image_tag | default('local') }}
+    - name: "Inspect pipecatapp:{{ pipecat_image_tag | default('local') }}"
+      ansible.builtin.command: "docker image inspect pipecatapp:{{ pipecat_image_tag | default('local') }}"
       register: pipecatapp_local_image_info
       changed_when: false
       failed_when: false
@@ -1054,7 +1053,8 @@
   become: yes
   become_user: "{{ target_user }}"
   environment:
-    PLAYWRIGHT_BROWSERS_PATH: "{{ pipecat_app_dir }}/pw-browsers"  async: 900 # Set timeout to 15 minutes
+    PLAYWRIGHT_BROWSERS_PATH: "{{ pipecat_app_dir }}/pw-browsers"
+  async: 900 # Set timeout to 15 minutes
   poll: 10   # Check status every 10 seconds
 
 - name: Install Playwright system dependencies


### PR DESCRIPTION
…pecatapp roles

- monitoring: Correct malformed `changed_when` and `failed_when` attributes.
- pipecatapp: Remove stray `image` keyword, quote values with colons, and fix misplaced `async` attribute.

Verified with `ansible-playbook --syntax-check` on affected playbooks.