### PR TITLE
Fix rsync vanished files error in core_infra.yaml

### DIFF
--- a/playbooks/services/core_infra.yaml
+++ b/playbooks/services/core_infra.yaml
@@ -27,6 +27,9 @@
         dest: /opt/cluster-infra/
         rsync_opts:
           - "--exclude=.git"
+          - "--exclude=os-image/chroot"
+          - "--exclude=os-image/binary"
+          - "--exclude=os-image/.build"
       when: inventory_hostname != 'localhost'
 
     - name: Synchronize control repository for local bootstrap
@@ -37,6 +40,9 @@
         dest: /opt/cluster-infra/
         rsync_opts:
           - "--exclude=.git"
+          - "--exclude=os-image/chroot"
+          - "--exclude=os-image/binary"
+          - "--exclude=os-image/.build"
       when: inventory_hostname == 'localhost'
   roles:
     - role: btrfs_snapshot


### PR DESCRIPTION
During the bootstrap process, `rsync` was failing with code 24 ("some files vanished before they could be transferred") because temporary build artifacts inside the `os-image/` directory (like `chroot`, `binary`, and `.build`) were being created and deleted rapidly while the synchronization was running. This change explicitly excludes these ephemeral directories in `playbooks/services/core_infra.yaml` to ensure reliable synchronization of the control repository.

---
*PR created automatically by Jules for task [11809836522039404664](https://jules.google.com/task/11809836522039404664) started by @LokiMetaSmith*