### PR TITLE
Fix smolagents ImportError on degraded bootstrap and recovery scripts

### DIFF
--- a/ansible/roles/tool_server/tools/smol_agent_tool.py
+++ b/ansible/roles/tool_server/tools/smol_agent_tool.py
@@ -3,26 +3,6 @@ import os
 import shutil
 import re
 
-# This is a placeholder for the actual smolagents library.
-# We will assume it's available in the environment. In a real scenario,
-# this would be a dependency managed by our project's requirements.
-try:
-    from smolagents import CodeAgent, LiteLLMModel
-except ImportError:
-    # If smolagents is not installed, we create mock classes to allow
-    # the application to load without crashing. The tool will return an
-    # error message if it's actually used.
-    class CodeAgent:
-        def __init__(self, *args, **kwargs):
-            raise ImportError("The 'smolagents' library is not installed.")
-        def run(self, *args, **kwargs):
-            pass
-
-    class LiteLLMModel:
-        def __init__(self, *args, **kwargs):
-            pass
-
-
 class SmolAgentTool:
     """
     A tool that uses a smolagents.CodeAgent to solve complex tasks
@@ -48,6 +28,13 @@ class SmolAgentTool:
             # This check ensures that 'deno' is available before trying to use the tool.
             if not shutil.which("deno"):
                 raise FileNotFoundError("The 'deno' runtime is not installed or not in the system's PATH.")
+
+            try:
+                from smolagents import CodeAgent, LiteLLMModel
+            except ImportError as e:
+                import logging
+                logging.error(f"Failed to import 'smolagents': {e}. Please ensure the package is installed.")
+                raise ImportError("The 'smolagents' library is not installed.") from e
 
             # This model will use the environment's LLM provider configuration (e.g., OPENAI_API_KEY).
             model = LiteLLMModel(model_id="gpt-4o")

--- a/pipecatapp/requirements.txt
+++ b/pipecatapp/requirements.txt
@@ -104,3 +104,4 @@ tree-sitter-swift>=0.7.0
 
 # Model Context Protocol support
 mcp
+smolagents

--- a/pipecatapp/tools/smol_agent_tool.py
+++ b/pipecatapp/tools/smol_agent_tool.py
@@ -4,26 +4,6 @@ import shutil
 import re
 from pipecatapp.utils.command_runner import CommandRunner
 
-# This is a placeholder for the actual smolagents library.
-# We will assume it's available in the environment. In a real scenario,
-# this would be a dependency managed by our project's requirements.
-try:
-    from smolagents import CodeAgent, LiteLLMModel
-except ImportError:
-    # If smolagents is not installed, we create mock classes to allow
-    # the application to load without crashing. The tool will return an
-    # error message if it's actually used.
-    class CodeAgent:
-        def __init__(self, *args, **kwargs):
-            raise ImportError("The 'smolagents' library is not installed.")
-        def run(self, *args, **kwargs):
-            pass
-
-    class LiteLLMModel:
-        def __init__(self, *args, **kwargs):
-            pass
-
-
 class SmolAgentTool:
     """
     A tool that uses a smolagents.CodeAgent to solve complex tasks
@@ -49,6 +29,13 @@ class SmolAgentTool:
             # This check ensures that 'deno' is available before trying to use the tool.
             if not shutil.which("deno"):
                 raise FileNotFoundError("The 'deno' runtime is not installed or not in the system's PATH.")
+
+            try:
+                from smolagents import CodeAgent, LiteLLMModel
+            except ImportError as e:
+                import logging
+                logging.error(f"Failed to import 'smolagents': {e}. Please ensure the package is installed.")
+                raise ImportError("The 'smolagents' library is not installed.") from e
 
             # Configure LiteLLMModel to use our local llama.cpp endpoint hosting LFM2.5-1.2B
             model = LiteLLMModel(

--- a/scripts/run_smol_recovery.py
+++ b/scripts/run_smol_recovery.py
@@ -6,9 +6,6 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'p
 
 try:
     from tools.smol_agent_tool import SmolAgentTool
-    # smolagents natively supports adding tools to the agent.
-    # In a real environment, we'd wrap our pipecatapp tools into smolagents.Tool subclass.
-    from smolagents import Tool
 except ImportError as e:
     print(f"Error importing dependencies: {e}")
     sys.exit(1)


### PR DESCRIPTION
Resolves an issue where `scripts/run_smol_recovery.py` would crash immediately with an `ImportError` because `smolagents` was imported at the top-level but was completely missing from `pipecatapp/requirements.txt`.

Fixes implemented:
1.  **Added Missing Dependency**: Appended `smolagents` to the end of `pipecatapp/requirements.txt`.
2.  **Cleaned up Recovery Script**: Removed an unused, eager `import Tool from smolagents` statement from the `run_smol_recovery.py` script.
3.  **Lazy Loading**: In both `pipecatapp/tools/smol_agent_tool.py` and `ansible/roles/tool_server/tools/smol_agent_tool.py`, the `smolagents` library is now lazily imported inside the `_initialize()` method.
4.  **Graceful Fallbacks**: Removed messy top-level mock classes. If `smolagents` fails to import during `_initialize()`, the `ImportError` is correctly trapped, a clean error string is logged, and the tool correctly fails rather than bringing down the importer.

---
*PR created automatically by Jules for task [18181555192370881491](https://jules.google.com/task/18181555192370881491) started by @LokiMetaSmith*