### PR TITLE
Fix thinc build failure on Python 3.13

### DIFF
--- a/pipecatapp/requirements.txt
+++ b/pipecatapp/requirements.txt
@@ -53,7 +53,7 @@ requests
 sentence-transformers
 soundfile
 spacy>=3.8.0,<4.0.0
-thinc>=8.3.13
+thinc>=8.3.13,<8.4.0
 transformers
 ultralytics
 uvicorn


### PR DESCRIPTION
This PR resolves a build failure during the deployment of `pipecatapp` on Python 3.13. The failure occurred when `pip` attempted to compile `thinc 9.1.1` from source, resulting in the error `'ndarray' is not a type identifier`.

By pinning `thinc` to the `>=8.3.13,<8.4.0` range, we ensure that `pip` selects a version that provides pre-compiled binary wheels for Python 3.13, avoiding the source build issue and maintaining compatibility with the project's `spacy` requirement.

---
*PR created automatically by Jules for task [6615116258220132575](https://jules.google.com/task/6615116258220132575) started by @LokiMetaSmith*