### PR TITLE
Implement Phase 2 output token reserve capping in llm_clients and exp…

### DIFF
--- a/pipecatapp/expert_tracker.py
+++ b/pipecatapp/expert_tracker.py
@@ -12,6 +12,13 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+OUTPUT_RESERVE_CAP = 2000
+
+def clamp_output_tokens(requested_max_tokens: int | None) -> int:
+    """Clamps pre-flight output token estimation to prevent bogus rate limit exclusions."""
+    requested = requested_max_tokens if (requested_max_tokens is not None and requested_max_tokens > 0) else 1000
+    return min(requested, OUTPUT_RESERVE_CAP)
+
 class ExpertTracker:
     """A thread-safe class to track performance and health metrics for LLM experts.
 

--- a/pipecatapp/llm_clients.py
+++ b/pipecatapp/llm_clients.py
@@ -3,6 +3,13 @@ import aiohttp
 import asyncio
 import re
 
+OUTPUT_RESERVE_CAP = 2000
+
+def clamp_output_tokens(requested_max_tokens: int | None) -> int:
+    """Clamps pre-flight output token estimation to prevent bogus rate limit exclusions."""
+    requested = requested_max_tokens if (requested_max_tokens is not None and requested_max_tokens > 0) else 1000
+    return min(requested, OUTPUT_RESERVE_CAP)
+
 class ExternalLLMClient:
     """A generic client for interacting with OpenAI-compatible LLM APIs.
 
@@ -29,6 +36,13 @@ class ExternalLLMClient:
         self.api_key = api_key
         self.model = model
         self._session = None
+
+    def estimate_request_tokens(self, prompt: str, requested_max_tokens: int | None = None) -> int:
+        """Estimates total request tokens (input + clamped output reserve) for pre-flight routing validation."""
+        # Simple heuristic: 4 characters per token
+        input_tokens = len(prompt) // 4
+        clamped_output = clamp_output_tokens(requested_max_tokens)
+        return input_tokens + clamped_output
 
     async def close(self):
         """Closes the underlying aiohttp session."""

--- a/pipecatapp/tests/test_llm_clients_new.py
+++ b/pipecatapp/tests/test_llm_clients_new.py
@@ -45,3 +45,19 @@ async def test_external_llm_client_error():
         assert "Error: Could not connect" in response
 
     await client.close()
+
+def test_output_token_clamping():
+    from pipecatapp.llm_clients import clamp_output_tokens, OUTPUT_RESERVE_CAP
+
+    # Under the cap
+    assert clamp_output_tokens(500) == 500
+    # Over the cap
+    assert clamp_output_tokens(5000) == OUTPUT_RESERVE_CAP
+    # None or 0 fallback
+    assert clamp_output_tokens(None) == 1000
+    assert clamp_output_tokens(0) == 1000
+
+def test_estimate_request_tokens():
+    client = ExternalLLMClient(base_url="http://mock-api.com", api_key="test-key", model="test-model")
+    # Prompt has 40 chars -> 10 input tokens. Max tokens 5000 -> clamped to 2000. Total = 2010.
+    assert client.estimate_request_tokens("A" * 40, 5000) == 2010

--- a/tests/unit/test_expert_tracker.py
+++ b/tests/unit/test_expert_tracker.py
@@ -147,3 +147,13 @@ async def test_connect_and_store_relation_exception(caplog):
         await tracker.connect_and_store_relation("source", "rel", "target")
 
         assert "Failed to store relation in memory graph" in caplog.text
+
+def test_tracker_token_clamping():
+    from pipecatapp.expert_tracker import clamp_output_tokens, OUTPUT_RESERVE_CAP
+
+    # Under the cap
+    assert clamp_output_tokens(500) == 500
+    # Over the cap
+    assert clamp_output_tokens(4500) == OUTPUT_RESERVE_CAP
+    # Fallback
+    assert clamp_output_tokens(None) == 1000


### PR DESCRIPTION
…ert_tracker

- Defined OUTPUT_RESERVE_CAP = 2000 in both pipecatapp/llm_clients.py and pipecatapp/expert_tracker.py.
- Implemented clamp_output_tokens and estimate_request_tokens to compute pre-flight token requirements correctly, preventing false-positive TPM rate limit exclusions.
- Added comprehensive unit tests inside pipecatapp/tests/test_llm_clients_new.py and tests/unit/test_expert_tracker.py.