### PR TITLE
Fix moe-gateway startup blocking & add missing last30days_service tem…

### DIFF
--- a/ansible/roles/last30days_service/handlers/main.yaml
+++ b/ansible/roles/last30days_service/handlers/main.yaml
@@ -1,5 +1,5 @@
 - name: Run last30days job
-  ansible.builtin.command: "nomad job run {{ nomad_jobs_dir }}/last30days.nomad"
+  ansible.builtin.command: "nomad job run -detach {{ nomad_jobs_dir }}/last30days.nomad"
   become: yes
   environment:
     NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"


### PR DESCRIPTION
…plate & TLS env & detach

- Set CONSUL_HTTP_ADDR in moe-gateway.nomad.j2 to HTTPS port 8501.
- Refactor gateway.py to run service discovery asynchronously on startup via the FastAPI lifespan context manager, preventing blocking of Uvicorn and failure of Nomad health checks.
- Add strict, secure CA/TLS certificate verification in gateway.py for Consul HTTPS API calls.
- Eliminate deprecated @app.on_event("startup") warning.
- Copy the missing load_image_task.nomad.j2 template to the last30days_service templates directory.
- Update last30days_service tasks and handler to check for Nomad CLI TLS certs and inject correct Nomad environment variables.
- Add -detach flag to last30days_service nomad job run to prevent deployment hangs.