### PR TITLE
Fix 'avg_tokens' undefined error in Ansible tasks

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -996,25 +996,13 @@
     rpc_pool_job_name: "llamacpp-rpc-pool"
     # DO NOT redefine ansible_facts['memtotal_mb'] here
     # The benchmark data calculation can stay if needed, adjust variable names if necessary
-    benchmark_data_for_expert: >-
-      {{
-        (benchmark_results |
-        selectattr('model', 'in', expert_models[current_expert] | map(attribute='filename') | list) |
-        list) | default([])
-      }}
-      avg_tokens: >-
-      {{
-        (benchmark_data_for_expert | map(attribute='tokens_per_second') | list | sum / (benchmark_data_for_expert | length))
-        if (benchmark_data_for_expert | length > 0) else 0
-      }}
-    # expert_tags definition can stay, but ensure it doesn't redefine ansible_facts['memtotal_mb']
-    current_expert_tags: >-
-      [
-        "expert={{ current_expert }}",
-        "avg_tps={{ avg_tokens | float | round(2) }}",
-        "memory_mb={{ ansible_facts['memtotal_mb'] }}", # Access global fact directly
-        "models={{ model_list | map(attribute='filename') | join(',') }}"
-      ]
+    benchmark_data_for_expert: "{{ (benchmark_results | default([])) | selectattr('status', 'equalto', 'success') | selectattr('model', 'in', expert_models[current_expert] | map(attribute='filename') | list) | list }}"
+    avg_tokens: "{{ (benchmark_data_for_expert | map(attribute='tokens_per_second') | list | sum / benchmark_data_for_expert | length) if benchmark_data_for_expert | length > 0 else 0 }}"
+    current_expert_tags:
+      - "expert={{ current_expert }}"
+      - "avg_tps={{ avg_tokens | float | round(2) }}"
+      - "memory_mb={{ ansible_facts['memtotal_mb'] }}"
+      - "models={{ model_list | map(attribute='filename') | join(',') }}"
 
 - name: Fallback and warn if no verified experts found
   ansible.builtin.debug:


### PR DESCRIPTION
Fixed a bug in the Ansible task "Create expert job files from template for verified models" where the `avg_tokens` variable was undefined due to malformed YAML indentation. I also improved the benchmark data selection by filtering for successful results and cleaned up the tag formatting.

---
*PR created automatically by Jules for task [11687352085701112919](https://jules.google.com/task/11687352085701112919) started by @LokiMetaSmith*