### PR TITLE
Add Ternary and 1-bit Bonsai 27B External Expert Models

### DIFF
--- a/ansible/roles/moe_gateway/files/gateway.py
+++ b/ansible/roles/moe_gateway/files/gateway.py
@@ -126,7 +126,9 @@ if not EXTERNAL_EXPERTS:
     EXTERNAL_EXPERTS = {
         "openai_gpt4": {"model": "gpt-4-turbo"},
         "openrouter_claude_sonnet": {"model": "anthropic/claude-3.5-sonnet"},
-        "openrouter_gemini_flash": {"model": "google/gemini-2.0-flash-001"}
+        "openrouter_gemini_flash": {"model": "google/gemini-2.0-flash-001"},
+        "together_ternary_bonsai_27b": {"model": "prism-ml/ternary-bonsai-27b"},
+        "together_1bit_bonsai_27b": {"model": "prism-ml/1bit-bonsai-27b"}
     }
 
 def get_expert_scores(db_path: str, external_experts: dict) -> dict:
@@ -195,6 +197,10 @@ def get_expert_scores(db_path: str, external_experts: dict) -> dict:
             intel = 0.95
         elif "qwen_72b" in name:
             intel = 0.8
+        elif "ternary_bonsai_27b" in name:
+            intel = 0.8
+        elif "1bit_bonsai_27b" in name:
+            intel = 0.75
         elif "flash" in name or "mini" in name:
             intel = 0.4
 

--- a/group_vars/external_experts.yaml
+++ b/group_vars/external_experts.yaml
@@ -37,3 +37,11 @@ external_experts_config:
     base_url: "https://openrouter.ai/api/v1"
     api_key_env: "OPENROUTER_API_KEY"
     model: "qwen/qwen-2.5-72b-instruct"
+  together_ternary_bonsai_27b:
+    base_url: "https://api.together.xyz/v1"
+    api_key_env: "TOGETHER_API_KEY"
+    model: "prism-ml/ternary-bonsai-27b"
+  together_1bit_bonsai_27b:
+    base_url: "https://api.together.xyz/v1"
+    api_key_env: "TOGETHER_API_KEY"
+    model: "prism-ml/1bit-bonsai-27b"

--- a/pipecatapp/tests/test_moe_gateway.py
+++ b/pipecatapp/tests/test_moe_gateway.py
@@ -63,3 +63,61 @@ def test_select_best_expert():
 
     if os.path.exists(test_db):
         os.remove(test_db)
+
+def test_bonsai_expert_scores():
+    # Verify both models are in the external experts dictionary
+    assert "together_ternary_bonsai_27b" in gateway.EXTERNAL_EXPERTS
+    assert "together_1bit_bonsai_27b" in gateway.EXTERNAL_EXPERTS
+
+    test_db = "/tmp/test_bonsai_metrics.db"
+    if os.path.exists(test_db):
+        os.remove(test_db)
+
+    conn = sqlite3.connect(test_db)
+    c = conn.cursor()
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS requests (
+            request_id TEXT PRIMARY KEY,
+            timestamp REAL,
+            user_input TEXT,
+            response TEXT,
+            status_code INTEGER,
+            latency REAL,
+            expert_name TEXT DEFAULT 'default'
+        )
+    ''')
+
+    now = time.time()
+    # Log equal successes and latency for ternary and 1-bit Bonsai
+    for i in range(5):
+        c.execute('''
+            INSERT INTO requests (request_id, timestamp, user_input, response, status_code, latency, expert_name)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        ''', (f"req-ternary-{i}", now - i * 60, "hi", "response", 200, 0.5, "together_ternary_bonsai_27b"))
+        c.execute('''
+            INSERT INTO requests (request_id, timestamp, user_input, response, status_code, latency, expert_name)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        ''', (f"req-1bit-{i}", now - i * 60, "hi", "response", 200, 0.5, "together_1bit_bonsai_27b"))
+
+    conn.commit()
+    conn.close()
+
+    # Mock sample_beta to return exactly expected values for precise comparison
+    original_sample_beta = gateway.sample_beta
+    try:
+        # Mock sample_beta to return a constant 1.0 (perfect reliability) for predictable scoring
+        gateway.sample_beta = lambda a, b: 1.0
+        scores = gateway.get_expert_scores(test_db, gateway.EXTERNAL_EXPERTS)
+
+        assert "together_ternary_bonsai_27b" in scores
+        assert "together_1bit_bonsai_27b" in scores
+
+        # ternary should have score higher than 1bit because of higher intelligence score (0.8 > 0.75)
+        # score = 0.5 * reliability (1.0) + 0.25 * speed + 0.25 * intel
+        assert scores["together_ternary_bonsai_27b"] > scores["together_1bit_bonsai_27b"]
+        assert scores["together_ternary_bonsai_27b"] - scores["together_1bit_bonsai_27b"] == pytest.approx(0.25 * (0.8 - 0.75))
+    finally:
+        gateway.sample_beta = original_sample_beta
+
+    if os.path.exists(test_db):
+        os.remove(test_db)


### PR DESCRIPTION
Added support for PrismML's newly announced Bonsai 27B model variants (Ternary Bonsai 27B and 1-bit Bonsai 27B) as external LLM experts on the Together AI platform. This configuration is fully integrated into the Mixture of Experts (MoE) Gateway, mapping their normalized intelligence scores (0.8 and 0.75 respectively) to influence the Thompson-sampling routing bandit. Integrated robust unit tests verifying that both models are configured and scored correctly relative to each other.

---
*PR created automatically by Jules for task [17384085284677954692](https://jules.google.com/task/17384085284677954692) started by @LokiMetaSmith*