### PR TITLE
Fix Python 3.13 compatibility for misaki dependency

### DIFF
--- a/ansible/roles/python_deps/files/requirements.txt
+++ b/ansible/roles/python_deps/files/requirements.txt
@@ -22,7 +22,7 @@ https://github.com/KittenML/KittenTTS/releases/download/0.1/kittentts-0.1.0-py3-
 langchain
 langchain-community
 langchain-core
-misaki[en]>=0.9.4
+misaki[en] @ git+https://github.com/hexgrad/misaki.git@fba1236595f2d2bf21d414ba6e57d25256afada3
 python-nomad
 num2words
 numpy

--- a/ansible/roles/tool_server/Dockerfile
+++ b/ansible/roles/tool_server/Dockerfile
@@ -46,7 +46,7 @@ RUN pip install --no-cache-dir \
     faster-whisper==1.2.1 \
     fugashi-plus \
     kittentts \
-    "misaki[en]>=0.9.4" \
+    "misaki[en] @ git+https://github.com/hexgrad/misaki.git@fba1236595f2d2bf21d414ba6e57d25256afada3" \
     num2words \
     onnxruntime \
     opencv-python-headless \

--- a/pipecatapp/requirements.txt
+++ b/pipecatapp/requirements.txt
@@ -24,7 +24,7 @@ https://github.com/KittenML/KittenTTS/releases/download/0.1/kittentts-0.1.0-py3-
 langchain
 langchain-community
 langchain-core
-misaki[en]
+misaki[en] @ git+https://github.com/hexgrad/misaki.git@fba1236595f2d2bf21d414ba6e57d25256afada3
 python-nomad
 num2words
 numpy


### PR DESCRIPTION
Fixed the cluster bootstrap failure by updating the `misaki` dependency to install from GitHub instead of PyPI. Current PyPI versions (up to 0.9.4) have metadata that prevents installation on Python 3.13, which caused the bootstrap process to fail during dependency installation. By pointing to the GitHub repository, `pip` can correctly resolve and install the package on Python 3.13. The change was applied consistently across the main application requirements, the Ansible role dependencies, and the tool server's Dockerfile. Dependency resolution was verified via `pip install --dry-run` and structural test integrity was confirmed via `pytest --collect-only`.

---
*PR created automatically by Jules for task [3411415748359824649](https://jules.google.com/task/3411415748359824649) started by @LokiMetaSmith*