### PR TITLE
Fix strict SSL CA keyUsage verification in Consul and Nomad roles

### DIFF
--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -171,9 +171,10 @@
         if [ ! -f "{{ consul_temp_cert_dir }}/ca.pem" ]; then
           exit 1
         fi
-        # Verify Root CA has CA:TRUE and Key Usage extensions
-        openssl x509 -in "{{ consul_temp_cert_dir }}/ca.pem" -text -noout | grep -q "X509v3 Key Usage"
+        # Verify Root CA has CA:TRUE and Key Usage extensions with Certificate Sign / keyCertSign
         openssl x509 -in "{{ consul_temp_cert_dir }}/ca.pem" -text -noout | grep -q "CA:TRUE"
+        openssl x509 -in "{{ consul_temp_cert_dir }}/ca.pem" -text -noout | grep -E -q "X509v3 Key Usage|keyUsage"
+        openssl x509 -in "{{ consul_temp_cert_dir }}/ca.pem" -text -noout | grep -E -q "Certificate Sign|keyCertSign"
         # Check server node certificates if they exist
         for host in {{ groups['controller_nodes'] | join(' ') }}; do
           if [ ! -f "{{ consul_temp_cert_dir }}/${host}.pem" ]; then

--- a/ansible/roles/nomad/tasks/tls.yaml
+++ b/ansible/roles/nomad/tasks/tls.yaml
@@ -22,9 +22,10 @@
     if [ ! -f "{{ nomad_temp_cert_dir }}/ca.pem" ]; then
       exit 1
     fi
-    # Verify Root CA has CA:TRUE and Key Usage extensions
-    openssl x509 -in "{{ nomad_temp_cert_dir }}/ca.pem" -text -noout | grep -q "X509v3 Key Usage"
+    # Verify Root CA has CA:TRUE and Key Usage extensions with Certificate Sign / keyCertSign
     openssl x509 -in "{{ nomad_temp_cert_dir }}/ca.pem" -text -noout | grep -q "CA:TRUE"
+    openssl x509 -in "{{ nomad_temp_cert_dir }}/ca.pem" -text -noout | grep -E -q "X509v3 Key Usage|keyUsage"
+    openssl x509 -in "{{ nomad_temp_cert_dir }}/ca.pem" -text -noout | grep -E -q "Certificate Sign|keyCertSign"
     # Check server node certificates
     for host in {{ groups['controller_nodes'] | default([]) | join(' ') }}; do
       if [ ! -f "{{ nomad_temp_cert_dir }}/${host}.pem" ]; then


### PR DESCRIPTION
Under Python 3.13 / OpenSSL 3.0, strict SSL/TLS verification is enforced which rejects CA certificates that do not include the Certificate Sign (keyCertSign) keyUsage extension. This PR updates the compliance validation checks in both the Consul and Nomad Ansible roles to specifically verify that existing CA certificates contain this extension, ensuring they are automatically regenerated and rotated if non-compliant, which resolves urlopen SSL validation failures.

---
*PR created automatically by Jules for task [13159163439113069063](https://jules.google.com/task/13159163439113069063) started by @LokiMetaSmith*