### PR TITLE
Graceful Btrfs Snapshot Fallback and Skipped Setup Handling

### DIFF
--- a/ansible/roles/btrfs_snapshot/defaults/main.yaml
+++ b/ansible/roles/btrfs_snapshot/defaults/main.yaml
@@ -5,6 +5,10 @@ btrfs_active_subvolume: "/btrfs_root/active"
 btrfs_device: "/dev/vdb"  # can be overridden in inventory/host_vars/group_vars
 btrfs_format_device: false
 
+# Fallback sparse file details if physical device is unavailable
+btrfs_loop_file: "/opt/btrfs_root.img"
+btrfs_loop_file_size: "5G"
+
 # Directories to back up/protect and sync to the Btrfs active subvolume
 btrfs_protected_dirs:
   - "/etc/nomad.d"

--- a/ansible/roles/btrfs_snapshot/tasks/main.yaml
+++ b/ansible/roles/btrfs_snapshot/tasks/main.yaml
@@ -4,6 +4,24 @@
     name: btrfs-progs
     state: present
   become: yes
+  failed_when: false
+
+- name: Check if btrfs command is available
+  ansible.builtin.command: which btrfs
+  register: btrfs_cmd_check
+  failed_when: false
+  changed_when: false
+
+- name: Check if Btrfs is supported by the kernel
+  ansible.builtin.shell: "grep -q btrfs /proc/filesystems"
+  register: btrfs_kernel_support
+  failed_when: false
+  changed_when: false
+  become: yes
+
+- name: Set btrfs_supported fact
+  ansible.builtin.set_fact:
+    btrfs_supported: "{{ btrfs_cmd_check.rc == 0 and btrfs_kernel_support.rc == 0 }}"
 
 - name: Check if btrfs mount point directory exists
   ansible.builtin.file:
@@ -20,21 +38,135 @@
   changed_when: false
   become: yes
 
-- name: Create Btrfs filesystem on device if requested
+- name: Set initial btrfs_enabled fact
+  ansible.builtin.set_fact:
+    btrfs_enabled: "{{ findmnt_result.rc == 0 and findmnt_result.stdout == 'btrfs' }}"
+
+- name: Check if btrfs device exists and is a block device
+  ansible.builtin.stat:
+    path: "{{ btrfs_device }}"
+  register: btrfs_device_stat
+  become: yes
+  when: not btrfs_enabled
+
+- name: Check physical device filesystem type
+  ansible.builtin.command: "blkid -o value -s TYPE {{ btrfs_device }}"
+  register: physical_device_fs_type
+  failed_when: false
+  changed_when: false
+  become: yes
+  when:
+    - not btrfs_enabled
+    - btrfs_supported
+    - btrfs_device_stat.stat.exists | default(false)
+    - btrfs_device_stat.stat.isblk | default(false)
+
+- name: Create Btrfs filesystem on physical device if requested and suitable
   ansible.builtin.command:
     cmd: "mkfs.btrfs -f {{ btrfs_device }}"
-  when:
-    - findmnt_result.rc != 0
-    - btrfs_format_device | default(false) | bool
   become: yes
+  when:
+    - not btrfs_enabled
+    - btrfs_supported
+    - btrfs_device_stat.stat.exists | default(false)
+    - btrfs_device_stat.stat.isblk | default(false)
+    - physical_device_fs_type.stdout != 'btrfs'
+    - btrfs_format_device | default(false) | bool
 
-- name: Mount Btrfs device
-  ansible.builtin.mount:
+- name: Attempt to mount physical Btrfs device
+  ansible.posix.mount:
     path: "{{ btrfs_subvolume_path }}"
     src: "{{ btrfs_device }}"
     fstype: btrfs
     state: mounted
+  register: mount_physical_result
+  failed_when: false
   become: yes
