### PR TITLE
Fix moe-gateway startup blocking & add missing last30days_service tem…

### DIFF
--- a/ansible/roles/last30days_service/handlers/main.yaml
+++ b/ansible/roles/last30days_service/handlers/main.yaml
@@ -2,4 +2,7 @@
   ansible.builtin.command: "nomad job run {{ nomad_jobs_dir }}/last30days.nomad"
   become: yes
   environment:
-    NOMAD_ADDR: "{{ nomad_addr | default('http://127.0.0.1:4646') }}"
+    NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
+    NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if (nomad_cli_cert_stat is defined and nomad_cli_cert_stat.stat is defined and nomad_cli_cert_stat.stat.exists) else omit }}"
+    NOMAD_CLIENT_CERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.cert.pem') if (nomad_cli_cert_stat is defined and nomad_cli_cert_stat.stat is defined and nomad_cli_cert_stat.stat.exists) else omit }}"
+    NOMAD_CLIENT_KEY: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.key.pem') if (nomad_cli_cert_stat is defined and nomad_cli_cert_stat.stat is defined and nomad_cli_cert_stat.stat.exists) else omit }}"

--- a/ansible/roles/last30days_service/tasks/main.yaml
+++ b/ansible/roles/last30days_service/tasks/main.yaml
@@ -1,3 +1,12 @@
+- name: Check if Nomad CLI cert exists
+  ansible.builtin.stat:
+    path: "{{ nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.cert.pem' }}"
+  register: nomad_cli_cert_stat
+
+- name: Set nomad_protocol fact
+  ansible.builtin.set_fact:
+    nomad_protocol: "{{ \"https\" if nomad_cli_cert_stat.stat.exists else \"http\" }}"
+
 - name: Prune Docker system to free space
   ansible.builtin.command: docker system prune --force
   become: yes


### PR DESCRIPTION
…plate & TLS env

- Set CONSUL_HTTP_ADDR in moe-gateway.nomad.j2 to HTTPS port 8501.
- Refactor gateway.py to run service discovery asynchronously on startup via the FastAPI lifespan context manager, preventing blocking of Uvicorn and failure of Nomad health checks.
- Add strict, secure CA/TLS certificate verification in gateway.py for Consul HTTPS API calls.
- Eliminate deprecated @app.on_event("startup") warning.
- Copy the missing load_image_task.nomad.j2 template to the last30days_service templates directory.
- Update last30days_service tasks and handler to check for Nomad CLI TLS certs and inject correct Nomad environment variables.