### PR TITLE
docs: compile, index, and cross-reference docs/manual/ documents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,26 +20,26 @@ All user-facing manuals, deployment playbooks, and architectural blueprints are 
 
 The `analysis/` directory contains strategic technical reviews, system comparisons, and capability evaluation reports compiled during development.
 
-*   **[LiteGraph vs ReactFlow Analysis](analysis/LITEGRAPH_VS_REACTFLOW.md)**: Completed comparison of front-end graph UI frameworks.
-*   **[Agent Lightning Analysis](analysis/AGENT_LIGHTNING_ANALYSIS.md)**: Investigation into agentic latency optimizations.
-*   **[Ceph Storage Cluster Evaluation](analysis/CEPH_EVALUATION.md)**: Assessment of Ceph for block/file storage cluster inclusion.
-*   **[A Guide to Benchmarking](analysis/BENCHMARKING.MD)**: Standard benchmarking procedures and performance suites.
-*   **[Clamav Evaluation](analysis/CLAMAV_EVALUATION.md)**: Analysis of real-time antivirus scans for agentic code.
-*   **[Claude Code CLI Analysis](analysis/CLAUDE_CODE_ANALYSIS.md)**: Insights on terminal-based autonomous coding.
-*   **[Dirac Evaluation](analysis/DIRAC_EVALUATION.md)**: Deprecation review of the Dirac toolset.
-*   **[LLMRouter Evaluation Report](analysis/EVALUATION_LLMROUTER.md)**: Multi-model routing strategies and benchmark findings.
-*   **[Flowise UI Analysis](analysis/FLOWISE_ANALYSIS.md)**: Web interface and node integration analysis.
-*   **[GCP Generative AI Review](analysis/GCP_GENERATIVE_AI_REVIEW.md)**: Integration analysis of GCP vertex endpoints.
-*   **[Haystack Analysis and Integration](analysis/HAYSTACK_ANALYSIS.md)**: Utilizing Haystack pipeline patterns inside the agent loop.
-*   **[IPv6 Audit Report](analysis/IPV6_AUDIT.md)**: Audit of address mapping and dual-stack requirements.
-*   **[LangChain Hybrid Integration](analysis/LANGCHAIN_ANALYSIS.md)**: Analysis of LangChain components for memory persistence.
-*   **[Memento Skills Analysis](analysis/MEMENTO_SKILLS_ANALYSIS.md)**: Investigating procedural skills databases.
-*   **[Paseo Orchestration Analysis](analysis/PASEO_ANALYSIS.md)**: Multi-agent message routing concepts.
-*   **[Pollen WASM Comparison](analysis/POLLEN_COMPARISON.md)**: Utilizing WebAssembly for lightweight edge tasks.
-*   **[Refactoring Proposal: Hybrid Architecture](analysis/REFACTOR_PROPOSAL_hybrid_architecture.md)**: Proposal for cluster-native de-monolithization.
-*   **[Security Audit Log](analysis/SECURITY_AUDIT.md)**: Central record of vulnerability checks and mitigations.
-*   **[Tool Evaluation & Strategic Direction](analysis/TOOL_EVALUATION.md)**: Evaluating security sandboxing for agent tools.
-*   **[vLLM Project Evaluation](analysis/VLLM_PROJECT_EVALUATION.md)**: Highly-parallelized vLLM deployment analysis.
-*   **[YAML Files Report](analysis/YAML_FILES_REPORT.md)**: Review of root-level YAML playbooks and configs.
-*   **[Heretic Repository Evaluation](analysis/heretic_evaluation.md)**: Aligning open-weight LLMs via supervised fine-tuning.
-*   **[Project Review Report](analysis/review_report.md)**: Consolidated review of overall code structure and future direction.
+*   **[LiteGraph vs ReactFlow Analysis](analysis/LITEGRAPH_VS_REACTFLOW.md)**: Implemented (Analysis completed)
+*   **[Agent Lightning Analysis](analysis/AGENT_LIGHTNING_ANALYSIS.md)**: Implemented (Investigated as agent improvement method)
+*   **[Ceph Evaluation](analysis/CEPH_EVALUATION.md)**: Completed (Evaluated for potential cluster inclusion)
+*   **[Benchmarking](analysis/BENCHMARKING.MD)**: Implemented (Benchmarking suite exists)
+*   **[Clamav Evaluation](analysis/CLAMAV_EVALUATION.md)**: Implemented (Ansible role and custom signatures deployed)
+*   **[Claude Code Analysis](analysis/CLAUDE_CODE_ANALYSIS.md)**: Implemented (CLI techniques implemented)
+*   **[Dirac Evaluation](analysis/DIRAC_EVALUATION.md)**: Discarded (Dirac toolset deprecated)
+*   **[LLMRouter Evaluation](analysis/EVALUATION_LLMROUTER.md)**: Implemented (Integration completed)
+*   **[Flowise Analysis](analysis/FLOWISE_ANALYSIS.md)**: Implemented (UI integration completed)
+*   **[GCP Generative AI Review](analysis/GCP_GENERATIVE_AI_REVIEW.md)**: Implemented (Adaptive Always-On Memory Agent integrated via SQLite MemoryStore)
+*   **[Haystack Analysis](analysis/HAYSTACK_ANALYSIS.md)**: Implemented (Pipeline/component concepts integrated)
+*   **[IPv6 Audit](analysis/IPV6_AUDIT.md)**: Yet to be implemented (Underlay fallback remains IPv4-specific)
+*   **[Langchain Analysis](analysis/LANGCHAIN_ANALYSIS.md)**: Implemented (LangChain Hybrid Approach completed)
+*   **[Memento Skills Analysis](analysis/MEMENTO_SKILLS_ANALYSIS.md)**: Implemented (Skills-as-Files and dynamic execution loop integrated)
+*   **[Paseo Analysis](analysis/PASEO_ANALYSIS.md)**: Implemented (Orchestration concepts integrated)
+*   **[Pollen Comparison](analysis/POLLEN_COMPARISON.md)**: Implemented (WASM mesh efficiencies integrated)
+*   **[Refactor Proposal Hybrid Architecture](analysis/REFACTOR_PROPOSAL_hybrid_architecture.md)**: Implemented (Migrate to Hybrid Architecture - Phase 1)
+*   **[Security Audit](analysis/SECURITY_AUDIT.md)**: Implemented (Security Audit completed)
+*   **[Tool Evaluation](analysis/TOOL_EVALUATION.md)**: Implemented (Tools evaluated and updated)
+*   **[vLLM Project Evaluation](analysis/VLLM_PROJECT_EVALUATION.md)**: Implemented (Evaluated findings)
+*   **[YAML Files Report](analysis/YAML_FILES_REPORT.md)**: Yet to be implemented (Playbooks relocate pending cleanup)
+*   **[Heretic Evaluation](analysis/heretic_evaluation.md)**: Implemented (Heretic tool exists)
+*   **[Review Report](analysis/review_report.md)**: Completed (Review completed and path corrections applied)


### PR DESCRIPTION
This commit cleans up the docs/manual/ directory by:
1. Adding a clean, bulleted Table of Contents (TOC) at the top of all 26 included manuals and design files.
2. Cross-referencing and deep-linking manuals using standard relative Markdown links and header slugs to maintain high inter-doc discoverability.
3. Creating a brand new, highly descriptive, and thematically-categorized docs/manual/README.md cataloging all manuals under logical topics.
4. Aligning and correcting paths/references in the root-level README.md and parent docs/README.md to resolve deprecated or broken links (such as docs/manual/TODO.md), while fully preserving and updating the Implemented / Yet to be Implemented status notes for all analysis documents.
5. Keeping raw Markdown clean by strictly avoiding Obsidian-specific block identifiers (^block-id) to ensure optimal Git web compatibility.