### PR TITLE
fix(consul/btrfs): resolve consul TLS verification and btrfs loop dev…

### DIFF
--- a/ansible/roles/btrfs_snapshot/defaults/main.yaml
+++ b/ansible/roles/btrfs_snapshot/defaults/main.yaml
@@ -7,7 +7,7 @@ btrfs_format_device: false
 
 # Fallback sparse file details if physical device is unavailable
 btrfs_loop_file: "/opt/btrfs_root.img"
-btrfs_loop_file_size: "5G"
+btrfs_loop_file_size: "15G"
 
 # Directories to back up/protect and sync to the Btrfs active subvolume
 btrfs_protected_dirs:

--- a/ansible/roles/btrfs_snapshot/tasks/main.yaml
+++ b/ansible/roles/btrfs_snapshot/tasks/main.yaml
@@ -109,7 +109,7 @@
 
 - name: Create sparse fallback file
   ansible.builtin.command:
-    cmd: "truncate -s {{ btrfs_loop_file_size | default('5G') }} {{ btrfs_loop_file }}"
+    cmd: "truncate -s {{ btrfs_loop_file_size | default('15G') }} {{ btrfs_loop_file }}"
     creates: "{{ btrfs_loop_file }}"
   become: yes
   when:
@@ -168,6 +168,44 @@
       - "****************************************************************"
   when: not btrfs_enabled
 
+- name: Expand existing loop fallback file if it is smaller than configured size
+  block:
+    - name: Get current size of loop file
+      ansible.builtin.stat:
+        path: "{{ btrfs_loop_file }}"
+      register: loop_file_stat
+      become: yes
+
+    - name: Expand loop file and resize Btrfs filesystem
+      block:
+        - name: Expand loop file
+          ansible.builtin.command:
+            cmd: "truncate -s {{ btrfs_loop_file_size | default('15G') }} {{ btrfs_loop_file }}"
+          become: yes
+
+        - name: Find loop device associated with loop file
+          ansible.builtin.shell: |
+            set -o pipefail
+            losetup -j "{{ btrfs_loop_file }}" | cut -d: -f1
+          register: losetup_device
+          become: yes
+          changed_when: false
+
+        - name: Refresh loop device size
+          ansible.builtin.command:
+            cmd: "losetup -c {{ losetup_device.stdout }}"
+          become: yes
+          when: losetup_device.stdout | trim | length > 0
+
+        - name: Resize Btrfs filesystem to maximum size
+          ansible.builtin.command:
+            cmd: "btrfs filesystem resize max {{ btrfs_subvolume_path }}"
+          become: yes
+      when:
+        - loop_file_stat.stat.exists
+        - loop_file_stat.stat.size < (15 * 1024 * 1024 * 1024) # 15GB
+  when: btrfs_enabled and btrfs_supported
+
 - name: Ensure active subvolume exists
   ansible.builtin.command:
     cmd: "btrfs subvolume create {{ btrfs_active_subvolume }}"
@@ -213,7 +251,7 @@
         echo "Skipping NFS mount {{ item }} on client node"
       else
         mkdir -p "{{ btrfs_active_subvolume }}{{ item }}"
-        rsync -a --delete \
+        rsync -a --delete --delete-excluded \
           --exclude=".venv/" \
           --exclude="venv/" \
           --exclude="node_modules/" \
@@ -226,6 +264,7 @@
           --exclude="pw-browsers/" \
           --exclude="datasets/" \
           --exclude="chromadb/" \
+          --exclude="ipfs/" \
           "{{ item }}/" "{{ btrfs_active_subvolume }}{{ item }}/"
       fi
     fi

--- a/scripts/recover_os.py
+++ b/scripts/recover_os.py
@@ -68,7 +68,8 @@ def create_snapshot():
         "--exclude=.git/",
         "--exclude=pw-browsers/",
         "--exclude=datasets/",
-        "--exclude=chromadb/"
+        "--exclude=chromadb/",
+        "--exclude=ipfs/"
     ]
     for p_dir in protected_dirs:
         if os.path.exists(p_dir):
@@ -88,7 +89,7 @@ def create_snapshot():
             os.makedirs(target_sub_dir, exist_ok=True)
             print(f"  Syncing {p_dir} -> {target_sub_dir}")
             try:
-                subprocess.check_call(["rsync", "-a", "--delete"] + exclude_args + [f"{p_dir}/", f"{target_sub_dir}/"])
+                subprocess.check_call(["rsync", "-a", "--delete", "--delete-excluded"] + exclude_args + [f"{p_dir}/", f"{target_sub_dir}/"])
             except subprocess.CalledProcessError as e:
                 print(f"Warning: Failed to sync {p_dir}: {e}")
 
@@ -195,7 +196,8 @@ def rollback_snapshot(target=None):
             "--exclude=.git/",
             "--exclude=pw-browsers/",
             "--exclude=datasets/",
-            "--exclude=chromadb/"
+            "--exclude=chromadb/",
+            "--exclude=ipfs/"
         ]
         print("Restoring protected directories from snapshot back to system...")
         for p_dir in protected_dirs:
@@ -216,7 +218,7 @@ def rollback_snapshot(target=None):
                 print(f"  Restoring {snapshot_source_dir} -> {p_dir}")
                 os.makedirs(p_dir, exist_ok=True)
                 try:
-                    subprocess.check_call(["rsync", "-a", "--delete"] + exclude_args + [f"{snapshot_source_dir}/", f"{p_dir}/"])
+                    subprocess.check_call(["rsync", "-a", "--delete", "--delete-excluded"] + exclude_args + [f"{snapshot_source_dir}/", f"{p_dir}/"])
                 except subprocess.CalledProcessError as e:
                     print(f"Warning: Failed to restore {p_dir}: {e}")
 


### PR DESCRIPTION
…ice space exhaustion

1. Add validation for existing local Consul CA certificate. Regenerate CA with proper X509v3 Key Usage and basicConstraints extensions if missing, and clear the local temporary certs directory to force regeneration of dependent signed certificates.
2. Exclude pw-browsers/, datasets/, chromadb/, and ipfs/ from Btrfs synchronization tasks (in btrfs_snapshot role and recover_os.py script) using rsync with --delete-excluded flag to reclaim space from previously synchronized directories.
3. Automatically expand backing sparse loop files to 15G and resize Btrfs filesystems to max size on-the-fly for existing/active deployments.