### PR TITLE
fix: resolve mcp dependency crash and local world model import issue

### DIFF
--- a/pipecatapp/local_world_model.py
+++ b/pipecatapp/local_world_model.py
@@ -6,7 +6,19 @@ import httpx
 import yaml
 import re
 from typing import Dict, Any, List, Optional
-from pipecatapp.ontology import WorldOntology, Device, Agent, Node, Cluster
+try:
+    from pipecatapp.ontology import WorldOntology, Device, Agent, Node, Cluster
+except ImportError:
+    try:
+        from ontology import WorldOntology, Device, Agent, Node, Cluster
+    except ImportError:
+        import sys
+        import os
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        parent_dir = os.path.dirname(current_dir)
+        if parent_dir not in sys.path:
+            sys.path.insert(0, parent_dir)
+        from pipecatapp.ontology import WorldOntology, Device, Agent, Node, Cluster
 
 try:
     import paho.mqtt.client as mqtt

--- a/tests/unit/test_app_hybrid.py
+++ b/tests/unit/test_app_hybrid.py
@@ -103,7 +103,7 @@ async def test_monolith_mode_answers_hello(mocker):
     }
     mock_workflow_runner.run = AsyncMock(return_value=final_response_payload)
 
-    with patch('app.PMMMemoryClient'), patch('app.PMMMemory'), patch('tools.code_runner_tool.docker.from_env', create=True), patch('tools.skill_builder_tool.MemoryStore'):
+    with patch('app.PMMMemoryClient'), patch('app.PMMMemory'), patch('tools.code_runner_tool.docker.from_env', create=True), patch('tools.skill_builder_tool.MemoryStore'), patch('pipecatapp.tools.document_tool.os.path.exists', return_value=True), patch('pipecatapp.tools.p2p_sync_tool.os.makedirs'):
         with patch.dict(os.environ, {"HA_URL": "http://mock-ha", "HA_TOKEN": "mock-token", "LLAMA_API_URL_OVERRIDE": "http://localhost:8080"}):
             service = TwinService(mock_llm, mock_vision, mock_runner, mock_config, asyncio.Queue())
 


### PR DESCRIPTION
- Added `mcp` production package to `pipecatapp/requirements.txt` and lazy-loaded it inside `MCPClientAdapter` with graceful runtime exception handling to avoid hard-crashes.
- Implemented robust fallback import handling in `local_world_model.py` to prevent `ModuleNotFoundError: No module named 'pipecatapp.ontology'` during pre-flight checks in various execution layouts.
- Added comprehensive unit tests in `test_mcp_client_adapter.py` validating both healthy and degraded dependency path behaviors.
- Patched unit tests in `test_app_hybrid.py` to correctly mock environment layout assumptions.