### PR TITLE
Fix run_smol_recovery pathing and unit test imports

### DIFF
--- a/scripts/run_smol_recovery.py
+++ b/scripts/run_smol_recovery.py
@@ -1,6 +1,7 @@
 import sys
 import os
 
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'pipecatapp')))
 
 try:

--- a/tests/unit/test_archivist_tool.py
+++ b/tests/unit/test_archivist_tool.py
@@ -6,9 +6,8 @@ from unittest.mock import MagicMock, patch, AsyncMock
 # To handle relative imports (from .mcp_tool import MCP_Tool), we need to import
 # archivist_tool as part of a package.
 # We add the parent directory of 'tools' to sys.path.
-tools_parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'ansible', 'roles', 'pipecatapp', 'files'))
-if tools_parent_dir not in sys.path:
-    sys.path.insert(0, tools_parent_dir)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp')))
 
 # Now we can import from tools.archivist_tool
 from tools.archivist_tool import ArchivistTool

--- a/tests/unit/test_open_workers_tool.py
+++ b/tests/unit/test_open_workers_tool.py
@@ -6,7 +6,8 @@ import requests
 import re
 
 # Add the tools directory to sys.path so we can import the tool
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../ansible/roles/pipecatapp/files/tools'))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp', 'tools')))
 
 from open_workers_tool import OpenWorkersTool
 

--- a/tests/unit/test_opencode_tool.py
+++ b/tests/unit/test_opencode_tool.py
@@ -4,7 +4,8 @@ import sys
 import os
 
 # Ensure the tool module can be imported
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../ansible/roles/pipecatapp/files')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp')))
 
 from tools.opencode_tool import OpencodeTool
 

--- a/tests/unit/test_pipecat_app_unit.py
+++ b/tests/unit/test_pipecat_app_unit.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock, AsyncMock, patch
 import asyncio
 
 # Add the parent directory of 'testing' to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'ansible', 'roles', 'pipecatapp', 'files')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp')))
 
 # Mock problematic modules before importing app
 sys.modules["pyaudio"] = MagicMock()

--- a/tests/unit/test_poc_ensemble.py
+++ b/tests/unit/test_poc_ensemble.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock, AsyncMock, patch
 import logging
 
 # Add the ansible/roles/pipecatapp/files directory to sys.path
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../ansible/roles/pipecatapp/files')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp')))
 
 from workflow.runner import WorkflowRunner
 from workflow.context import WorkflowContext
@@ -42,7 +43,7 @@ class TestPoCEnsemble(unittest.TestCase):
         # Set dummy env vars for keys
         os.environ["OPENAI_API_KEY"] = "sk-dummy"
         os.environ["OPENROUTER_API_KEY"] = "sk-or-dummy"
-        self.workflow_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../ansible/roles/pipecatapp/files/workflows/poc_ensemble.yaml'))
+        self.workflow_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp', 'workflows', 'poc_ensemble.yaml'))
 
     @patch('httpx.AsyncClient')
     def test_workflow_execution(self, mock_client_cls):

--- a/tests/unit/test_prompt_improver_tool.py
+++ b/tests/unit/test_prompt_improver_tool.py
@@ -5,7 +5,8 @@ import os
 import asyncio
 
 # Add the path to the app files directory
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../ansible/roles/pipecatapp/files')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp')))
 
 from tools.prompt_improver_tool import PromptImproverTool
 

--- a/tests/unit/test_smol_agent_tool.py
+++ b/tests/unit/test_smol_agent_tool.py
@@ -4,7 +4,9 @@ import os
 from unittest.mock import patch, MagicMock
 
 # Add tools directory to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'ansible', 'roles', 'pipecatapp', 'files', 'tools')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp', 'tools')))
 
 from smol_agent_tool import SmolAgentTool
 

--- a/tests/unit/test_term_everything_tool.py
+++ b/tests/unit/test_term_everything_tool.py
@@ -5,7 +5,8 @@ import subprocess
 from unittest.mock import patch, AsyncMock
 
 # Ensure the tool's path is in the system path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../ansible/roles/pipecatapp/files/tools')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'pipecatapp', 'tools')))
 
 from term_everything_tool import TermEverythingTool
 


### PR DESCRIPTION
Resolved the No module named 'pipecatapp' error that prevents autonomous recovery via smol_agent from executing. Also cleaned up 8 unit test files containing outdated paths to 'ansible/roles/pipecatapp/files' to align with the standard location of 'pipecatapp' in the repository root, ensuring all unit tests pass perfectly.

---
*PR created automatically by Jules for task [8389870983457235954](https://jules.google.com/task/8389870983457235954) started by @LokiMetaSmith*