### PR TITLE
chore: enforce strict TLS certificate validation across playbooks

### DIFF
--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -60,7 +60,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/authentik/secret-key"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: GET
     headers:
       X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
@@ -81,7 +81,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/authentik/secret-key"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     headers:
       X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
@@ -97,7 +97,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/authentik/db-password"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: GET
     headers:
       X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
@@ -118,7 +118,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/authentik/db-password"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     headers:
       X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"

--- a/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
@@ -75,7 +75,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port }}/v1/health/service/llamacpp-rpc-provider"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     headers:
       X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
     return_content: yes

--- a/ansible/roles/bootstrap_agent/tasks/main.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/main.yaml
@@ -35,7 +35,7 @@
     - name: Wait for at least 1 Nomad peer
       ansible.builtin.uri:
         url: "https://{{ inventory_hostname }}:{{ nomad_http_port }}/v1/status/peers"
-        validate_certs: no
+        ca_path: "{{ nomad_tls_dir }}/ca.pem"
         return_content: yes
         client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
         client_key: "{{ nomad_tls_dir }}/cli.key.pem"
@@ -59,7 +59,7 @@
 - name: Get Nomad peer status for summary
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port }}/v1/status/peers"
-    validate_certs: no
+    ca_path: "{{ nomad_tls_dir }}/ca.pem"
     return_content: yes
     client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
     client_key: "{{ nomad_tls_dir }}/cli.key.pem"

--- a/ansible/roles/config_manager/tasks/main.yaml
+++ b/ansible/roles/config_manager/tasks/main.yaml
@@ -17,7 +17,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port }}/v1/kv/config/models/{{ item.key }}"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     body: "{{ item.value | to_json }}"
     status_code: 200
@@ -44,7 +44,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port }}/v1/kv/config/app/settings"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     body: >
       {{

--- a/ansible/roles/consul/tasks/acl.yaml
+++ b/ansible/roles/consul/tasks/acl.yaml
@@ -82,7 +82,7 @@
             url: "https://{{ advertise_ip }}:{{ consul_https_port }}/v1/status/leader"
             client_cert: "{{ consul_config_dir | default('/etc/consul.d') }}/cert.pem"
             client_key: "{{ consul_config_dir | default('/etc/consul.d') }}/key.pem"
-            validate_certs: false
+            ca_path: "/etc/consul.d/ca.pem"
           register: consul_status_recovery
           until: consul_status_recovery.status is defined and consul_status_recovery.status == 200
           retries: 30

--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -447,7 +447,7 @@
         url: "https://{{ cluster_ip }}:{{ consul_https_port }}/v1/status/leader"
         client_cert: "{{ consul_config_dir | default('/etc/consul.d') }}/cert.pem"
         client_key: "{{ consul_config_dir | default('/etc/consul.d') }}/key.pem"
-        validate_certs: false
+        ca_path: "/etc/consul.d/ca.pem"
 
       register: consul_status
       until: consul_status.status == 200

--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -35,7 +35,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs?keys"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: GET
     headers:
       X-Consul-Token: "{{ consul_token }}"
@@ -55,7 +55,7 @@
         url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/{{ item }}?raw=true"
         client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
         client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-        validate_certs: false
+        ca_path: "/etc/consul.d/ca.pem"
         method: GET
         headers:
           X-Consul-Token: "{{ consul_token }}"

--- a/ansible/roles/moe_gateway/tasks/main.yaml
+++ b/ansible/roles/moe_gateway/tasks/main.yaml
@@ -54,7 +54,7 @@
 - name: Wait for Nomad API to be ready
   ansible.builtin.uri:
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port }}/v1/status/leader"
-    validate_certs: no
+    ca_path: "{{ nomad_tls_dir }}/ca.pem"
     method: GET
     status_code: 200
     client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
@@ -105,7 +105,7 @@
         url: "https://127.0.0.1:{{ consul_https_port }}/v1/health/service/moe-gateway"
         client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
         client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-        validate_certs: false
+        ca_path: "/etc/consul.d/ca.pem"
         method: GET
         headers:
           X-Consul-Token: "{{ consul_bootstrap_token }}"

--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -86,7 +86,7 @@
         url: "https://{{ cluster_ip }}:{{ consul_https_port }}/v1/status/leader"
         client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
         client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-        validate_certs: false
+        ca_path: "/etc/consul.d/ca.pem"
         return_content: yes
       register: consul_leader_check
       ignore_errors: yes
@@ -100,7 +100,7 @@
         url: "https://{{ cluster_ip }}:{{ consul_https_port }}/v1/agent/self"
         client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
         client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-        validate_certs: false
