### PR TITLE
Install magic-wormhole and hermes-agent

### DIFF
--- a/ansible/roles/common-tools/tasks/main.yaml
+++ b/ansible/roles/common-tools/tasks/main.yaml
@@ -12,6 +12,7 @@
       - figlet
       - lolcat
       - age
+      - magic-wormhole
     state: present
   become: yes
 

--- a/ansible/roles/hermes_agent/tasks/main.yaml
+++ b/ansible/roles/hermes_agent/tasks/main.yaml
@@ -1,0 +1,22 @@
+- name: Check if hermes command is already installed
+  ansible.builtin.shell: command -v hermes
+  register: hermes_check
+  ignore_errors: yes
+  changed_when: false
+
+- name: Install Hermes Agent
+  ansible.builtin.shell:
+    cmd: "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --non-interactive --skip-setup"
+  when: hermes_check.rc != 0
+  become: yes
+  become_user: "{{ target_user | default('pipecatapp') }}"
+  register: hermes_install
+  changed_when: "'Installation Complete' in hermes_install.stdout"
+
+- name: Ensure ~/.local/bin is on PATH for target user
+  ansible.builtin.lineinfile:
+    path: "/home/{{ target_user | default('pipecatapp') }}/.bashrc"
+    line: 'export PATH="$HOME/.local/bin:$PATH"'
+    state: present
+  become: yes
+  become_user: "{{ target_user | default('pipecatapp') }}"

--- a/playbooks/developer_tools.yaml
+++ b/playbooks/developer_tools.yaml
@@ -7,3 +7,4 @@
 
   roles:
     - role: heretic_tool
+    - role: hermes_agent


### PR DESCRIPTION
I have updated the cluster's provisioning logic to include `magic-wormhole` and the `hermes-agent`.

- **Wormhole:** Added to the `common-tools` role as a system package (`magic-wormhole`). This enables secure, simple background file transfers across the cluster nodes.
- **Hermes:** Created a new Ansible role (`hermes_agent`) that automates the installation of the Nous Research Hermes Agent. This role uses the official installer in non-interactive mode, ensures it's installed for the target application user, and adds it to the system path.
- **Integration:** The Hermes installation is now part of the `developer-tools` playbook, which is run during the standard cluster bootstrap process.

I've manually verified both installations in the current environment:
- `wormhole --version` confirms `magic-wormhole 0.12.0`.
- `hermes --version` confirms `Hermes Agent v0.18.0`.

---
*PR created automatically by Jules for task [5463257408498940779](https://jules.google.com/task/5463257408498940779) started by @LokiMetaSmith*