### PR TITLE
fix(consul/btrfs): resolve consul TLS verification and btrfs loop dev…

### DIFF
--- a/ansible/roles/btrfs_snapshot/tasks/main.yaml
+++ b/ansible/roles/btrfs_snapshot/tasks/main.yaml
@@ -223,6 +223,9 @@
           --exclude="target/" \
           --exclude="*.log" \
           --exclude=".git/" \
+          --exclude="pw-browsers/" \
+          --exclude="datasets/" \
+          --exclude="chromadb/" \
           "{{ item }}/" "{{ btrfs_active_subvolume }}{{ item }}/"
       fi
     fi

--- a/scripts/recover_os.py
+++ b/scripts/recover_os.py
@@ -65,7 +65,10 @@ def create_snapshot():
         "--exclude=.mypy_cache/",
         "--exclude=target/",
         "--exclude=*.log",
-        "--exclude=.git/"
+        "--exclude=.git/",
+        "--exclude=pw-browsers/",
+        "--exclude=datasets/",
+        "--exclude=chromadb/"
     ]
     for p_dir in protected_dirs:
         if os.path.exists(p_dir):
@@ -189,7 +192,10 @@ def rollback_snapshot(target=None):
             "--exclude=.mypy_cache/",
             "--exclude=target/",
             "--exclude=*.log",
-            "--exclude=.git/"
+            "--exclude=.git/",
+            "--exclude=pw-browsers/",
+            "--exclude=datasets/",
+            "--exclude=chromadb/"
         ]
         print("Restoring protected directories from snapshot back to system...")
         for p_dir in protected_dirs:


### PR DESCRIPTION
…ice space exhaustion

1. Add validation for existing local Consul CA certificate. Regenerate CA with proper X509v3 Key Usage and basicConstraints extensions if missing, and clear the local temporary certs directory to force regeneration of dependent signed certificates.
2. Exclude pw-browsers/, datasets/, and chromadb/ from Btrfs synchronization tasks (in btrfs_snapshot role and recover_os.py script) to prevent loop device space exhaustion on 5G volumes.