### PR TITLE
Fix moe-gateway startup blocking and enable HTTPS Consul with strict TLS

### DIFF
--- a/ansible/roles/moe_gateway/files/gateway.py
+++ b/ansible/roles/moe_gateway/files/gateway.py
@@ -22,6 +22,15 @@ logger = logging.getLogger(__name__)
 PIPECAT_SERVICE_URL = ""
 GATEWAY_URL = f"http://{os.getenv('NOMAD_IP_http')}:{os.getenv('NOMAD_PORT_http')}" if os.getenv('NOMAD_IP_http') and os.getenv('NOMAD_PORT_http') else "http://127.0.0.1:8001"
 CONSUL_HTTP_ADDR = os.getenv("CONSUL_HTTP_ADDR", "http://127.0.0.1:8500")
+
+# Enforce strict SSL/TLS verification using system CA or Consul CA
+verify_param = True
+if CONSUL_HTTP_ADDR.startswith("https://"):
+    for ca_path in ["/etc/consul.d/ca.pem", "/etc/ssl/certs/ca-certificates.crt"]:
+        if os.path.exists(ca_path):
+            verify_param = ca_path
+            break
+
 # Use a writable directory for the DB, defaulting to /tmp/gateway_data
 DB_DIR = os.getenv("GATEWAY_DB_DIR", "/tmp/gateway_data")
 DB_PATH = os.path.join(DB_DIR, "gateway_metrics.db")
@@ -247,11 +256,20 @@ async def get_metrics() -> Dict:
     """Async wrapper for fetching metrics."""
     return await asyncio.to_thread(_get_metrics_sync)
 
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # On startup, discover the pipecat service in the background so it doesn't block startup
+    asyncio.create_task(discover_pipecat_service())
+    yield
+
 # --- FastAPI App ---
 app = FastAPI(
     title="Mixture of Experts (MoE) Gateway",
     description="An OpenAI-compatible API gateway for the distributed agent cluster.",
     version="1.0.0",
+    lifespan=lifespan,
 )
 
 # Serve Static Files (Dashboard)
@@ -304,7 +322,7 @@ async def discover_pipecat_service():
         headers["X-Consul-Token"] = token
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=verify_param) as client:
             response = await client.get(consul_url, headers=headers, timeout=5.0)
             response.raise_for_status()
             services = response.json()
@@ -325,14 +343,6 @@ async def discover_pipecat_service():
     except Exception as e:
         logger.exception(f"An unexpected error occurred during service discovery: {e}")
         raise
-
-@app.on_event("startup")
-async def startup_event():
-    """On startup, discover the pipecat service."""
-    try:
-        await discover_pipecat_service()
-    except Exception as e:
-        logger.warning(f"Startup service discovery failed: {e}. Continuing to allow health checks.")
 
 # --- Health Check Endpoint ---
 @app.get("/health", status_code=200)
@@ -397,7 +407,7 @@ async def chat_completions(request: Request, payload: Dict = Body(...)):
             "expert_name": selected_expert
         }
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=verify_param) as client:
             response = await client.post(f"{PIPECAT_SERVICE_URL}/internal/chat", json=forward_payload, timeout=5.0)
             response.raise_for_status()
 

--- a/ansible/roles/moe_gateway/templates/moe-gateway.nomad.j2
+++ b/ansible/roles/moe_gateway/templates/moe-gateway.nomad.j2
@@ -36,6 +36,7 @@ job "moe-gateway" {
 
       env {
         CONSUL_HTTP_TOKEN = "{{ consul_bootstrap_token }}"
+        CONSUL_HTTP_ADDR  = "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}"
       }
 
       config {


### PR DESCRIPTION
Fixed the moe-gateway Nomad job deployment failure. The gateway service was failing to start successfully because the startup service discovery blocked FastAPI initialization, causing Nomad health checks to time out. 

To fix this:
1. Configured CONSUL_HTTP_ADDR in the Nomad job template (`moe-gateway.nomad.j2`) to use HTTPS on port 8501 and the correct cluster IP.
2. Refactored `gateway.py` to use FastAPI's modern `lifespan` context manager hook instead of the deprecated `@app.on_event("startup")` hook.
3. Shifted the initial `discover_pipecat_service()` execution to run asynchronously in the background so that Uvicorn starts immediately and serves the `/health` endpoint without delay.
4. Implemented secure TLS verification using standard system CAs or the Consul CA file, adhering to the zero-tolerance SSL/TLS bypass policy.

---
*PR created automatically by Jules for task [12284750836911928695](https://jules.google.com/task/12284750836911928695) started by @LokiMetaSmith*