### PR TITLE
Fix Consul CA keyUsage validation and extensions

### DIFF
--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -164,15 +164,60 @@
         state: directory
         mode: '0755'
 
+    - name: Check if existing Consul CA certificate has required extensions
+      become: false
+      ansible.builtin.shell: |
+        set -e
+        if [ ! -f "{{ consul_temp_cert_dir }}/ca.pem" ]; then
+          exit 0
+        fi
+        openssl x509 -in "{{ consul_temp_cert_dir }}/ca.pem" -text -noout | grep -q "X509v3 Key Usage"
+        openssl x509 -in "{{ consul_temp_cert_dir }}/ca.pem" -text -noout | grep -q "CA:TRUE"
+      register: consul_ca_cert_validity
+      failed_when: false
+      changed_when: false
+
+    - name: Force regeneration of certificates if Consul CA is invalid or missing extensions
+      become: false
+      ansible.builtin.file:
+        path: "{{ consul_temp_cert_dir }}"
+        state: absent
+      when: consul_ca_cert_validity is defined and consul_ca_cert_validity.rc != 0
+
+    - name: Ensure local certs directory exists after force purge
+      become: false
+      ansible.builtin.file:
+        path: "{{ consul_temp_cert_dir }}"
+        state: directory
+        mode: '0755'
+      when: consul_ca_cert_validity is defined and consul_ca_cert_validity.rc != 0
+
     - name: Generate CA key
       become: false
       ansible.builtin.command: "openssl genrsa -out {{ consul_temp_cert_dir }}/ca.key 2048"
       args:
         creates: "{{ consul_temp_cert_dir }}/ca.key"
 
+    - name: Generate OpenSSL config for Consul CA
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ consul_temp_cert_dir }}/ca.cnf"
+        content: |
+          [req]
+          distinguished_name = req_distinguished_name
+          x509_extensions = v3_ca
+          prompt = no
+          [req_distinguished_name]
+          CN = Consul CA
+          [v3_ca]
+          keyUsage = critical, keyCertSign, cRLSign
+          basicConstraints = critical, CA:TRUE
+          subjectKeyIdentifier = hash
+          authorityKeyIdentifier = keyid:always,issuer
+
     - name: Generate CA certificate
       become: false
-      ansible.builtin.command: "openssl req -new -x509 -days 3650 -key {{ consul_temp_cert_dir }}/ca.key -out {{ consul_temp_cert_dir }}/ca.pem -subj '/CN=Consul CA'"
+      ansible.builtin.command: "openssl req -new -x509 -days 3650 -key {{ consul_temp_cert_dir }}/ca.key -out {{ consul_temp_cert_dir }}/ca.pem -config {{ consul_temp_cert_dir }}/ca.cnf -extensions v3_ca"
       args:
         creates: "{{ consul_temp_cert_dir }}/ca.pem"
 


### PR DESCRIPTION
This change implements proper certificate validation and generation with the required keyUsage extension for the Consul CA. Modern Python client environments (such as Python 3.13) require CA certificates to include the standard X509v3 Key Usage extensions (keyCertSign, cRLSign) and basicConstraints (CA:TRUE) for TLS verification.

Prior to this fix, the CA was generated with a basic openssl command lacking these extensions, and because the generation used the Ansible 'creates:' directive, the invalid CA key/cert persisted even during service resets/cleanups.

This change:
1. Performs a sanity check on any existing local Consul CA certificate.
2. Force-purges the temporary certs directory if the CA certificate is missing required extensions, ensuring both the CA and all signed server/client node certificates are cleanly regenerated.
3. Uses a dedicated OpenSSL configuration (ca.cnf) specifying the standard extensions.
4. Correctly signs and generates the new valid Consul CA certificate.

---
*PR created automatically by Jules for task [1736442420319419694](https://jules.google.com/task/1736442420319419694) started by @LokiMetaSmith*