+  when:
+    - not btrfs_enabled
+    - btrfs_supported
+    - btrfs_device_stat.stat.exists | default(false)
+    - btrfs_device_stat.stat.isblk | default(false)
+    - (physical_device_fs_type.stdout == 'btrfs' or btrfs_format_device | default(false) | bool)
+
+- name: Update btrfs_enabled fact if physical mount succeeded
+  ansible.builtin.set_fact:
+    btrfs_enabled: true
+  when:
+    - not btrfs_enabled
+    - mount_physical_result is succeeded
+    - mount_physical_result is not skipped
+
+- name: Ensure loop fallback file directory exists
+  ansible.builtin.file:
+    path: "{{ btrfs_loop_file | dirname }}"
+    state: directory
+    mode: '0755'
+  become: yes
+  when:
+    - not btrfs_enabled
+    - btrfs_supported
+
+- name: Create sparse fallback file
+  ansible.builtin.command:
+    cmd: "truncate -s {{ btrfs_loop_file_size | default('5G') }} {{ btrfs_loop_file }}"
+    creates: "{{ btrfs_loop_file }}"
+  become: yes
+  when:
+    - not btrfs_enabled
+    - btrfs_supported
+
+- name: Check loop file filesystem type
+  ansible.builtin.command: "blkid -o value -s TYPE {{ btrfs_loop_file }}"
+  register: loop_file_fs_type
+  failed_when: false
+  changed_when: false
+  become: yes
+  when:
+    - not btrfs_enabled
+    - btrfs_supported
+
+- name: Format loop file as Btrfs if unformatted
+  ansible.builtin.command:
+    cmd: "mkfs.btrfs -f {{ btrfs_loop_file }}"
+  become: yes
+  when:
+    - not btrfs_enabled
+    - btrfs_supported
+    - loop_file_fs_type.stdout | default('') != 'btrfs'
+
+- name: Mount loop Btrfs device
+  ansible.posix.mount:
+    path: "{{ btrfs_subvolume_path }}"
+    src: "{{ btrfs_loop_file }}"
+    fstype: btrfs
+    opts: loop
+    state: mounted
+  register: mount_loop_result
+  failed_when: false
+  become: yes
+  when:
+    - not btrfs_enabled
+    - btrfs_supported
+
+- name: Update btrfs_enabled fact if loop mount succeeded
+  ansible.builtin.set_fact:
+    btrfs_enabled: true
+  when:
+    - not btrfs_enabled
+    - mount_loop_result is succeeded
+    - mount_loop_result is not skipped
+
+- name: Warn operator if Btrfs recovery snapshotting is unavailable
+  ansible.builtin.debug:
+    msg:
+      - "****************************************************************"
+      - "WARNING: Btrfs recovery snapshotting is unavailable on this node!"
+      - "Reason: Btrfs kernel/tool support is missing, or formatting/mounting"
+      - "failed for both physical device and fallback loop device."
+      - "Pre-deployment snapshots and OS recovery will be skipped."
+      - "****************************************************************"
+  when: not btrfs_enabled
 
 - name: Ensure active subvolume exists
   ansible.builtin.command:
@@ -43,6 +175,7 @@
   failed_when: false
   changed_when: "'Created subvolume' in subvol_create_result.stdout"
   become: yes
+  when: btrfs_enabled
 
 - name: Ensure snapshots directory exists
   ansible.builtin.file:
@@ -50,6 +183,7 @@
     state: directory
     mode: '0755'
   become: yes
+  when: btrfs_enabled
 
 - name: Ensure target scripts directory exists
   ansible.builtin.file:
@@ -81,12 +215,14 @@
   loop: "{{ btrfs_protected_dirs }}"
   become: yes
   changed_when: true
+  when: btrfs_enabled
 
 - name: Create pre-deployment snapshot
   ansible.builtin.command:
     cmd: "btrfs subvolume snapshot {{ btrfs_active_subvolume }} {{ btrfs_snapshot_dir }}/pre-deploy-{{ ansible_date_time.iso8601_basic_short | default('latest') }}"
   become: yes
   register: snapshot_result
