### PR TITLE
Fix Btrfs snapshot synchronization and skip NFS mounts

### DIFF
--- a/ansible/roles/btrfs_snapshot/tasks/main.yaml
+++ b/ansible/roles/btrfs_snapshot/tasks/main.yaml
@@ -208,21 +208,20 @@
 
 - name: Synchronize current state of protected directories to active subvolume
   ansible.builtin.shell: |
-    mkdir -p "{{ btrfs_active_subvolume }}{{ item }}"
     if [ -d "{{ item }}" ]; then
-      rsync -a --delete \
-        --exclude=".venv/" \
-        --exclude="venv/" \
-        --exclude="node_modules/" \
-        --exclude="__pycache__/" \
-        --exclude=".pytest_cache/" \
-        --exclude=".mypy_cache/" \
-        --exclude="target/" \
-        "{{ item }}/" "{{ btrfs_active_subvolume }}{{ item }}/"
       if findmnt -n -o FSTYPE "{{ item }}" 2>/dev/null | grep -q 'nfs'; then
         echo "Skipping NFS mount {{ item }} on client node"
       else
-        rsync -a --delete "{{ item }}/" "{{ btrfs_active_subvolume }}{{ item }}/"
+        mkdir -p "{{ btrfs_active_subvolume }}{{ item }}"
+        rsync -a --delete \
+          --exclude=".venv/" \
+          --exclude="venv/" \
+          --exclude="node_modules/" \
+          --exclude="__pycache__/" \
+          --exclude=".pytest_cache/" \
+          --exclude=".mypy_cache/" \
+          --exclude="target/" \
+          "{{ item }}/" "{{ btrfs_active_subvolume }}{{ item }}/"
       fi
     fi
   loop: "{{ btrfs_protected_dirs }}"

--- a/scripts/recover_os.py
+++ b/scripts/recover_os.py
@@ -67,6 +67,18 @@ def create_snapshot():
     ]
     for p_dir in protected_dirs:
         if os.path.exists(p_dir):
+            try:
+                fstype = subprocess.check_output(
+                    ["findmnt", "-n", "-o", "FSTYPE", p_dir],
+                    text=True,
+                    stderr=subprocess.DEVNULL
+                ).strip()
+                if "nfs" in fstype:
+                    print(f"  Skipping NFS mount {p_dir} on client node")
+                    continue
+            except Exception:
+                pass
+
             target_sub_dir = f"{BTRFS_ACTIVE_SUBVOLUME}{p_dir}"
             os.makedirs(target_sub_dir, exist_ok=True)
             print(f"  Syncing {p_dir} -> {target_sub_dir}")
@@ -177,6 +189,18 @@ def rollback_snapshot(target=None):
         ]
         print("Restoring protected directories from snapshot back to system...")
         for p_dir in protected_dirs:
+            try:
+                fstype = subprocess.check_output(
+                    ["findmnt", "-n", "-o", "FSTYPE", p_dir],
+                    text=True,
+                    stderr=subprocess.DEVNULL
+                ).strip()
+                if "nfs" in fstype:
+                    print(f"  Skipping restore for NFS mount {p_dir} on client node")
+                    continue
+            except Exception:
+                pass
+
             snapshot_source_dir = f"{BTRFS_ACTIVE_SUBVOLUME}{p_dir}"
             if os.path.exists(snapshot_source_dir):
                 print(f"  Restoring {snapshot_source_dir} -> {p_dir}")

--- a/tests/unit/test_recover_os.py
+++ b/tests/unit/test_recover_os.py
@@ -70,3 +70,80 @@ def test_recover_os_excludes_in_rollback():
                 assert "--exclude=target/" in args
                 assert "--delete" in args
         assert called, "rsync was not called during rollback restoration"
