### PR TITLE
Fix llxprt_code Ansible role bootstrap failure

### DIFF
--- a/ansible/roles/llxprt_code/tasks/main.yaml
+++ b/ansible/roles/llxprt_code/tasks/main.yaml
@@ -26,7 +26,7 @@
 
 - name: Add NodeSource repository
   ansible.builtin.copy:
-    content: "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main"
+    content: "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main"
     dest: /etc/apt/sources.list.d/nodesource.list
   become: yes
 
@@ -63,7 +63,7 @@
     dest: "{{ llxprt_code_dir }}/.env"
 
 - name: Remove existing MCP server from llxprt-code
-  ansible.builtin.command: node bundle/llxprt.js mcp remove tool-server
+  ansible.builtin.command: npx llxprt mcp remove tool-server
   args:
     chdir: "{{ llxprt_code_dir }}"
   ignore_errors: true
@@ -72,8 +72,8 @@
 - name: Add MCP server to llxprt-code
   ansible.builtin.command:
     argv:
-      - node
-      - bundle/llxprt.js
+      - npx
+      - llxprt
       - mcp
       - add
       - tool-server


### PR DESCRIPTION
This PR fixes the bootstrap failure in the `llxprt_code` Ansible role:
1. It updates the configured NodeSource repository to install Node.js v24.x, ensuring full compliance with the package engine requirements (`node >=24`).
2. It replaces outdated commands pointing to the retired `bundle/llxprt.js` file with standard `npx llxprt mcp ...` execution in tasks, avoiding MODULE_NOT_FOUND errors.
3. Unit tests for the associated `llxprt_code_tool.py` continue to pass successfully.

---
*PR created automatically by Jules for task [13758709874720150148](https://jules.google.com/task/13758709874720150148) started by @LokiMetaSmith*