### PR TITLE
Restrict NFS client mount tasks to worker nodes only

### DIFF
--- a/ansible/roles/nfs/tasks/main.yaml
+++ b/ansible/roles/nfs/tasks/main.yaml
@@ -53,6 +53,7 @@
     state: directory
     mode: '0777'
   become: yes
+  when: inventory_hostname not in groups['controller_nodes']
 
 - name: Mount NFS Share on all hosts
   ansible.posix.mount:
@@ -62,7 +63,9 @@
     opts: "noatime,nodiratime,rsize=32768,wsize=32768,tcp,timeo=15,retrans=2,async,_netdev,bg"
     state: mounted
   become: yes
-  when: not ansible_check_mode
+  when:
+    - inventory_hostname not in groups['controller_nodes']
+    - not ansible_check_mode
 
 - name: Configure daily 2:00 AM automated backup cron job on controllers
   ansible.builtin.cron:


### PR DESCRIPTION
Restrict the client mount and mount point directory creation tasks in the NFS Ansible role tasks to worker nodes only (not in `groups['controller_nodes']`). Since controllers are hosting the export, trying to mount it back onto themselves over the Tailscale mesh is redundant and triggers loopback access denial, whereas worker nodes can successfully mount it at the identical path.

---
*PR created automatically by Jules for task [609590081886641243](https://jules.google.com/task/609590081886641243) started by @LokiMetaSmith*