+  when: btrfs_enabled
 
 - name: Symlink current snapshot as pre-deploy-latest
   ansible.builtin.file:
@@ -94,5 +230,9 @@
     dest: "{{ btrfs_snapshot_dir }}/pre-deploy-latest"
     state: link
     force: yes
-  when: snapshot_result.rc == 0
+  when:
+    - btrfs_enabled
+    - snapshot_result is defined
+    - snapshot_result.rc is defined
+    - snapshot_result.rc == 0
   become: yes

--- a/scripts/recover_os.py
+++ b/scripts/recover_os.py
@@ -21,6 +21,22 @@ def check_btrfs():
         return False
     return True
 
+def check_btrfs_mount():
+    """Checks if the BTRFS_SUBVOLUME_PATH is a valid Btrfs mount point."""
+    try:
+        output = subprocess.check_output(
+            ["findmnt", "-n", "-o", "FSTYPE", BTRFS_SUBVOLUME_PATH],
+            text=True,
+            stderr=subprocess.DEVNULL
+        ).strip()
+        if output == "btrfs":
+            return True
+    except Exception:
+        pass
+    print(f"Error: {BTRFS_SUBVOLUME_PATH} is not mounted as a Btrfs filesystem.")
+    print("Pre-deployment OS recovery/snapshotting is not available on this node.")
+    return False
+
 def get_protected_dirs():
     """Loads configuration detailing which directories are protected."""
     if os.path.exists(CONFIG_FILE):
@@ -35,7 +51,7 @@ def get_protected_dirs():
 
 def create_snapshot():
     """Syncs protected directories to active subvolume, then creates a snapshot."""
-    if not check_btrfs():
+    if not check_btrfs() or not check_btrfs_mount():
         return False
 
     protected_dirs = get_protected_dirs()
@@ -75,7 +91,7 @@ def create_snapshot():
 
 def list_snapshots():
     """Lists existing Btrfs snapshots."""
-    if not check_btrfs():
+    if not check_btrfs() or not check_btrfs_mount():
         return False
 
     print("\nAvailable Pre-deployment Snapshots:")
@@ -96,12 +112,12 @@ def list_snapshots():
 
 def rollback_snapshot(target=None):
     """Rolls back the active subvolume and restores the protected folders."""
-    if not check_btrfs():
+    if not check_btrfs() or not check_btrfs_mount():
         return False
 
     if not target:
         snapshots = list_snapshots()
-        if not snapshots:
+        if not snapshots or not isinstance(snapshots, list):
             print("No snapshots available to rollback.")
             return False
 
@@ -194,13 +210,18 @@ def main():
             print("\nExiting.")
             sys.exit(0)
     else:
+        success = False
         if args.create:
-            create_snapshot()
+            success = create_snapshot()
         elif args.list:
-            list_snapshots()
+            res = list_snapshots()
+            success = isinstance(res, list)
         elif args.rollback:
             target = "pre-deploy-latest" if args.rollback == "latest" else args.rollback
-            rollback_snapshot(target)
+            success = rollback_snapshot(target)
+
+        if not success:
+            sys.exit(1)
 
 if __name__ == "__main__":
     if os.getuid() != 0:


### PR DESCRIPTION
This pull request implements a highly robust and fail-safe mechanism for the btrfs_snapshot role and the recover_os.py utility. It dynamically auto-detects kernel Btrfs support, physical device suitability, and automatically falls back to a sparse file loopback device if the dedicated block device (/dev/vdb) is unavailable, already in use, or not present (such as in local containers or sandbox testing). If Btrfs is entirely unsupported on the system, the role issues a highly visible operator warning and safely bypasses all snapshot/subvolume tasks so bootstrap can finish successfully. The recover_os.py utility has also been updated to exit with code 1 and clean messages on nodes with disabled Btrfs support.

---
*PR created automatically by Jules for task [9573236451245567636](https://jules.google.com/task/9573236451245567636) started by @LokiMetaSmith*