### PR TITLE
RAG Context Pruning with LLM Grading

### DIFF
--- a/pipecatapp/agent_factory.py
+++ b/pipecatapp/agent_factory.py
@@ -9,6 +9,8 @@ from tools.power_tool import Power_Tool
 from tools.summarizer_tool import SummarizerTool
 from tools.term_everything_tool import TermEverythingTool
 from tools.rag_tool import RAG_Tool
+from utils.rag_pruner import RAGPruner
+from llm_clients import ExternalLLMClient
 from tools.ha_tool import HA_Tool
 from tools.git_tool import Git_Tool
 from tools.orchestrator_tool import OrchestratorTool
@@ -187,10 +189,35 @@ def create_tools(config: dict, twin_service=None, runner=None) -> dict:
                     # Allow configurability for base_dir, but default to secure app dir
                     rag_base_dir = config.get("rag_base_dir", "/opt/pipecatapp")
                     rag_allowed_root = config.get("rag_allowed_root", rag_base_dir)
+
+                    # Optional RAG Pruning
+                    pruner = None
+                    pruner_model = config.get("rag_pruner_model")
+                    if pruner_model:
+                        # Use the same base URL as the router if not specified
+                        # We try to find a sensible base_url for the pruner
+                        pruner_base_url = config.get("rag_pruner_base_url")
+                        if not pruner_base_url:
+                            # Attempt to infer from other config or env
+                            pruner_base_url = os.getenv("LLAMA_API_BASE_URL") or config.get("llama_api_url")
+
+                        pruner_api_key = config.get("rag_pruner_api_key") or os.getenv("GROQ_API_KEY") or os.getenv("OPENAI_API_KEY") or "dummy"
+
+                        if pruner_base_url and pruner_model:
+                            llm_client = ExternalLLMClient(
+                                base_url=pruner_base_url,
+                                api_key=pruner_api_key,
+                                model=pruner_model
+                            )
+                            pruner = RAGPruner(llm_client=llm_client)
+
                     tools["rag"] = RAG_Tool(
                         pmm_memory=twin_service.long_term_memory if twin_service else None,
                         base_dir=rag_base_dir,
-                        allowed_root=rag_allowed_root
+                        allowed_root=rag_allowed_root,
+                        pruner=pruner,
+                        pruning_threshold=config.get("rag_pruning_threshold", 4),
+                        keep_top_k=config.get("rag_keep_top_k", 3)
                     )
                 elif name == "ha":
                     tools["ha"] = HA_Tool(

--- a/pipecatapp/services/rag/rag_server.py
+++ b/pipecatapp/services/rag/rag_server.py
@@ -49,25 +49,25 @@ class ScanDirectoryRequest(BaseModel):
     directory: str
 
 @app.post("/add_document", dependencies=[Depends(verify_token)])
-def add_document(req: AddDocumentRequest):
+async def add_document(req: AddDocumentRequest):
     try:
-        result = rag_tool_instance.add_document(req.filepath)
+        result = await rag_tool_instance.add_document(req.filepath)
         return {"status": "success", "result": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/search", dependencies=[Depends(verify_token)])
-def search(req: SearchRequest):
+async def search(req: SearchRequest):
     try:
-        result = rag_tool_instance.search(req.query, k=req.k)
+        result = await rag_tool_instance.search(req.query, k=req.k)
         return {"status": "success", "result": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/scan_directory", dependencies=[Depends(verify_token)])
-def scan_directory(req: ScanDirectoryRequest):
+async def scan_directory(req: ScanDirectoryRequest):
     try:
-        result = rag_tool_instance.scan_directory(req.directory)
+        result = await rag_tool_instance.scan_directory(req.directory)
         return {"status": "success", "result": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/pipecatapp/tests/test_rag_pruning.py
+++ b/pipecatapp/tests/test_rag_pruning.py
@@ -1,0 +1,108 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+import sys
+import os
+import numpy as np
+
+# Define modules to mock before importing anything
+mock_modules = {
+    "extism": MagicMock(),
+    "pmm_memory": MagicMock(),
+    "ultralytics": MagicMock(),
+    "sentence_transformers": MagicMock(),
+    "faiss": MagicMock(),
+    "chromadb": MagicMock(),
+    "chromadb.config": MagicMock(),
+    "langchain_community": MagicMock(),
+    "langchain_community.document_loaders": MagicMock(),
+    "langchain_text_splitters": MagicMock()
+}
+
+# Torch mock needs to have __spec__ to satisfy transformers
+mock_torch = MagicMock()
+mock_torch.__spec__ = MagicMock()
+mock_modules["torch"] = mock_torch
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_mocks():
+    with patch.dict(sys.modules, mock_modules):
+        yield
+
+@pytest.fixture
+def mock_llm_client():
+    client = MagicMock()
+    client.process_text = AsyncMock()
+    return client
+
+@pytest.fixture
+def pruner(mock_llm_client):
+    from pipecatapp.utils.rag_pruner import RAGPruner
+    return RAGPruner(llm_client=mock_llm_client)
+
+@pytest.mark.asyncio
+async def test_rag_pruner_grading(pruner, mock_llm_client):
+    query = "How do I use API X?"
+    chunks = [
+        {"id": "chunk1", "content": "To use API X, do this..."},
+        {"id": "chunk2", "content": "API Y is unrelated."}
+    ]
+
+    # Mock LLM response
+    mock_llm_client.process_text.return_value = json.dumps({"chunk1": 5, "chunk2": 1})
+
+    grades = await pruner.prune_chunks(query, chunks)
+
+    assert grades["chunk1"] == 5
+    assert grades["chunk2"] == 1
+    assert mock_llm_client.process_text.called
+
+@pytest.mark.asyncio
+async def test_rag_pruner_json_extraction(pruner, mock_llm_client):
+    # Test that it can extract JSON from markdown-like chatter
+    mock_llm_client.process_text.return_value = "Here is the grading: ```json\n{\"c1\": 4}\n```"
+    chunks = [{"id": "c1", "content": "some content"}]
+
+    grades = await pruner.prune_chunks("query", chunks)
+    assert grades["c1"] == 4
+
+@pytest.mark.asyncio
+async def test_rag_tool_with_pruning():
+    from pipecatapp.tools.rag_tool import RAG_Tool
+
+    mock_memory = MagicMock()
+    mock_pruner = MagicMock()
+    mock_pruner.prune_chunks = AsyncMock()
+
+    with patch("pipecatapp.tools.rag_tool.SentenceTransformer") as mock_st_class:
+        mock_model = mock_st_class.return_value
+        mock_model.get_sentence_embedding_dimension.return_value = 384
+        # Return a numpy array to support .tolist()
+        mock_model.encode.return_value = np.array([[0.1] * 384], dtype=np.float32)
+
+        tool = RAG_Tool(
+            pmm_memory=mock_memory,
+            base_dir="/tmp",
+            pruner=mock_pruner,
+            pruning_threshold=4,
+            keep_top_k=1
+        )
+        tool.is_ready = True
+        tool.initialization_error = None
+
+        # Mock ChromaDB result
+        mock_collection = tool.chroma_client.get_collection.return_value
+        mock_collection.query.return_value = {
+            "documents": [["doc1", "doc2", "doc3"]],
+            "metadatas": [[{"source": "src1"}, {"source": "src2"}, {"source": "src3"}]],
+            "ids": [["id1", "id2", "id3"]]
+        }
+
+        # Mock pruner grades: id1 is top-k (kept anyway), id2 is high (kept), id3 is low (pruned)
+        mock_pruner.prune_chunks.return_value = {"id1": "1", "id2": "5", "id3": "2"}
+
+        results_str = await tool.search_knowledge_base("my query", k=3)
+
+        assert "src1" in results_str # Kept because i < keep_top_k (0 < 1)
+        assert "src2" in results_str # Kept because grade (5) >= threshold (4)
+        assert "src3" not in results_str # Pruned because grade (2) < threshold (4) and i >= keep_top_k

--- a/pipecatapp/tests/test_rag_tool.py
+++ b/pipecatapp/tests/test_rag_tool.py
@@ -40,6 +40,11 @@ def mock_memory():
             self.events.append({"kind": kind, "content": content, "meta": meta or {}})
     return MockPMMMemory()
 
+@pytest.fixture(autouse=True)
+def mock_thread():
+    with patch("threading.Thread") as mock:
+        yield mock
+
 @pytest.fixture
 def test_dirs(tmp_path):
     root = tmp_path / "root"
@@ -52,7 +57,8 @@ def test_dirs(tmp_path):
     forbidden.mkdir()
     return root, subdir, forbidden
 
-def test_rag_scope_security(rag_tool_class, mock_memory, test_dirs):
+@pytest.mark.asyncio
+async def test_rag_scope_security(rag_tool_class, mock_memory, test_dirs):
     root, subdir, forbidden = test_dirs
 
     # Setup mock return for encode
@@ -64,13 +70,14 @@ def test_rag_scope_security(rag_tool_class, mock_memory, test_dirs):
     tool = rag_tool_class(pmm_memory=mock_memory, base_dir=str(root), allowed_root=str(root))
 
     assert tool.base_dir == str(root)
-    assert tool.set_scope(str(subdir)) is True
+    assert await tool.set_scope(str(subdir)) is True
     assert tool.base_dir == str(subdir)
-    assert tool.set_scope(str(forbidden)) is False
+    assert await tool.set_scope(str(forbidden)) is False
     assert tool.base_dir == str(subdir)
-    assert tool.set_scope(str(root)) is True
+    assert await tool.set_scope(str(root)) is True
 
-def test_rag_filtering(rag_tool_class, mock_memory, test_dirs):
+@pytest.mark.asyncio
+async def test_rag_filtering(rag_tool_class, mock_memory, test_dirs):
     root, subdir, forbidden = test_dirs
 
     mock_model_instance = mock_st.SentenceTransformer.return_value
@@ -131,7 +138,7 @@ def test_rag_filtering(rag_tool_class, mock_memory, test_dirs):
     tool.index.ntotal = 0
 
     # We are scoped to root, should find doc1
-    results = tool.search_knowledge_base("content 1")
+    results = await tool.search_knowledge_base("content 1")
     assert "doc1.txt" in results
     assert "doc2.txt" in results # since it's under root
 
@@ -141,7 +148,7 @@ def test_rag_filtering(rag_tool_class, mock_memory, test_dirs):
         os.remove(tool.checkpoint_file)
 
     added_docs.clear()
-    tool.set_scope(str(subdir))
+    await tool.set_scope(str(subdir))
     tool._build_knowledge_base()
 
     sources = [s for s, _ in added_docs]
@@ -150,11 +157,12 @@ def test_rag_filtering(rag_tool_class, mock_memory, test_dirs):
 
     # Query should now be scoped to subdir
     tool.index.ntotal = 0
-    results = tool.search_knowledge_base("content")
+    results = await tool.search_knowledge_base("content")
     assert "doc1.txt" not in results
     assert "doc2.txt" in results
 
-def test_rag_sibling_directory_isolation(rag_tool_class, mock_memory, test_dirs):
+@pytest.mark.asyncio
+async def test_rag_sibling_directory_isolation(rag_tool_class, mock_memory, test_dirs):
     root, subdir, forbidden = test_dirs
 
     # Create a sibling directory that shares prefix with 'subdir'
@@ -242,7 +250,7 @@ def test_rag_sibling_directory_isolation(rag_tool_class, mock_memory, test_dirs)
     # The where clause will use $contains which would match /root/subdir and not /root/subdir-secret
     # Since we simulate the actual behavior in mock_query using startswith, we test the intent
     tool.index.ntotal = 0
-    results = tool.search_knowledge_base("secret")
+    results = await tool.search_knowledge_base("secret")
     assert "secret.txt" not in results
     assert "doc2.txt" in results # doc2 will be returned by our mock because it is in the allowed scope.
 

--- a/pipecatapp/tools/rag_tool.py
+++ b/pipecatapp/tools/rag_tool.py
@@ -35,7 +35,7 @@ class RAG_Tool:
     the agent to find relevant information to answer user queries about the
     project.
     """
-    def __init__(self, pmm_memory: Optional[PMMMemory] = None, base_dir=None, allowed_root: Optional[str] = None, model_name="all-MiniLM-L6-v2", allow_root_scan: bool = False):
+    def __init__(self, pmm_memory: Optional[PMMMemory] = None, base_dir=None, allowed_root: Optional[str] = None, model_name="all-MiniLM-L6-v2", allow_root_scan: bool = False, pruner=None, pruning_threshold: int = 4, keep_top_k: int = 3):
         """Initializes the RAG_Tool.
 
         Args:
@@ -46,6 +46,9 @@ class RAG_Tool:
                 Defaults to base_dir if not provided.
             model_name (str): The name of the SentenceTransformer model to use.
             allow_root_scan (bool): Explicitly allow scanning the filesystem root (/). Defaults to False.
+            pruner (Optional[RAGPruner]): An instance of RAGPruner to prune retrieved context.
+            pruning_threshold (int): The minimum grade (1-5) for a chunk to be kept.
+            keep_top_k (int): Number of top reranked chunks to keep regardless of pruning grade.
         """
         self.name = "rag"
         self.description = (
@@ -100,13 +103,17 @@ class RAG_Tool:
         # Checkpoint file for tracking processed files
         self.checkpoint_file = os.path.join(self.chromadb_dir, "rag_checkpoint.json")
 
+        self.pruner = pruner
+        self.pruning_threshold = pruning_threshold
+        self.keep_top_k = keep_top_k
+
         if self.pmm_memory:
             # Run knowledge base build in a separate thread
             threading.Thread(target=self._build_knowledge_base, daemon=True).start()
         else:
              logging.warning("RAG Tool disabled: PMMMemory unavailable.")
 
-    def set_scope(self, path: str) -> bool:
+    async def set_scope(self, path: str) -> bool:
         """Updates the search scope to a new directory.
 
         Args:
@@ -309,18 +316,18 @@ class RAG_Tool:
         logging.info(f"RAG knowledge base built/loaded successfully. Total documents in ChromaDB: {doc_count}.")
 
 
-    def scan_directory(self, directory: str) -> str:
+    async def scan_directory(self, directory: str) -> str:
         """Scans a new directory and adds documents to the index."""
-        if self.set_scope(directory):
+        if await self.set_scope(directory):
             self._build_knowledge_base()
             return f"Successfully scanned and indexed directory: {directory}"
         return f"Failed to scan directory: {directory}"
 
-    def search(self, query: str, k: int = 5) -> str:
+    async def search(self, query: str, k: int = 5) -> str:
         """Searches the knowledge base for text relevant to the query."""
-        return self.search_knowledge_base(query)
+        return await self.search_knowledge_base(query, k=k)
 
-    def add_document(self, filepath: str) -> str:
+    async def add_document(self, filepath: str) -> str:
         """Adds a single document to the index using LangChain Loaders and Splitters."""
         if not os.path.exists(filepath):
             return f"Error: File '{filepath}' does not exist."
@@ -405,11 +412,12 @@ class RAG_Tool:
         except Exception:
             return None
 
-    def search_knowledge_base(self, query: str) -> str:
+    async def search_knowledge_base(self, query: str, k: int = 5) -> str:
         """Searches the knowledge base for text relevant to the query.
 
         Args:
             query (str): The user's question or topic to search for.
+            k (int): Number of relevant chunks to retrieve.
 
         Returns:
             str: A formatted string containing the most relevant document
@@ -431,12 +439,14 @@ class RAG_Tool:
         results = []
         found_in_cache = False
 
+        # If pruning is enabled, we fetch more candidates than requested to allow for discarding.
+        k_retrieval = max(k, 15) if self.pruner else k
+
         # 1. Search FAISS Cache first
-        k = 3
         if self.index is not None and self.index.ntotal > 0:
             # We want to use FAISS if the results are very close
             # We will fetch top k and check distances
-            distances, indices = self.index.search(query_embedding_np, k)
+            distances, indices = self.index.search(query_embedding_np, k_retrieval)
 
             # Simple threshold for FAISS L2 distance to consider it a "cache hit"
             # SentenceTransformers often output normalized embeddings where max distance is ~2.0
@@ -446,7 +456,13 @@ class RAG_Tool:
                 if indices[0][i] != -1 and distances[0][i] < 1.0:
                     doc_index = indices[0][i]
                     doc = self.documents[doc_index]
-                    valid_cache_results.append(f"From {doc['source']} (Cached):\n---\n{doc['content']}\n---")
+                    # We store structured results for pruning
+                    valid_cache_results.append({
+                        "content": doc['content'],
+                        "source": doc['source'],
+                        "id": doc['id'],
+                        "is_cached": True
+                    })
 
             if valid_cache_results:
                 logging.info("RAG FAISS Cache HIT.")
@@ -464,7 +480,7 @@ class RAG_Tool:
                 base_dir_prefix = os.path.join(self.base_dir, "")
                 chroma_results = collection.query(
                     query_embeddings=query_embedding.tolist(),
-                    n_results=k,
+                    n_results=k_retrieval,
                     where={"source": {"$contains": base_dir_prefix}}
                 )
 
@@ -475,18 +491,24 @@ class RAG_Tool:
                     # distances in chroma might be available depending on metric, usually in chroma_results['distances'][0]
 
                     for doc_text, metadata, doc_id in zip(docs, metadatas, ids):
-                        results.append(f"From {metadata['source']}:\n---\n{doc_text}\n---")
+                        results.append({
+                            "content": doc_text,
+                            "source": metadata['source'],
+                            "id": doc_id,
+                            "is_cached": False
+                        })
 
                         # Add to FAISS cache
-                        # Check if it's already in the cache first (naive check by ID could be added, but appending is fine for now)
-                        # We append the document to our list and add the embedding to FAISS
-                        doc_embedding = self.model.encode([doc_text], show_progress_bar=False)
-                        self.documents.append({
-                            "id": doc_id,
-                            "source": metadata['source'],
-                            "content": doc_text
-                        })
-                        self.index.add(np.array(doc_embedding, dtype=np.float32))
+                        if self.index is not None:
+                            # Check if it's already in the cache first (naive check by ID could be added, but appending is fine for now)
+                            # We append the document to our list and add the embedding to FAISS
+                            doc_embedding = self.model.encode([doc_text], show_progress_bar=False)
+                            self.documents.append({
+                                "id": doc_id,
+                                "source": metadata['source'],
+                                "content": doc_text
+                            })
+                            self.index.add(np.array(doc_embedding, dtype=np.float32))
 
             except Exception as e:
                 logging.error(f"Error querying ChromaDB: {e}")
@@ -495,4 +517,34 @@ class RAG_Tool:
         if not results:
             return "I could not find any relevant information in the knowledge base to answer your question."
 
-        return "\n\n".join(results)
+        # 3. Pruning logic
+        if self.pruner:
+            logging.info(f"Pruning {len(results)} RAG candidates...")
+            # Prepare chunks for pruner
+            chunks_to_grade = [{"id": res["id"], "content": res["content"]} for res in results]
+            grades = await self.pruner.prune_chunks(query, chunks_to_grade)
+
+            pruned_results = []
+            for i, res in enumerate(results):
+                # Always keep top K reranked chunks, or chunks above the pruning threshold
+                grade_raw = grades.get(str(res["id"]), 1)
+                try:
+                    grade = int(grade_raw)
+                except (ValueError, TypeError):
+                    grade = 1
+
+                if i < self.keep_top_k or grade >= self.pruning_threshold:
+                    pruned_results.append(res)
+                else:
+                    logging.debug(f"Pruned chunk {res['id']} with grade {grade}")
+
+            logging.info(f"RAG Pruning complete: {len(results)} -> {len(pruned_results)} chunks.")
+            results = pruned_results
+
+        # 4. Format final results
+        formatted_results = []
+        for res in results:
+            cached_str = " (Cached)" if res.get("is_cached") else ""
+            formatted_results.append(f"From {res['source']}{cached_str}:\n---\n{res['content']}\n---")
+
+        return "\n\n".join(formatted_results[:k])

--- a/pipecatapp/utils/rag_pruner.py
+++ b/pipecatapp/utils/rag_pruner.py
@@ -1,0 +1,92 @@
+import logging
+import json
+import re
+from typing import List, Dict, Any
+from pipecatapp.llm_clients import ExternalLLMClient
+
+class RAGPruner:
+    """
+    A context pruner for RAG that uses a small LLM to grade retrieved chunks.
+    Inspired by Kapa.ai's blog post on pruning RAG context.
+    """
+    def __init__(self, llm_client: ExternalLLMClient):
+        self.llm_client = llm_client
+
+    async def prune_chunks(self, query: str, chunks: List[Dict[str, Any]]) -> Dict[str, int]:
+        """
+        Grades each chunk on a scale of 1-5 based on its relevance to the query.
+
+        Args:
+            query: The user's question.
+            chunks: A list of dictionaries containing 'id' and 'content'.
+
+        Returns:
+            A dictionary mapping chunk IDs to their numerical grade (1-5).
+        """
+        if not chunks:
+            return {}
+
+        prompt = self._construct_grading_prompt(query, chunks)
+        response_text = await self.llm_client.process_text(prompt)
+
+        return self._parse_grading_response(response_text, chunks)
+
+    def _construct_grading_prompt(self, query: str, chunks: List[Dict[str, Any]]) -> str:
+        chunks_text = ""
+        for chunk in chunks:
+            chunks_text += f"ID: {chunk['id']}\nContent: {chunk['content']}\n\n"
+
+        prompt = f"""
+You are an expert at evaluating the relevance of documentation for answering technical questions.
+Your task is to grade a set of retrieved document chunks based on how much they contribute to answering a specific question.
+
+QUESTION: {query}
+
+RETRIEVED CHUNKS:
+{chunks_text}
+
+Use the following 5-level scale for grading:
+
+5: ESSENTIAL - The answer cannot be produced without this chunk, whether it answers directly or is a definition/prerequisite.
+4: CONTRIBUTING - Supplies something a complete answer needs in combination with other chunks.
+3: SUPPORTING - On topic and plausibly useful, but the answer is likely complete without it.
+2: TANGENTIAL - Same domain or shared terminology, but no concrete contribution.
+1: UNRELATED - No meaningful connection.
+
+Analyze all chunks together as a set. Chunks that depend on each other should both receive high grades if their combination is needed.
+
+Respond ONLY with a JSON object where the keys are the chunk IDs and the values are the numerical grades (1-5).
+Example: {{"chunk_1": 5, "chunk_2": 2}}
+"""
+        return prompt.strip()
+
+    def _parse_grading_response(self, response_text: str, chunks: List[Dict[str, Any]]) -> Dict[str, int]:
+        try:
+            # Attempt to extract JSON if the LLM added markdown or chatter
+            json_match = re.search(r"(\{.*?\})", response_text, re.DOTALL)
+            if json_match:
+                grades = json.loads(json_match.group(1))
+            else:
+                grades = json.loads(response_text)
+
+            # Ensure all IDs are present and values are valid integers
+            result = {}
+            for chunk in chunks:
+                chunk_id = str(chunk['id'])
+                # Try both original ID and string ID in case LLM converted it
+                grade = grades.get(chunk_id)
+                if grade is None:
+                    grade = grades.get(str(chunk['id']))
+
+                if grade is None:
+                    grade = 1 # Default to 1 if missing
+
+                try:
+                    result[chunk_id] = int(grade)
+                except (ValueError, TypeError):
+                    result[chunk_id] = 1
+            return result
+        except Exception as e:
+            logging.error(f"Failed to parse RAG pruner response: {e}. Response was: {response_text}")
+            # Fallback: give everything a safe grade of 3 if parsing fails
+            return {str(chunk['id']): 3 for chunk in chunks}


### PR DESCRIPTION
Implemented a RAG context pruning mechanism inspired by Kapa.ai. A cheap LLM grades retrieved chunks on a 5-level scale, and only the most relevant are passed to the expensive generator. This cuts token usage and improves answer quality. The entire RAG pipeline was converted to async to support non-blocking LLM calls during pruning.

---
*PR created automatically by Jules for task [5971675545931631695](https://jules.google.com/task/5971675545931631695) started by @LokiMetaSmith*