### PR TITLE
Document status option in bootstrap.sh help menu

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,6 +48,7 @@ show_help() {
     echo "  --home-assistant-debug       Enable debug mode for Home Assistant."
     echo "  --container                  Run the entire infrastructure inside a single large container."
     echo "  --watch <target>             Pause for inspection after the specified target (task/role) completes."
+    echo "  --status                     Show the current cluster and Opencode status and exit."
     echo "  -h, --help                   Display this help message and exit."
     echo ""
     echo "OS Recovery Snapshot Options:"


### PR DESCRIPTION
Documented the '--status' command option in 'bootstrap.sh' help menu so that it displays correctly when running with '-h' or '--help'.

---
*PR created automatically by Jules for task [17011510116560692256](https://jules.google.com/task/17011510116560692256) started by @LokiMetaSmith*