### PR TITLE
Make troubleshoot subcommand argument optional and default to report generation

### DIFF
--- a/scripts/troubleshoot.py
+++ b/scripts/troubleshoot.py
@@ -900,7 +900,7 @@ def cmd_opencode_status(args):
 def main():
     """Main CLI execution entry point."""
     parser = argparse.ArgumentParser(description="Troubleshoot Nomad & Systemd services.")
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="command")
 
     opencode_status_parser = subparsers.add_parser("opencode-status", help="Unified Opencode status diagnostics")
     opencode_status_parser.add_argument("--json", action="store_true", help="Output in JSON format")
@@ -938,7 +938,12 @@ def main():
     daemon_parser.set_defaults(func=cmd_daemon)
 
     args = parser.parse_args()
-    args.func(args)
+    if args.command is None:
+        # Default to comprehensive troubleshooting report
+        args.json = False
+        cmd_report(args)
+    else:
+        args.func(args)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_troubleshoot.py
+++ b/tests/unit/test_troubleshoot.py
@@ -278,3 +278,14 @@ def test_fetch_alloc_logs_with_fallback(mock_api_get, mock_run_command):
     assert "DriverError" in logs
     assert "Docker container died on startup" in logs
     assert "Actual docker stderr fallback log line!" in logs
+
+
+@patch('troubleshoot.cmd_report')
+def test_main_default_command(mock_cmd_report):
+    """Verifies that calling main with no command arguments defaults to cmd_report."""
+    with patch('sys.argv', ['troubleshoot.py']):
+        troubleshoot.main()
+        mock_cmd_report.assert_called_once()
+        args_passed = mock_cmd_report.call_args[0][0]
+        assert args_passed.command is None
+        assert args_passed.json is False


### PR DESCRIPTION
Made the troubleshoot subcommand parameter optional and set the default fallback action to run cmd_report (comprehensive diagnostics report), preventing upbringing failures on bootstrap scripts.

---
*PR created automatically by Jules for task [2713234229458894068](https://jules.google.com/task/2713234229458894068) started by @LokiMetaSmith*