### PR TITLE
Fix Btrfs snapshot synchronization and resolve pre-deploy-latest conf…

### DIFF
--- a/ansible/roles/btrfs_snapshot/tasks/main.yaml
+++ b/ansible/roles/btrfs_snapshot/tasks/main.yaml
@@ -229,16 +229,32 @@
   changed_when: true
   when: btrfs_enabled
 
+- name: Get current timestamp from system
+  ansible.builtin.command: date +%Y%m%d%H%M%S
+  register: system_timestamp
+  changed_when: false
+  failed_when: false
+  when: btrfs_enabled
+
 - name: Create pre-deployment snapshot
   ansible.builtin.command:
-    cmd: "btrfs subvolume snapshot {{ btrfs_active_subvolume }} {{ btrfs_snapshot_dir }}/pre-deploy-{{ ansible_date_time.iso8601_basic_short | default('latest') }}"
+    cmd: "btrfs subvolume snapshot {{ btrfs_active_subvolume }} {{ btrfs_snapshot_dir }}/pre-deploy-{{ ansible_date_time.iso8601_basic_short | default(system_timestamp.stdout | default('latest')) }}"
   become: yes
   register: snapshot_result
   when: btrfs_enabled
 
+- name: Remove existing pre-deploy-latest directory/subvolume/link if exists
+  ansible.builtin.shell: |
+    if [ -e "{{ btrfs_snapshot_dir }}/pre-deploy-latest" ] || [ -L "{{ btrfs_snapshot_dir }}/pre-deploy-latest" ]; then
+      btrfs subvolume delete "{{ btrfs_snapshot_dir }}/pre-deploy-latest" 2>/dev/null || rm -rf "{{ btrfs_snapshot_dir }}/pre-deploy-latest"
+    fi
+  become: yes
+  failed_when: false
+  when: btrfs_enabled
+
 - name: Symlink current snapshot as pre-deploy-latest
   ansible.builtin.file:
-    src: "{{ btrfs_snapshot_dir }}/pre-deploy-{{ ansible_date_time.iso8601_basic_short | default('latest') }}"
+    src: "{{ btrfs_snapshot_dir }}/pre-deploy-{{ ansible_date_time.iso8601_basic_short | default(system_timestamp.stdout | default('latest')) }}"
     dest: "{{ btrfs_snapshot_dir }}/pre-deploy-latest"
     state: link
     force: yes


### PR DESCRIPTION
…licts

- Fixes control flow bug in btrfs_snapshot Ansible role where non-NFS mounts were synchronized twice, the second time without exclusions, causing disk space exhaustion.
- Adds dynamic fallback timestamps (using system date +%Y%m%d%H%M%S) when ansible_date_time is undefined/empty.
- Adds explicit deletion of any existing pre-deploy-latest directory/subvolume/link in ansible tasks before symlinking to prevent directory-to-link conversion errors.
- Updates scripts/recover_os.py to check for and gracefully skip NFS mounts using findmnt during both snapshot creation and rollback.
- Adds mock-based unit tests to tests/unit/test_recover_os.py to verify NFS mount skipping behavior during snapshots and rollbacks.