+        ca_path: "/etc/consul.d/ca.pem"
         headers:
           X-Consul-Token: "{{ consul_bootstrap_token | default('') }}"
         return_content: yes
@@ -130,7 +130,7 @@
     - name: Wait for Nomad API to be ready after restart
       ansible.builtin.uri:
         url: "https://{{ cluster_ip }}:{{ nomad_http_port }}/v1/agent/self"
-        validate_certs: no
+        ca_path: "{{ nomad_tls_dir }}/ca.pem"
         status_code: 200
         client_cert: "{{ nomad_tls_dir }}/cli.cert.pem"
         client_key: "{{ nomad_tls_dir }}/cli.key.pem"
@@ -311,7 +311,7 @@
         url: "https://{{ advertise_ip }}:{{ consul_https_port }}/v1/health/service/mqtt?passing"
         client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
         client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-        validate_certs: false
+        ca_path: "/etc/consul.d/ca.pem"
         method: GET
         headers:
           X-Consul-Token: "{{ consul_bootstrap_token | default('') }}"

--- a/ansible/roles/nomad/handlers/restart_nomad_handler_tasks.yaml
+++ b/ansible/roles/nomad/handlers/restart_nomad_handler_tasks.yaml
@@ -24,7 +24,7 @@
 - name: Wait for Nomad API to be ready after restart
   ansible.builtin.uri:
     url: "{{ nomad_protocol | default('https') }}://{{ cluster_ip }}:{{ nomad_http_port }}/v1/agent/self"
-    validate_certs: "{{ 'yes' if nomad_cli_cert_stat_handler.stat.exists else 'no' }}"
+    validate_certs: yes
     ca_path: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat_handler.stat.exists else omit }}"
     client_cert: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.cert.pem') if nomad_cli_cert_stat_handler.stat.exists else omit }}"
     client_key: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.key.pem') if nomad_cli_cert_stat_handler.stat.exists else omit }}"

--- a/ansible/roles/nomad/tasks/main.yaml
+++ b/ansible/roles/nomad/tasks/main.yaml
@@ -480,7 +480,7 @@
 - name: Wait for Nomad API to be ready
   ansible.builtin.uri:
     url: "{{ nomad_protocol | default('https') }}://{{ cluster_ip }}:{{ nomad_http_port }}/v1/agent/self"
-    validate_certs: "{{ 'yes' if nomad_cli_cert_stat.stat.exists else 'no' }}"
+    validate_certs: yes
     ca_path: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
     status_code: 200
     client_cert: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.cert.pem') if nomad_cli_cert_stat.stat.exists else omit }}"

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -44,7 +44,7 @@
 - name: Wait for Nomad API to be ready on mesh network
   ansible.builtin.uri:
     url: "{{ nomad_protocol | default('https') }}://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}/v1/agent/self"
-    validate_certs: "{{ 'yes' if nomad_cli_cert_stat.stat.exists else 'no' }}"
+    validate_certs: yes
     ca_path: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
     method: GET
     status_code: 200
@@ -1149,7 +1149,7 @@
 - name: Wait for Nomad API to be ready
   ansible.builtin.uri:
     url: "{{ nomad_protocol | default('https') }}://{{ cluster_ip }}:{{ nomad_http_port | default(4646) }}/v1/agent/self"
-    validate_certs: "{{ 'yes' if nomad_cli_cert_stat.stat.exists else 'no' }}"
+    validate_certs: yes
     ca_path: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
     method: GET
     status_code: 200

--- a/ansible/roles/pipecatapp/templates/start_pipecatapp.sh.j2
+++ b/ansible/roles/pipecatapp/templates/start_pipecatapp.sh.j2
@@ -251,7 +251,7 @@ if [ "$MODE" = "distributed" ]; then
 
     # Wait for Nomad cluster network to be ready
     log_msg "Waiting for Nomad cluster to become accessible..."
-    while ! curl -k -s "${NOMAD_ADDR}/v1/agent/self" > /dev/null; do
+    while ! curl --cacert "${NOMAD_CACERT}" -s "${NOMAD_ADDR}/v1/agent/self" > /dev/null; do
         log_msg "Nomad API at ${NOMAD_ADDR} not yet available. Retrying in 5 seconds..."
         sleep 5
     done

--- a/ansible/roles/seed_models/tasks/main.yaml
+++ b/ansible/roles/seed_models/tasks/main.yaml
@@ -17,7 +17,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/{{ item }}?raw=true"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: GET
     headers:
       X-Consul-Token: "{{ consul_token }}"
