### PR TITLE
Fix Btrfs snapshot synchronization, resolve pre-deploy-latest conflic…

### DIFF
--- a/ansible/roles/nfs/tasks/main.yaml
+++ b/ansible/roles/nfs/tasks/main.yaml
@@ -44,6 +44,9 @@
     - not ansible_check_mode
   become: yes
 
+- name: Flush handlers to apply NFS export settings immediately
+  ansible.builtin.meta: flush_handlers
+
 - name: Create client mount point directory
   ansible.builtin.file:
     path: /opt/unified_fs_backend


### PR DESCRIPTION
…ts, and apply NFS export flushing

- Fixes control flow bug in btrfs_snapshot Ansible role where non-NFS mounts were synchronized twice, the second time without exclusions, causing disk space exhaustion.
- Excludes log files (*.log) and the .git directory in both Ansible and scripts/recover_os.py to prevent Btrfs loop device exhaustion by massive active logs.
- Adds dynamic fallback timestamps (using system date +%Y%m%d%H%M%S) when ansible_date_time is undefined/empty.
- Adds explicit deletion of any existing pre-deploy-latest directory/subvolume/link in ansible tasks before symlinking to prevent directory-to-link conversion errors.
- Updates scripts/recover_os.py to check for and gracefully skip NFS mounts using findmnt during both snapshot creation and rollback.
- Adds mock-based unit tests to tests/unit/test_recover_os.py to verify NFS mount skipping behavior during snapshots and rollbacks.
- Inserts flush_handlers meta task immediately following starting NFS service to ensure exports are actively reloaded and applied before any clients try to mount.