### PR TITLE
fix(ansible): resolve 'avg_tokens' undefined and Nomad API timeout er…

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -1048,8 +1048,8 @@
 
 - name: Wait for Nomad API to be ready
   ansible.builtin.uri:
-    url: "{{ nomad_protocol | default('https') }}://{{ cluster_ip }}:{{ nomad_http_port }}/v1/status/leader"
-    validate_certs: yes
+    url: "{{ nomad_protocol | default('https') }}://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}/v1/agent/self"
+    validate_certs: "{{ 'yes' if nomad_cli_cert_stat.stat.exists else 'no' }}"
     ca_path: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
     method: GET
     status_code: 200
@@ -1057,7 +1057,7 @@
     client_key: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.key.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
   register: nomad_api_status
   until: nomad_api_status.status == 200
-  retries: 12 # Total wait time = retries * delay = 60 seconds
+  retries: 24 # Total wait time = retries * delay = 120 seconds
   delay: 5   # Wait 5 seconds between retries
   ignore_errors: false
 


### PR DESCRIPTION
…rors

This commit fixes two critical failures in the 'pipecatapp' role:
1. Corrected indentation in the 'vars' block of the expert job creation task. Previously, 'avg_tokens' was incorrectly swallowed into the string value of 'benchmark_data_for_expert' due to a malformed scalar block.
2. Made the 'Wait for Nomad API to be ready' task more robust:
   - Switched from '/v1/status/leader' to '/v1/agent/self' for local readiness.
   - Added conditional certificate validation based on CLI cert existence.
   - Increased retries from 12 to 24 (120s total) to handle slower startup.
   - Added fallback defaults for 'cluster_ip' and 'nomad_http_port'.

These changes ensure successful cluster bootstrap and expert model deployment.