@@ -101,7 +101,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/llm/{{ item.item.filename }}"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -153,7 +153,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/vllm/{{ item.item.repo_id.split('/')[-1] }}"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -224,7 +224,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/stt/{{ item.item[0].key }}/{{ item.item[1].filename }}"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -246,7 +246,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/stt/{{ item.item[0].key }}/{{ item.item[1].name }}"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -294,7 +294,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/tts/{{ item.item.filename }}"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -364,7 +364,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/vision/{{ item.item.filename }}"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -386,7 +386,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/vision/{{ item.item.name }}"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -438,7 +438,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/embedding/{{ item.item.name }}"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     body: "{{ item.stdout }}"
     headers:
@@ -460,7 +460,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/reference_data/main"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: PUT
     body: "{{ reference_data_ipfs_cid.stdout }}"
     headers:

--- a/ansible/roles/tpm_ssh/tasks/main.yaml
+++ b/ansible/roles/tpm_ssh/tasks/main.yaml
@@ -143,7 +143,7 @@
         url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/ssh-keys/{{ inventory_hostname }}"
         client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
         client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-        validate_certs: false
+        ca_path: "/etc/consul.d/ca.pem"
         method: PUT
         body: "{{ tpm_pub_key.stdout }}"
         status_code: [200, 201]

--- a/ansible/tasks/deploy_model_gpu_provider.yaml
+++ b/ansible/tasks/deploy_model_gpu_provider.yaml
@@ -68,7 +68,7 @@
       X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     return_content: yes
   register: consul_health
   until: "consul_health.json is defined and consul_health.json | length >= expected_worker_count | int"

--- a/ansible/tests/verify_grafana.yaml
+++ b/ansible/tests/verify_grafana.yaml
@@ -24,7 +24,7 @@
         return_content: yes
         client_cert: "/etc/nomad.d/tls/cli.cert.pem"
         client_key: "/etc/nomad.d/tls/cli.key.pem"
-        validate_certs: no
+        validate_certs: yes
       register: grafana_job_status
       retries: 5
       delay: 5

--- a/playbooks/benchmark_single_model.yaml
+++ b/playbooks/benchmark_single_model.yaml
@@ -17,7 +17,7 @@
     url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/models/ipfs/llm/{{ model_item.filename }}?raw=true"
     client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
     client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-    validate_certs: false
+    ca_path: "/etc/consul.d/ca.pem"
     method: GET
     headers:
       X-Consul-Token: "{{ (benchmark_consul_token_slurp.content | b64decode | trim) if (benchmark_consul_token_slurp.content is defined) else '' }}"

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -282,7 +282,7 @@
               X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
             client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
             client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-            validate_certs: false
+            ca_path: "/etc/consul.d/ca.pem"
             return_content: yes
           register: expert_health
           until: >

--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -17,7 +17,7 @@
         url: "https://{{ cluster_ip }}:{{ consul_https_port | default(8501) }}/v1/status/leader"
         client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
         client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-        validate_certs: false
+        ca_path: "/etc/consul.d/ca.pem"
         return_content: yes
       register: consul_leader_status
       until: consul_leader_status.status is defined and consul_leader_status.status == 200 and consul_leader_status.content is defined and consul_leader_status.content != '""'

--- a/playbooks/services/final_verification.yaml
+++ b/playbooks/services/final_verification.yaml
@@ -33,7 +33,7 @@
               url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/status/leader"
               client_cert: "{{ consul_client_cert_path | default('/etc/consul.d/cert.pem') }}"
               client_key: "{{ consul_client_key_path | default('/etc/consul.d/key.pem') }}"
-              validate_certs: false
+              ca_path: "/etc/consul.d/ca.pem"
               return_content: yes
             register: consul_leader_status
             until: consul_leader_status.status is defined and consul_leader_status.status == 200 and consul_leader_status.content is defined and consul_leader_status.content != '""'

--- a/tests/playbooks/verify_cluster_network.yaml
+++ b/tests/playbooks/verify_cluster_network.yaml
@@ -49,7 +49,7 @@
         method: GET
         client_cert: "{{ nomad_tls_dir | default('/etc/nomad.d/tls') }}/cli.cert.pem"
         client_key: "{{ nomad_tls_dir | default('/etc/nomad.d/tls') }}/cli.key.pem"
-        validate_certs: no # Skip verify if using self-signed
+        validate_certs: yes # Skip verify if using self-signed
       register: nomad_api_result
       ignore_errors: yes
 


### PR DESCRIPTION
Replaced TLS certificate bypasses with strict validation and CA path provisioning in playbooks.

---
*PR created automatically by Jules for task [14456971442382611293](https://jules.google.com/task/14456971442382611293) started by @LokiMetaSmith*