### PR TITLE
Add Zero-Tolerance TLS/SSL Bypass Security Directive

### DIFF
--- a/.julesrules
+++ b/.julesrules
@@ -2,6 +2,17 @@
 
 These rules are mandatory for all autonomous agents (like Jules) operating within this repository. They are designed to prevent "path of least resistance" workarounds that break the system architecture.
 
+## 🔒 SECURITY ENFORCEMENT: Zero-Tolerance for TLS/SSL Bypasses
+Core Rule: You are strictly prohibited from bypassing, disabling, or ignoring TLS/SSL certificate validation to resolve connection errors or force a failing pipeline to pass.
+
+Forbidden Mechanisms: You must never use arguments such as validate_certs: no (Ansible), --insecure / -k (cURL), verify=False (Python/Requests), NODE_TLS_REJECT_UNAUTHORIZED=0 (Node.js), or any equivalent bypass.
+
+Fix the Root Cause: If a TLS handshake fails (e.g., "invalid certificate", "unknown issuer"), you must diagnose and fix the underlying cryptographic trust infrastructure.
+
+Certificate Requirements: When troubleshooting mesh or cluster SSL errors, verify that the Root CA has the correct basicConstraints (CA:TRUE) and keyUsage, ensure Subject Alternative Names (SANs) include the correct mesh IPs (e.g., Tailscale 100.x.y.z) and DNS names, and verify the CA is correctly appended to the target system's trust store.
+
+No Band-Aids: "Green" pipelines achieved by disabling security are considered critical failures. Absolute mesh security and zero-trust integrity supersede task completion speed.
+
 ## 1. Network Architecture (Non-Negotiable)
 
 *   **Rule 1.1:** All node-to-node and cluster-internal communication **must strictly use the `tailscale0` interface** (the 100.x.x.x mesh network).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,17 @@ Welcome, Agent. This file contains the mandatory operating procedures and playbo
 
 You must strictly adhere to the following rules, tools, and workflows. Do not deviate, shortcut, or attempt to bypass these instructions.
 
+## 🔒 SECURITY ENFORCEMENT: Zero-Tolerance for TLS/SSL Bypasses
+Core Rule: You are strictly prohibited from bypassing, disabling, or ignoring TLS/SSL certificate validation to resolve connection errors or force a failing pipeline to pass.
+
+Forbidden Mechanisms: You must never use arguments such as validate_certs: no (Ansible), --insecure / -k (cURL), verify=False (Python/Requests), NODE_TLS_REJECT_UNAUTHORIZED=0 (Node.js), or any equivalent bypass.
+
+Fix the Root Cause: If a TLS handshake fails (e.g., "invalid certificate", "unknown issuer"), you must diagnose and fix the underlying cryptographic trust infrastructure.
+
+Certificate Requirements: When troubleshooting mesh or cluster SSL errors, verify that the Root CA has the correct basicConstraints (CA:TRUE) and keyUsage, ensure Subject Alternative Names (SANs) include the correct mesh IPs (e.g., Tailscale 100.x.y.z) and DNS names, and verify the CA is correctly appended to the target system's trust store.
+
+No Band-Aids: "Green" pipelines achieved by disabling security are considered critical failures. Absolute mesh security and zero-trust integrity supersede task completion speed.
+
 ## 1. Executable Oracles
 
 You are provided with several executable oracles to verify your work. You must use these tools to test your code before considering a task complete.


### PR DESCRIPTION
This PR adds a mandatory `🔒 SECURITY ENFORCEMENT: Zero-Tolerance for TLS/SSL Bypasses` section verbatim near the top of both `AGENTS.md` and `.julesrules`. This guarantees that autonomous agents operate with strict zero-trust integrity, forbidding shortcuts or security disables to fix transient or persistent handshake errors.

---
*PR created automatically by Jules for task [8799334537786535821](https://jules.google.com/task/8799334537786535821) started by @LokiMetaSmith*