+
+
+def test_recover_os_nfs_skip_in_rsync():
+    """Test that recover_os.py skips NFS mounted folders during snapshot creation."""
+    with patch("recover_os.check_btrfs", return_value=True), \
+         patch("recover_os.check_btrfs_mount", return_value=True), \
+         patch("recover_os.get_protected_dirs", return_value=["/opt/cluster-infra", "/opt/unified_fs_backend"]), \
+         patch("os.path.exists", return_value=True), \
+         patch("os.path.islink", return_value=True), \
+         patch("os.remove"), \
+         patch("os.symlink"), \
+         patch("os.makedirs") as mock_makedirs, \
+         patch("subprocess.check_call") as mock_check_call, \
+         patch("subprocess.check_output") as mock_check_output:
+
+        # Let's mock check_output such that /opt/cluster-infra returns 'ext4' and /opt/unified_fs_backend returns 'nfs4'
+        def check_output_side_effect(args, **kwargs):
+            cmd_str = " ".join(args)
+            if "/opt/cluster-infra" in cmd_str:
+                return "ext4\n"
+            elif "/opt/unified_fs_backend" in cmd_str:
+                return "nfs4\n"
+            return ""
+
+        mock_check_output.side_effect = check_output_side_effect
+
+        # Call create_snapshot
+        recover_os.create_snapshot()
+
+        # Verify that rsync was called for /opt/cluster-infra but NOT for /opt/unified_fs_backend
+        synced_dirs = []
+        for call in mock_check_call.call_args_list:
+            args = call[0][0]
+            if args[0] == "rsync":
+                # The source dir is one of the last args
+                synced_dirs.append(args[-2])
+
+        assert "/opt/cluster-infra/" in synced_dirs
+        assert "/opt/unified_fs_backend/" not in synced_dirs
+
+
+def test_recover_os_nfs_skip_in_rollback():
+    """Test that recover_os.py skips NFS mounted folders during snapshot rollback."""
+    with patch("recover_os.check_btrfs", return_value=True), \
+         patch("recover_os.check_btrfs_mount", return_value=True), \
+         patch("recover_os.get_protected_dirs", return_value=["/opt/cluster-infra", "/opt/unified_fs_backend"]), \
+         patch("os.path.exists", return_value=True), \
+         patch("os.makedirs") as mock_makedirs, \
+         patch("builtins.input", return_value="y"), \
+         patch("subprocess.call"), \
+         patch("subprocess.check_call") as mock_check_call, \
+         patch("subprocess.check_output") as mock_check_output:
+
+        # Let's mock check_output such that /opt/cluster-infra returns 'ext4' and /opt/unified_fs_backend returns 'nfs'
+        def check_output_side_effect(args, **kwargs):
+            cmd_str = " ".join(args)
+            if "/opt/cluster-infra" in cmd_str:
+                return "ext4\n"
+            elif "/opt/unified_fs_backend" in cmd_str:
+                return "nfs\n"
+            return ""
+
+        mock_check_output.side_effect = check_output_side_effect
+
+        # Call rollback_snapshot for target='latest'
+        recover_os.rollback_snapshot("latest")
+
+        # Verify that rsync (restore) was called for /opt/cluster-infra but NOT for /opt/unified_fs_backend
+        restored_dirs = []
+        for call in mock_check_call.call_args_list:
+            args = call[0][0]
+            if args[0] == "rsync":
+                # In rollback rsync, target is the last arg (p_dir)
+                restored_dirs.append(args[-1])
+
+        assert "/opt/cluster-infra/" in restored_dirs
+        assert "/opt/unified_fs_backend/" not in restored_dirs


### PR DESCRIPTION
Addresses the Btrfs disk space exhaustion and duplicate file backup issues on client nodes. Corrects the control flow in the Ansible role to execute exactly one rsync with exclusions for standard folders after confirming they are not NFS. Updates the OS recovery CLI tool to use findmnt defensively when creating or rolling back snapshots, skipping NFS directories. Adds mock-based unit tests to guarantee compliance and prevent regression.

---
*PR created automatically by Jules for task [17568039899887588044](https://jules.google.com/task/17568039899887588044) started by @LokiMetaSmith*