### PR TITLE
Fix duplicate and orphaned opencode processes and add status diagnostics

### DIFF
--- a/ansible/roles/opencode/tasks/main.yaml
+++ b/ansible/roles/opencode/tasks/main.yaml
@@ -15,6 +15,12 @@
   ansible.builtin.set_fact:
     opencode_bin_path: "{{ opencode_npm_prefix_path.stdout }}/bin/opencode"
 
+- name: Proactively terminate any existing opencode processes
+  ansible.builtin.shell: pkill -9 -x "opencode" || pkill -9 -f "bin/opencode"
+  failed_when: false
+  changed_when: true
+  become: yes
+
 - name: Create Opencode Nomad job file
   ansible.builtin.template:
     src: opencode.nomad.j2

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -789,7 +789,10 @@ if [ "$DO_STATUS" = true ]; then
     echo -e "${BOLD}=== Cluster Status ===${NC}"
     ensure_python_environment
     python3 scripts/provisioning.py --only-status "${PROCESSED_ARGS[@]}"
-    exit $?
+
+    echo -e "\n${BOLD}=== Opencode Status ===${NC}"
+    python3 scripts/troubleshoot.py opencode-status
+    exit 0
 fi
 
 # --- OS Recovery Snapshot Actions ---

--- a/pipecatapp/tools/opencode_provider_tool.py
+++ b/pipecatapp/tools/opencode_provider_tool.py
@@ -80,8 +80,8 @@ class OpenCodeProviderTool:
                                 "Driver": "raw_exec",
                                 "Config": {
                                     # We use raw_exec assuming opencode is installed on the node (via the Ansible role)
-                                    "command": "/usr/local/bin/npm",
-                                    "args": ["exec", "--", "opencode", task]
+                                    "command": "timeout",
+                                    "args": [str(self.default_timeout), "/usr/local/bin/npm", "exec", "--", "opencode", task]
                                 },
                                 "Resources": {
                                     "CPU": 500,

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -158,6 +158,10 @@ if [ -d "/opt/nomad" ]; then
     sudo find /opt/nomad -mindepth 1 -maxdepth 1 ! -name "models" -exec rm -rf {} +
 fi
 
+# 8. Force kill orphaned and running opencode processes
+echo -e "\n${BOLD}🔪 Terminating all running and orphaned opencode processes...${NC}"
+sudo pkill -9 -x "opencode" || sudo pkill -9 -f "bin/opencode" || true
+
 
 echo -e "\n${GREEN}✨ Cleanup Complete!${NC}"
 df -h /

--- a/scripts/provisioning.py
+++ b/scripts/provisioning.py
@@ -314,6 +314,7 @@ def purge_nomad_jobs():
 
     kill_if_running("dllama-api")
     kill_if_running("/opt/pipecatapp/venv/bin/python3 /opt/pipecatapp/app.py")
+    kill_if_running("bin/opencode")
     print("Process cleanup complete.")
 
 

--- a/scripts/troubleshoot.py
+++ b/scripts/troubleshoot.py
@@ -791,10 +791,120 @@ def cmd_daemon(args):
         time.sleep(interval)
 
 
+def cmd_opencode_status(args):
+    """Checks the status of Opencode cross-referencing Nomad, Consul, and system processes."""
+    if not args.json:
+        print("=== Opencode Unified Diagnostic Report ===")
+
+    # 1. Query Nomad Allocations
+    allocations = get_nomad_allocations(quiet=True)
+    opencode_allocs = []
+    if allocations:
+        for alloc in allocations:
+            job_id = alloc.get("JobID", "")
+            if "opencode" in job_id.lower():
+                opencode_allocs.append({
+                    "id": alloc.get("ID"),
+                    "job_id": job_id,
+                    "node_name": alloc.get("NodeName", "N/A"),
+                    "client_status": alloc.get("ClientStatus", "N/A"),
+                    "desired_status": alloc.get("DesiredStatus", "N/A"),
+                    "create_time": format_time(alloc.get("CreateTime", 0))
+                })
+
+    # 2. Query Consul Health Checks
+    consul_url = "http://127.0.0.1:8500/v1/health/service/opencode-api"
+    consul_checks = []
+    try:
+        req = urllib.request.Request(consul_url)
+        consul_token = get_consul_token()
+        if consul_token:
+            req.add_header("X-Consul-Token", consul_token)
+        with urllib.request.urlopen(req, timeout=3) as response:
+            if response.status == 200:
+                data = json.loads(response.read().decode('utf-8'))
+                for node_svc in data:
+                    node_name = node_svc.get("Node", {}).get("Node", "N/A")
+                    address = node_svc.get("Service", {}).get("Address", "N/A")
+                    port = node_svc.get("Service", {}).get("Port", "N/A")
+                    checks = node_svc.get("Checks", [])
+                    status = "passing"
+                    for chk in checks:
+                        if chk.get("ServiceName") == "opencode-api" and chk.get("Status") != "passing":
+                            status = chk.get("Status")
+                    consul_checks.append({
+                        "node": node_name,
+                        "address": address,
+                        "port": port,
+                        "status": status
+                    })
+    except Exception:
+        pass
+
+    # 3. Query System-level Processes
+    system_processes = []
+    res = run_command(["ps", "-eo", "pid,ppid,%cpu,%mem,etime,cmd"])
+    if res["exit_code"] == 0:
+        for line in res["stdout"].splitlines():
+            if "opencode" in line and "grep" not in line and "troubleshoot.py" not in line:
+                parts = line.strip().split(None, 5)
+                if len(parts) >= 6:
+                    pid, ppid, cpu, mem, etime, cmd = parts
+                    system_processes.append({
+                        "pid": pid,
+                        "ppid": ppid,
+                        "cpu": cpu,
+                        "mem": mem,
+                        "etime": etime,
+                        "cmd": cmd
+                    })
+
+    if args.json:
+        report = {
+            "nomad_allocations": opencode_allocs,
+            "consul_health_checks": consul_checks,
+            "system_processes": system_processes
+        }
+        print(json.dumps(report, indent=2))
+        return
+
+    print("\n--- Nomad Allocations ---")
+    if opencode_allocs:
+        print(f"{'Alloc ID':<10} | {'Job ID':<30} | {'Node':<15} | {'ClientStatus':<12} | {'Desired':<10}")
+        print("-" * 85)
+        for alloc in opencode_allocs:
+            print(f"{alloc['id'][:8]:<10} | {alloc['job_id']:<30} | {alloc['node_name']:<15} | {alloc['client_status']:<12} | {alloc['desired_status']:<10}")
+    else:
+        print("No opencode allocations found in Nomad.")
+
+    print("\n--- Consul Service Status ---")
+    if consul_checks:
+        print(f"{'Node':<20} | {'Address':<20} | {'Port':<8} | {'Status':<10}")
+        print("-" * 64)
+        for chk in consul_checks:
+            print(f"{chk['node']:<20} | {chk['address']:<20} | {chk['port']:<8} | {chk['status']:<10}")
+    else:
+        print("No opencode-api services registered in Consul.")
+
+    print("\n--- System-level Processes ---")
+    if system_processes:
+        print(f"{'PID':<8} | {'PPID':<8} | {'%CPU':<5} | {'%MEM':<5} | {'Running Time':<12} | {'Command'}")
+        print("-" * 100)
+        for proc in system_processes:
+            print(f"{proc['pid']:<8} | {proc['ppid']:<8} | {proc['cpu']:<5} | {proc['mem']:<5} | {proc['etime']:<12} | {proc['cmd'][:60]}")
+        print(f"\nTotal system processes found: {len(system_processes)}")
+    else:
+        print("No opencode processes found running on this host.")
+
+
 def main():
     """Main CLI execution entry point."""
     parser = argparse.ArgumentParser(description="Troubleshoot Nomad & Systemd services.")
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    opencode_status_parser = subparsers.add_parser("opencode-status", help="Unified Opencode status diagnostics")
+    opencode_status_parser.add_argument("--json", action="store_true", help="Output in JSON format")
+    opencode_status_parser.set_defaults(func=cmd_opencode_status)
 
     list_parser = subparsers.add_parser("list", help="List Nomad jobs in dead or pending state")
     list_parser.add_argument("--json", action="store_true", help="Output in JSON format")


### PR DESCRIPTION
This PR prevents resource bloat and port conflicts on legacy cluster nodes by aggressively force-terminating orphaned opencode processes from raw_exec tasks during redeployments, bootstraps, and purges. It also enforces timeouts on on-demand coding tasks and implements a unified diagnostic CLI helper.

---
*PR created automatically by Jules for task [12091490634025867535](https://jules.google.com/task/12091490634025867535) started by @LokiMetaSmith*