### PR TITLE
Fix ISO build failure due to obsolete plasma-workspace-wayland package

### DIFF
--- a/os-image/config/package-lists/pipecat.list.chroot
+++ b/os-image/config/package-lists/pipecat.list.chroot
@@ -22,7 +22,7 @@ xorriso
 # --- CommandDeck GUI Kiosk and Fallback Desktop Dependencies ---
 sddm
 kde-plasma-desktop
-plasma-workspace-wayland
+plasma-workspace
 cage
 python3-webview
 gir1.2-webkit2-4.1


### PR DESCRIPTION
This replaces the obsolete `plasma-workspace-wayland` package with `plasma-workspace` in the `pipecat.list.chroot` package list for the custom Debian Trixie ISO build. `plasma-workspace-wayland` has no installation candidate as Plasma 6 directly bundles Wayland support. This fixes the apt installation failure during the `live-build` process.

---
*PR created automatically by Jules for task [11053479623495551366](https://jules.google.com/task/11053479623495551366) started by @LokiMetaSmith*