### PR TITLE
Resolve startup circular import in schema_harness_tool

### DIFF
--- a/pipecatapp/tools/schema_harness_tool.py
+++ b/pipecatapp/tools/schema_harness_tool.py
@@ -3,7 +3,6 @@ import json
 import uuid
 import logging
 from typing import Dict, Any, List, Optional
-from pipecatapp.workflow.runner import WorkflowRunner
 from pipecatapp.tools.code_runner_tool import CodeRunnerTool
 
 logger = logging.getLogger(__name__)
@@ -100,6 +99,7 @@ class SchemaHarnessTool:
             logger.info(f"SchemaHarness: Iteration {iteration}. Current state: {state}")
 
             # Deliberate & Plan: run the specialized schema harness workflow
+            from pipecatapp.workflow.runner import WorkflowRunner
             workflow_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "workflows", "schema_harness_workflow.yaml")
             runner = WorkflowRunner(workflow_path)
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -8,17 +8,22 @@ sys.path.append("/app/ansible/roles/pipecatapp/files")
 repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(repo_root, "pipecatapp"))
 
-print("DEBUG: Starting import test", flush=True)
+def test_import_app():
+    print("DEBUG: Starting import test", flush=True)
+    try:
+        print("DEBUG: Importing app...", flush=True)
+        import app
+        print("DEBUG: Successfully imported app.", flush=True)
+    except ImportError as e:
+        print(f"DEBUG: ImportError: {e}", flush=True)
+        raise e
+    except Exception as e:
+        print(f"DEBUG: Exception during import: {e}", flush=True)
+        raise e
+    print("DEBUG: Import test complete.", flush=True)
 
-try:
-    print("DEBUG: Importing app...", flush=True)
-    import app
-    print("DEBUG: Successfully imported app.", flush=True)
-except ImportError as e:
-    print(f"DEBUG: ImportError: {e}", flush=True)
-    sys.exit(1)
-except Exception as e:
-    print(f"DEBUG: Exception during import: {e}", flush=True)
-    sys.exit(1)
-
-print("DEBUG: Import test complete.", flush=True)
+if __name__ == "__main__":
+    try:
+        test_import_app()
+    except Exception:
+        sys.exit(1)


### PR DESCRIPTION
This pull request resolves a critical circular dependency on application startup between the `WorkflowRunner` class and the `schema_harness_tool.py` module. 

By changing the top-level import of `WorkflowRunner` in `pipecatapp/tools/schema_harness_tool.py` to a lazy/local import within the tool's `run` method, we break the circular eager import loop (`runner` -> `nodes` -> `tools` -> `runner`). 

Additionally, `tests/test_imports.py` has been updated to include a standard `test_import_app` function so it can be picked up and verified by `pytest` as a first-class test while remaining directly executable as a python script. All tests and import validations pass successfully.

---
*PR created automatically by Jules for task [7480816436774555492](https://jules.google.com/task/7480816436774555492) started by @LokiMetaSmith*