### PR TITLE
Fix Nomad log retrieval validation error on multi-task allocations

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -373,7 +373,7 @@
 
     - name: Fetch MQTT logs (stdout)
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad alloc logs {{ mqtt_alloc_id.stdout }}"
+        cmd: "/usr/local/bin/nomad alloc logs -task mosquitto {{ mqtt_alloc_id.stdout }}"
       environment:
         NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
@@ -390,7 +390,7 @@
 
     - name: Fetch MQTT logs (stderr)
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad alloc logs -stderr {{ mqtt_alloc_id.stdout }}"
+        cmd: "/usr/local/bin/nomad alloc logs -stderr -task mosquitto {{ mqtt_alloc_id.stdout }}"
       environment:
         NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -1240,7 +1240,7 @@
 
     - name: "Archivist : Fetch Archivist logs (stdout)"
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad alloc logs {{ arch_alloc_id.stdout }}"
+        cmd: "/usr/local/bin/nomad alloc logs -task architect-task {{ arch_alloc_id.stdout }}"
       environment:
         NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
@@ -1257,7 +1257,7 @@
 
     - name: "Archivist : Fetch Archivist logs (stderr)"
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad alloc logs -stderr {{ arch_alloc_id.stdout }}"
+        cmd: "/usr/local/bin/nomad alloc logs -stderr -task architect-task {{ arch_alloc_id.stdout }}"
       environment:
         NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
@@ -1625,7 +1625,7 @@
 
     - name: "Pipecat App : Fetch Pipecat App logs (stdout)"
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad alloc logs {{ pipecat_alloc_id.stdout }}"
+        cmd: "/usr/local/bin/nomad alloc logs -task pipecat-app {{ pipecat_alloc_id.stdout }}"
       environment:
         NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
@@ -1642,7 +1642,7 @@
 
     - name: "Pipecat App : Fetch Pipecat App logs (stderr)"
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad alloc logs -stderr {{ pipecat_alloc_id.stdout }}"
+        cmd: "/usr/local/bin/nomad alloc logs -stderr -task pipecat-app {{ pipecat_alloc_id.stdout }}"
       environment:
         NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -205,7 +205,7 @@
 
     - name: "Tool Server : Fetch Tool Server logs (stdout)"
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad alloc logs {{ ts_alloc_id.stdout }}"
+        cmd: "/usr/local/bin/nomad alloc logs -task tool-server-task {{ ts_alloc_id.stdout }}"
       environment:
         NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
@@ -223,7 +223,7 @@
 
     - name: "Tool Server : Fetch Tool Server logs (stderr)"
       ansible.builtin.command:
-        cmd: "/usr/local/bin/nomad alloc logs -stderr {{ ts_alloc_id.stdout }}"
+        cmd: "/usr/local/bin/nomad alloc logs -stderr -task tool-server-task {{ ts_alloc_id.stdout }}"
       environment:
         NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
         NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"


### PR DESCRIPTION
This PR resolves a validation error encountered when fetching Nomad allocation logs inside Ansible roles. Since several roles include the prestart lifecycle task load-image, their target allocations contain multiple tasks, causing `nomad alloc logs` to fail unless `-task <task_name>` is explicitly specified. We have updated the log fetching commands for the `mqtt`, `pipecatapp` (Archivist and Pipecat App), and `tool_server` roles to always specify their respective service tasks.

---
*PR created automatically by Jules for task [3217959223466654204](https://jules.google.com/task/3217959223466654204) started by @LokiMetaSmith*