### PR TITLE
Fix Jinja syntax and specify Nomad task name for log collection

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -249,6 +249,7 @@
 
 - name: Ensure Mosquitto image is pulled/loaded locally
   ansible.builtin.shell: |
+    {% raw %}
     if docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "eclipse-mosquitto:2"; then
       echo "Image already present"
     elif [ -f /opt/mosquitto.tar ]; then
@@ -256,6 +257,7 @@
     else
       docker pull eclipse-mosquitto:2
     fi
+    {% endraw %}
   become: yes
   changed_when: false
   register: ensure_mosquitto_local


### PR DESCRIPTION
Wrap Docker template format string in raw/endraw tags in MQTT role to prevent Jinja syntax errors, and explicitly pass the target task name argument to nomad alloc logs on multi-task allocations across several roles (mqtt, pipecatapp, tool_server).