### PR TITLE
fix: Resolve multiple Ansible YAML and task configuration errors

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -82,7 +82,7 @@
       {{
         verified_experts | default([]) + [item]
       }}
-      loop: "{{ experts }}"
+  loop: "{{ experts }}"
   vars:
     # Get the list of model filenames for the current expert
     expert_model_files: "{{ (expert_models[item] | default([])) | map(attribute='filename') | list }}"


### PR DESCRIPTION
- Corrected malformed `changed_when` and `failed_when` attributes in monitoring role.
- Fixed `pipecatapp` role by:
  - Removing stray `image` word.
  - Quoting task names and commands containing colons.
  - Correcting indentation of `loop` attribute to ensure it is a task-level property.
  - Moving `async` keyword out of the `environment` block to the task level.

Verified all affected playbooks pass `ansible-playbook --syntax-check`.