### PR TITLE
Fix Ansible Exo Role Task YAML Syntax Error

### DIFF
--- a/ansible/roles/exo/tasks/main.yaml
+++ b/ansible/roles/exo/tasks/main.yaml
@@ -59,7 +59,8 @@
   become: yes
   register: ipfs_add_result_exo
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"  when: exo_enable
+    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+  when: exo_enable
 
 - name: Clean up temporary Exo tarball
   ansible.builtin.file:


### PR DESCRIPTION
Fixed a syntax compilation error in `ansible/roles/exo/tasks/main.yaml` where `when: exo_enable` was appended to the same line as the `IPFS_PATH` environment variable block. Moving it to its own line restores correct task-level structure and allows playbooks/services/model_services.yaml to compile successfully.

---
*PR created automatically by Jules for task [329024728542513963](https://jules.google.com/task/329024728542513963) started by @LokiMetaSmith*