### PR TITLE
Run Telegraf asynchronously and fix World Model Service YAML parsing

### DIFF
--- a/ansible/roles/telegraf/tasks/main.yaml
+++ b/ansible/roles/telegraf/tasks/main.yaml
@@ -69,5 +69,7 @@
     NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
     NOMAD_CLIENT_CERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.cert.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
     NOMAD_CLIENT_KEY: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.key.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
+  async: 45
+  poll: 0
   changed_when: true
   become: no

--- a/ansible/roles/world_model_service/tasks/main.yaml
+++ b/ansible/roles/world_model_service/tasks/main.yaml
@@ -64,7 +64,8 @@
   ansible.builtin.command:
     cmd: "/opt/world_model_service/debug_world_model.sh"
   environment:
-    DEBUG_KEEP_ALIVE: "{{ 'true' if watch_target is defined and (watch_target in ansible_role_name or watch_target in 'World Model Service : Run debug script (verify container)') else 'false' }}"  become: true
+    DEBUG_KEEP_ALIVE: "{{ 'true' if watch_target is defined and (watch_target in ansible_role_name or watch_target in 'World Model Service : Run debug script (verify container)') else 'false' }}"
+  become: true
   register: debug_output
   changed_when: false
   failed_when: false


### PR DESCRIPTION
Configured the Telegraf task to execute asynchronously via both Ansible's native async/poll options and Nomad's detach flag. Also resolved a YAML parsing error in the world_model_service task file, enabling clean compilation and execution of the service playbooks.

---
*PR created automatically by Jules for task [183770622414321509](https://jules.google.com/task/183770622414321509) started by @LokiMetaSmith*