### PR TITLE
Fix Nomad deployment diagnostic errors: add psmisc dependency and guard log fetch on pending tasks

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -373,6 +373,11 @@
       register: mqtt_alloc_id
       ignore_errors: yes
 
+    - name: Check mosquitto task state
+      ansible.builtin.command: jq -r 'sort_by(.CreateTime) | reverse | .[0].TaskStates.mosquitto.State' /opt/mqtt_allocs.json
+      register: mosquitto_task_state
+      ignore_errors: yes
+
     - name: Fetch MQTT logs (stdout)
       ansible.builtin.command:
         cmd: "/usr/local/bin/nomad alloc logs -task mosquitto {{ mqtt_alloc_id.stdout }}"
@@ -383,7 +388,7 @@
         NOMAD_CLIENT_KEY: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.key.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
       register: mqtt_logs_stdout
       ignore_errors: yes
-      when: (mqtt_alloc_id.stdout | trim | length > 0) and (mqtt_alloc_id.stdout | trim != 'null')
+      when: (mqtt_alloc_id.stdout | trim | length > 0) and (mqtt_alloc_id.stdout | trim != 'null') and (mosquitto_task_state.stdout | trim != 'pending')
 
     - name: Display MQTT logs (stdout)
       ansible.builtin.debug:
@@ -400,7 +405,7 @@
         NOMAD_CLIENT_KEY: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.key.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
       register: mqtt_logs_stderr
       ignore_errors: yes
-      when: (mqtt_alloc_id.stdout | trim | length > 0) and (mqtt_alloc_id.stdout | trim != 'null')
+      when: (mqtt_alloc_id.stdout | trim | length > 0) and (mqtt_alloc_id.stdout | trim != 'null') and (mosquitto_task_state.stdout | trim != 'pending')
 
     - name: Display MQTT logs (stderr)
       ansible.builtin.debug:

--- a/ansible/roles/system_deps/tasks/main.yaml
+++ b/ansible/roles/system_deps/tasks/main.yaml
@@ -65,6 +65,7 @@
       - openssh-server
       - pkg-config
       - portaudio19-dev
+      - psmisc
       - python3
       - python3-dev
       - python3-full


### PR DESCRIPTION
This change addresses two tooling errors identified in the deployment logs during failure analysis:

1. **`fuser: not found`**: The `psmisc` package was added to the `system_deps` role to ensure that the port cleanup tasks (which use `fuser -k`) execute correctly instead of failing natively.
2. **Nomad logs 404 error**: The log-fetching diagnostic step was failing and throwing a `404` when the mosquitto container hung during the `pending` phase due to an underlying IPFS artifact download timeout. A `jq` check has been added to extract the task's state from the allocation JSON, explicitly gating the `alloc logs` command so it does not run while the task is still in a `pending` state, making failure triage much cleaner.

---
*PR created automatically by Jules for task [11566185324817519624](https://jules.google.com/task/11566185324817519624) started by @LokiMetaSmith*