### PR TITLE
User-Friendly DNS & TLS Split-Horizon Implementation

### DIFF
--- a/ansible/roles/headscale/defaults/main.yaml
+++ b/ansible/roles/headscale/defaults/main.yaml
@@ -5,3 +5,5 @@ headscale_listen_addr: "0.0.0.0"
 headscale_namespace: "default"
 # We use 100.64.0.0/10 (CGNAT) to avoid conflict with the legacy 10.0.0.0/24 network during migration.
 headscale_ip_prefix: "100.64.0.0/10"
+headscale_nameservers:
+  - 1.1.1.1

--- a/ansible/roles/headscale/templates/config.yaml.j2
+++ b/ansible/roles/headscale/templates/config.yaml.j2
@@ -34,6 +34,8 @@ unix_socket_permission: "0770"
 
 dns_config:
   magic_dns: true
-  base_domain: example.com
+  base_domain: {{ cluster_domain | default('local.mesh') }}
   nameservers:
-    - 1.1.1.1
+    {% for ns in headscale_nameservers | default(['1.1.1.1']) %}
+    - {{ ns }}
+    {% endfor %}

--- a/ansible/roles/traefik/defaults/main.yml
+++ b/ansible/roles/traefik/defaults/main.yml
@@ -1,2 +1,8 @@
 nomad_volumes_dir: /opt/nomad/volumes
 nomad_jobs_dir: /opt/nomad/jobs
+
+traefik_bind_address: "{{ cluster_ip }}"
+traefik_acme_enabled: false
+traefik_acme_email: "admin@{{ cluster_domain | default('local.mesh') }}"
+traefik_acme_dns_provider: "cloudflare"
+traefik_acme_dns_credentials: {}

--- a/ansible/roles/traefik/tasks/main.yml
+++ b/ansible/roles/traefik/tasks/main.yml
@@ -16,6 +16,16 @@
   loop:
     - "{{ nomad_jobs_dir }}"
 
+- name: Create Traefik ACME directory
+  ansible.builtin.file:
+    path: "{{ nomad_volumes_dir | default('/opt/nomad/volumes') }}/traefik"
+    state: directory
+    owner: "{{ target_user | default('pipecatapp') }}"
+    group: "{{ target_user | default('pipecatapp') }}"
+    mode: '0700'
+  become: yes
+  when: traefik_acme_enabled | bool
+
 - name: Template Traefik Nomad job
   ansible.builtin.template:
     src: traefik.nomad.j2

--- a/ansible/roles/traefik/templates/headscale-router.yaml.j2
+++ b/ansible/roles/traefik/templates/headscale-router.yaml.j2
@@ -5,7 +5,10 @@ http:
       service: headscale
       entryPoints:
         - websecure
-      tls: {}
+      tls:
+        {% if traefik_acme_enabled | bool %}
+        certResolver: dnsresolver
+        {% endif %}
 
   services:
     headscale:

--- a/ansible/roles/traefik/templates/traefik.nomad.j2
+++ b/ansible/roles/traefik/templates/traefik.nomad.j2
@@ -31,6 +31,14 @@ job "traefik" {
     task "traefik" {
       driver = "docker"
 
+      {% if traefik_acme_enabled | bool and traefik_acme_dns_credentials is defined and traefik_acme_dns_credentials | length > 0 %}
+      env {
+        {% for key, val in traefik_acme_dns_credentials.items() %}
+        {{ key }} = {{ val | to_json }}
+        {% endfor %}
+      }
+      {% endif %}
+
       config {
         image        = "traefik:v3.0"
         network_mode = "host"
@@ -38,6 +46,9 @@ job "traefik" {
           "local/traefik.yml:/etc/traefik/traefik.yml",
           "local/dynamic:/etc/traefik/dynamic",
           "local/certs:/etc/traefik/certs",
+          {% if traefik_acme_enabled | bool %}
+          "{{ nomad_volumes_dir | default('/opt/nomad/volumes') }}/traefik:/etc/traefik/acme",
+          {% endif %}
         ]
       }
 
@@ -45,11 +56,16 @@ job "traefik" {
         data = <<-EOF
 entryPoints:
   web:
-    address: ":{{ traefik_http_port | default(80) }}"
+    address: "{{ traefik_bind_address | default('0.0.0.0') }}:{{ traefik_http_port | default(80) }}"
   websecure:
-    address: ":{{ traefik_https_port | default(443) }}"
+    address: "{{ traefik_bind_address | default('0.0.0.0') }}:{{ traefik_https_port | default(443) }}"
+    {% if traefik_acme_enabled | bool %}
+    http:
+      tls:
+        certResolver: dnsresolver
+    {% endif %}
   traefik:
-    address: ":{{ traefik_api_port | default(8080) }}"
+    address: "{{ traefik_bind_address | default('0.0.0.0') }}:{{ traefik_api_port | default(8080) }}"
 
 api:
   dashboard: true
@@ -65,6 +81,16 @@ providers:
   file:
     directory: "/etc/traefik/dynamic"
     watch: true
+
+{% if traefik_acme_enabled | bool %}
+certificatesResolvers:
+  dnsresolver:
+    acme:
+      email: "{{ traefik_acme_email }}"
+      storage: "/etc/traefik/acme/acme.json"
+      dnsChallenge:
+        provider: "{{ traefik_acme_dns_provider }}"
+{% endif %}
 EOF
 
         destination = "local/traefik.yml"


### PR DESCRIPTION
This change implements key architecture lessons from a split-horizon DNS/VPN setup (inspired by tuxnet.dev) to make the internal DNS and TLS implementation more robust, flexible, secure, and user-friendly.

Specifically:
1. Dynamic Base Domain for MagicDNS: Replaced hardcoded `example.com` in Headscale with `{{ cluster_domain | default('local.mesh') }}`, aligning MagicDNS records perfectly with cluster routing.
2. User-Defined Nameservers: Added `headscale_nameservers` as a customizable list variable (defaulting to `1.1.1.1`) to configure Headscale MagicDNS resolvers.
3. Strict Traefik Interface Binding: Introduced `traefik_bind_address` and configured Traefik to bind strictly to the Tailscale mesh interface (`{{ cluster_ip }}`), providing a robust access control and security layer.
4. Native Let's Encrypt ACME DNS-01 Challenge Integration: Added a toggle system `traefik_acme_enabled` that dynamically provisions a persistent host directory `/opt/nomad/volumes/traefik` for secure `acme.json` storage, binds the `dnsresolver` to the `websecure` entrypoint, configures `certificatesResolvers`, and passes dynamic DNS API credentials into the container environment.

---
*PR created automatically by Jules for task [13057181267170784120](https://jules.google.com/task/13057181267170784120) started by @LokiMetaSmith*