### PR TITLE
Fix Btrfs snapshot synchronization and resolve pre-deploy-latest conf…

### DIFF
--- a/ansible/roles/btrfs_snapshot/tasks/main.yaml
+++ b/ansible/roles/btrfs_snapshot/tasks/main.yaml
@@ -221,6 +221,8 @@
           --exclude=".pytest_cache/" \
           --exclude=".mypy_cache/" \
           --exclude="target/" \
+          --exclude="*.log" \
+          --exclude=".git/" \
           "{{ item }}/" "{{ btrfs_active_subvolume }}{{ item }}/"
       fi
     fi

--- a/scripts/recover_os.py
+++ b/scripts/recover_os.py
@@ -63,7 +63,9 @@ def create_snapshot():
         "--exclude=__pycache__/",
         "--exclude=.pytest_cache/",
         "--exclude=.mypy_cache/",
-        "--exclude=target/"
+        "--exclude=target/",
+        "--exclude=*.log",
+        "--exclude=.git/"
     ]
     for p_dir in protected_dirs:
         if os.path.exists(p_dir):
@@ -185,7 +187,9 @@ def rollback_snapshot(target=None):
             "--exclude=__pycache__/",
             "--exclude=.pytest_cache/",
             "--exclude=.mypy_cache/",
-            "--exclude=target/"
+            "--exclude=target/",
+            "--exclude=*.log",
+            "--exclude=.git/"
         ]
         print("Restoring protected directories from snapshot back to system...")
         for p_dir in protected_dirs:

--- a/tests/unit/test_recover_os.py
+++ b/tests/unit/test_recover_os.py
@@ -35,6 +35,8 @@ def test_recover_os_excludes_in_rsync():
                 assert "--exclude=.pytest_cache/" in args
                 assert "--exclude=.mypy_cache/" in args
                 assert "--exclude=target/" in args
+                assert "--exclude=*.log" in args
+                assert "--exclude=.git/" in args
                 assert "--delete" in args
         assert called, "rsync was not called during snapshot creation"
         assert mock_remove.called
@@ -68,6 +70,8 @@ def test_recover_os_excludes_in_rollback():
                 assert "--exclude=.pytest_cache/" in args
                 assert "--exclude=.mypy_cache/" in args
                 assert "--exclude=target/" in args
+                assert "--exclude=*.log" in args
+                assert "--exclude=.git/" in args
                 assert "--delete" in args
         assert called, "rsync was not called during rollback restoration"
 


### PR DESCRIPTION
…licts

- Fixes control flow bug in btrfs_snapshot Ansible role where non-NFS mounts were synchronized twice, the second time without exclusions, causing disk space exhaustion.
- Excludes log files (*.log) and the .git directory in both Ansible and scripts/recover_os.py to prevent Btrfs loop device exhaustion by massive active logs.
- Adds dynamic fallback timestamps (using system date +%Y%m%d%H%M%S) when ansible_date_time is undefined/empty.
- Adds explicit deletion of any existing pre-deploy-latest directory/subvolume/link in ansible tasks before symlinking to prevent directory-to-link conversion errors.
- Updates scripts/recover_os.py to check for and gracefully skip NFS mounts using findmnt during both snapshot creation and rollback.
- Adds mock-based unit tests to tests/unit/test_recover_os.py to verify NFS mount skipping behavior during snapshots and rollbacks.