### PR TITLE
Fix IPFS race condition and bootstrap deployment stability

### DIFF
--- a/ansible/roles/ipfs/tasks/main.yaml
+++ b/ansible/roles/ipfs/tasks/main.yaml
@@ -131,6 +131,16 @@
     timeout: 300
     state: started
 
+- name: Wait for IPFS Gateway to be fully ready
+  ansible.builtin.uri:
+    url: "http://{{ cluster_ip | default('127.0.0.1') }}:{{ ipfs_gateway_port | default(8080) }}/"
+    return_content: yes
+    status_code: [200, 400, 403, 404]
+  register: ipfs_gateway_status
+  until: ipfs_gateway_status.status in [200, 400, 403, 404]
+  retries: 30
+  delay: 5
+
 - name: Deploy automated IPFS P2P model pinning script
   ansible.builtin.copy:
     content: |

--- a/ansible/roles/tailscale/tasks/main.yaml
+++ b/ansible/roles/tailscale/tasks/main.yaml
@@ -11,6 +11,12 @@
     state: present
     reload: yes
 
+- name: Ensure tailscaled is started and enabled
+  ansible.builtin.systemd:
+    name: tailscaled
+    state: started
+    enabled: yes
+
 - name: Check Tailscale status
   command: tailscale status
   register: tailscale_status
@@ -28,9 +34,9 @@
   changed_when: "'Success' in tailscale_up.stdout"
 
 - name: Wait for tailscale0 interface to have an IP
-  ansible.builtin.shell: |
-    set -o pipefail
-    tailscale ip -4 | grep "^100\."
+  ansible.builtin.shell: 'tailscale ip -4 | grep "^100\."'
+  args:
+    executable: /bin/bash
   register: tailscale_ip_check
   until: tailscale_ip_check.rc == 0
   retries: 24

--- a/ansible/tasks/deploy_expert_wrapper.yaml
+++ b/ansible/tasks/deploy_expert_wrapper.yaml
@@ -22,6 +22,10 @@
           - "--exclude=__pycache__"
           - "--exclude=*.pyc"
           - "--exclude=start_pipecat.sh"
+          - "--exclude=os-image/chroot"
+          - "--exclude=os-image/cache"
+          - "--exclude=os-image/.build"
+          - "--exclude=os-image/binary"
         rsync_path: "sudo rsync"
 
     - name: "Expert {{ expert_name }} : Build pipecatapp image if missing"

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -95,6 +95,10 @@
               - "--exclude=__pycache__"
               - "--exclude=*.pyc"
               - "--exclude=start_pipecat.sh"
+              - "--exclude=os-image/chroot"
+              - "--exclude=os-image/cache"
+              - "--exclude=os-image/.build"
+              - "--exclude=os-image/binary"
             rsync_path: "sudo rsync"
           tags:
             - deploy-expert

--- a/playbooks/services/core_infra.yaml
+++ b/playbooks/services/core_infra.yaml
@@ -27,6 +27,10 @@
         dest: /opt/cluster-infra/
         rsync_opts:
           - "--exclude=.git"
+          - "--exclude=os-image/chroot"
+          - "--exclude=os-image/cache"
+          - "--exclude=os-image/.build"
+          - "--exclude=os-image/binary"
       when: inventory_hostname != 'localhost'
 
     - name: Synchronize control repository for local bootstrap
@@ -37,6 +41,10 @@
         dest: /opt/cluster-infra/
         rsync_opts:
           - "--exclude=.git"
+          - "--exclude=os-image/chroot"
+          - "--exclude=os-image/cache"
+          - "--exclude=os-image/.build"
+          - "--exclude=os-image/binary"
       when: inventory_hostname == 'localhost'
   roles:
     - role: btrfs_snapshot


### PR DESCRIPTION
Fixed multiple related bugs in the cluster bootstrap scripts:
1. Added an explicit HTTP readiness check for the IPFS gateway to ensure `load-image` tasks on Nomad start reliably.
2. Modified the Ansible `tailscale` task to explicitly enable the `tailscaled` daemon and use `/bin/bash` to avoid pipeline errors on pure `/bin/sh` systems.
3. Added critical excludes (`os-image/chroot`, `os-image/cache`, `os-image/.build`, `os-image/binary`) to `ansible.posix.synchronize` loops to prevent rsync failures from transient build artifacts.

---
*PR created automatically by Jules for task [8013799654781669737](https://jules.google.com/task/8013799654781669737) started by @LokiMetaSmith*