### PR TITLE
docs: Add Headscale Android client setup guide

### DIFF
--- a/docs/manual/HEADSCALE_ANDROID_SETUP.md
+++ b/docs/manual/HEADSCALE_ANDROID_SETUP.md
@@ -1,0 +1,60 @@
+# Connecting an Android Client to Headscale
+
+This guide walks you through the process of connecting the official Tailscale Android client to our custom Headscale cluster mesh network.
+
+## Prerequisites
+
+* Your device must have network reachability to the Headscale service.
+* You need to know your cluster domain. By default, this is `local.mesh`, making the Headscale URL `https://headscale.local.mesh`.
+
+## 1. Installation
+
+Install the official Tailscale Android client from your preferred app store:
+
+* [Google Play Store](https://play.google.com/store/apps/details?id=com.tailscale.ipn)
+* [F-Droid](https://f-droid.org/packages/com.tailscale.ipn/)
+
+## 2. Connecting to the Node
+
+You can authenticate the Android client using either web authentication or a pre-authenticated key.
+
+### Option A: Connect via Web Authentication
+
+1. Open the Tailscale app and select the **Settings menu** in the upper-right corner.
+2. Tap on **Accounts**.
+3. Tap the kebab menu icon (three dots) in the upper-right corner and select **Use an alternate server**.
+4. Enter your Headscale server URL:
+   * **URL:** `https://headscale.<your_cluster_domain>` (e.g., `https://headscale.local.mesh`)
+5. Follow the on-screen instructions. The client will connect automatically as soon as the node registration is complete on the Headscale server. Until then, nothing is visible in the server logs.
+
+### Option B: Connect using a Pre-Authenticated Key
+
+1. Open the Tailscale app and select the **Settings menu** in the upper-right corner.
+2. Tap on **Accounts**.
+3. Tap the kebab menu icon (three dots) in the upper-right corner and select **Use an alternate server**.
+4. Enter your Headscale server URL:
+   * **URL:** `https://headscale.<your_cluster_domain>` (e.g., `https://headscale.local.mesh`)
+5. If a login prompt opens, close it and continue.
+6. Open the **Settings menu** again in the upper-right corner.
+7. Tap on **Accounts**.
+8. Tap the kebab menu icon (three dots) in the upper-right corner and select **Use an auth key**.
+9. Enter your pre-auth key (see [Getting a Pre-Auth Key](#getting-a-pre-auth-key) below).
+10. If needed, tap **Log in** on the main screen. You should now be connected to your Headscale mesh network.
+
+## Getting a Pre-Auth Key
+
+If you are an administrator, you need to provide users with a pre-authenticated key to use Option B.
+
+### During Ansible Provisioning
+
+The Ansible playbook automatically generates an initial 24-hour reusable pre-auth key for the default namespace during the cluster bootstrapping process. You can find this key by reviewing the output logs of the Ansible provisioning run, specifically during the `headscale` role execution under the task `Create pre-auth key` or `Set headscale auth key fact`.
+
+### Generating Manually via CLI
+
+If the initial key has expired or you need to generate a new one, log in to the node running Headscale and execute the following command:
+
+```bash
+headscale --user default preauthkeys create --reusable --expiration 24h
+```
+
+*(Note: Replace `default` with your specific namespace if you have customized the `headscale_namespace` variable in the Ansible configuration).*

--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -10,12 +10,12 @@ These manuals are organized thematically to provide a logical path from high-lev
 
 These documents provide a holistic view of the cluster design, core components, and high-level summaries of the entire hardware and software stack.
 
-*   **[Holistic Project Architecture](ARCHITECTURE.md)**
-    *   *Description:* A comprehensive overview of all seven layers of the cluster architecture, from physical PXE-boot provisioning and Ansible configuration, to Nomad orchestration, IPFS decentralized storage, Btrfs snapshot recovery, and the autonomous Self-Adaptation Loop (SEAL).
-*   **[Project Summary: Conversational AI Pipeline](PROJECT_SUMMARY.md)**
-    *   *Description:* A condensed, high-level summary detailing the final operational architecture, implemented real-time features, and reference designs.
-*   **[GEMINI Overview & Setup Instructions](GEMINI.md)**
-    *   *Description:* High-level guide for building, bootstrapping, and bringing up the cluster on single or multi-node configurations.
+* **[Holistic Project Architecture](ARCHITECTURE.md)**
+  * *Description:* A comprehensive overview of all seven layers of the cluster architecture, from physical PXE-boot provisioning and Ansible configuration, to Nomad orchestration, IPFS decentralized storage, Btrfs snapshot recovery, and the autonomous Self-Adaptation Loop (SEAL).
+* **[Project Summary: Conversational AI Pipeline](PROJECT_SUMMARY.md)**
+  * *Description:* A condensed, high-level summary detailing the final operational architecture, implemented real-time features, and reference designs.
+* **[GEMINI Overview & Setup Instructions](GEMINI.md)**
+  * *Description:* High-level guide for building, bootstrapping, and bringing up the cluster on single or multi-node configurations.
 
 ---
 
@@ -23,16 +23,16 @@ These documents provide a holistic view of the cluster design, core components, 
 
 These guides describe the cognitive models, Mixture of Experts (MoE) routing backends, and governance models that dictate the agent's behavior and intelligence.
 
-*   **[AI Agent Architectures](AGENTS.md)**
-    *   *Description:* Explains the dual agent architectures used in the system: the runtime Mixture of Experts (MoE) workflow engine for the production application and the multi-agent development Ensemble for code generation.
-*   **[AI Agent Integration Handbook](AGENT_HANDBOOK.md)**
-    *   *Description:* A practical handbook for extending and managing the MoE gateway, creating custom Model Context Protocol (MCP) servers, and optional Ansible role toggles.
-*   **[AI Governance & Architecture Plan](AI_GOVERNANCE.md)**
-    *   *Description:* Outlines the structural taxonomic definitions (KPMG TACO mapping) and the five core pillars of agentic governance (Identity, Capability Alignment, Logging/Auditing, Security, and Resource Bounds).
-*   **[Agent Memories & Operational Lessons](MEMORIES.md)**
-    *   *Description:* A living directory compiling critical operational best practices, lessons, and troubleshooting experiences across Ansible, Nomad, Consul, and development workflows.
-*   **[Frontier Agent Roadmap](FRONTIER_AGENT_ROADMAP.md)**
-    *   *Description:* A strategic gap analysis and multi-phase implementation roadmap for moving from simple chat loops to advanced reasoning and self-evolving autonomy.
+* **[AI Agent Architectures](AGENTS.md)**
+  * *Description:* Explains the dual agent architectures used in the system: the runtime Mixture of Experts (MoE) workflow engine for the production application and the multi-agent development Ensemble for code generation.
+* **[AI Agent Integration Handbook](AGENT_HANDBOOK.md)**
+  * *Description:* A practical handbook for extending and managing the MoE gateway, creating custom Model Context Protocol (MCP) servers, and optional Ansible role toggles.
+* **[AI Governance & Architecture Plan](AI_GOVERNANCE.md)**
+  * *Description:* Outlines the structural taxonomic definitions (KPMG TACO mapping) and the five core pillars of agentic governance (Identity, Capability Alignment, Logging/Auditing, Security, and Resource Bounds).
+* **[Agent Memories & Operational Lessons](MEMORIES.md)**
+  * *Description:* A living directory compiling critical operational best practices, lessons, and troubleshooting experiences across Ansible, Nomad, Consul, and development workflows.
+* **[Frontier Agent Roadmap](FRONTIER_AGENT_ROADMAP.md)**
+  * *Description:* A strategic gap analysis and multi-phase implementation roadmap for moving from simple chat loops to advanced reasoning and self-evolving autonomy.
 
 ---
 
@@ -40,16 +40,16 @@ These guides describe the cognitive models, Mixture of Experts (MoE) routing bac
 
 These documents describe how the conversational agent interacts with host systems, external applications, and knowledge bases.
 
-*   **[Obsidian Workflow Design: The Active Vault](OBSIDIAN_WORKFLOW_DESIGN.md)**
-    *   *Description:* Details the design of the "Active Vault" architecture which bridges the gap between Obsidian's 2D/3D Canvas interface and Pipecat's declarative YAML workflow runner.
-*   **[MCP Migration Plan](MCP_MIGRATION_PLAN.md)**
-    *   *Description:* The strategy and roadmap for decoupling tightly-coupled legacy tool executors into standardized, isolated JSON-RPC Model Context Protocol (MCP) servers.
-*   **[MCP Server Setup with Service Discovery](MCP_SERVER_SETUP.md)**
-    *   *Description:* Explores the implementation patterns for running MCP servers alongside dynamic discovery backends like Consul, etcd, or Kubernetes.
-*   **[External Application Hosting & Package Management](EXTERNAL_APP_HOSTING_GUIDE.md)**
-    *   *Description:* A developer guide to the containerized package manager, detailing the strict JSON manifest schemas, Btrfs subvolume provisioning lifecycle, and the companion CLI utility.
-*   **[TwinService Demonolithization Design](TWINSERVICE_DEMONOLITHIZATION_DESIGN.md)**
-    *   *Description:* An architectural design for decomposing the monolithic `TwinService` into clean, decoupled microservices separating real-time audio/video streaming from cognitive LLM routing.
+* **[Obsidian Workflow Design: The Active Vault](OBSIDIAN_WORKFLOW_DESIGN.md)**
+  * *Description:* Details the design of the "Active Vault" architecture which bridges the gap between Obsidian's 2D/3D Canvas interface and Pipecat's declarative YAML workflow runner.
+* **[MCP Migration Plan](MCP_MIGRATION_PLAN.md)**
+  * *Description:* The strategy and roadmap for decoupling tightly-coupled legacy tool executors into standardized, isolated JSON-RPC Model Context Protocol (MCP) servers.
+* **[MCP Server Setup with Service Discovery](MCP_SERVER_SETUP.md)**
+  * *Description:* Explores the implementation patterns for running MCP servers alongside dynamic discovery backends like Consul, etcd, or Kubernetes.
+* **[External Application Hosting & Package Management](EXTERNAL_APP_HOSTING_GUIDE.md)**
+  * *Description:* A developer guide to the containerized package manager, detailing the strict JSON manifest schemas, Btrfs subvolume provisioning lifecycle, and the companion CLI utility.
+* **[TwinService Demonolithization Design](TWINSERVICE_DEMONOLITHIZATION_DESIGN.md)**
+  * *Description:* An architectural design for decomposing the monolithic `TwinService` into clean, decoupled microservices separating real-time audio/video streaming from cognitive LLM routing.
 
 ---
 
@@ -57,14 +57,16 @@ These documents describe how the conversational agent interacts with host system
 
 These blueprints describe the dual-layer network, mesh tunnels, firewall rules, and cryptographic security features of the cluster.
 
-*   **[Network Architecture Blueprints](NETWORK.md)**
-    *   *Description:* Details the split between the Provisioning Underlay (static 10.0.0.x Layer 2 network for PXE booting) and the Production Overlay (Tailscale WireGuard mesh service network).
-*   **[AI Cluster Network Isolation Guide](NETWORK_ISOLATION.md)**
-    *   *Description:* Guarantees the absolute security of the cluster, outlining VLAN configurations, dedicated routing interfaces, and how to avoid standard "Double NAT" network traps.
-*   **[Cluster Load Testing and Network Validation](LOAD_TESTING.md)**
-    *   *Description:* Practical test playbooks to validate network isolation, verify Traefik Layer 7 load-balancing performance, and diagnose mesh network latency.
-*   **[SPIFFE/SPIRE Integration PoC](SPIRE_POC.md)**
-    *   *Description:* A proof-of-concept design for implementing a Zero-Trust service mesh with cryptographic SPIFFE IDs and SVID credentials on Nomad.
+* **[Network Architecture Blueprints](NETWORK.md)**
+  * *Description:* Details the split between the Provisioning Underlay (static 10.0.0.x Layer 2 network for PXE booting) and the Production Overlay (Tailscale WireGuard mesh service network).
+* **[AI Cluster Network Isolation Guide](NETWORK_ISOLATION.md)**
+  * *Description:* Guarantees the absolute security of the cluster, outlining VLAN configurations, dedicated routing interfaces, and how to avoid standard "Double NAT" network traps.
+* **[Cluster Load Testing and Network Validation](LOAD_TESTING.md)**
+  * *Description:* Practical test playbooks to validate network isolation, verify Traefik Layer 7 load-balancing performance, and diagnose mesh network latency.
+* **[SPIFFE/SPIRE Integration PoC](SPIRE_POC.md)**
+  * *Description:* A proof-of-concept design for implementing a Zero-Trust service mesh with cryptographic SPIFFE IDs and SVID credentials on Nomad.
+* **[Headscale Android Setup](HEADSCALE_ANDROID_SETUP.md)**
+  * *Description:* A guide to configuring and connecting the Tailscale Android client to the custom Headscale cluster mesh network.
 
 ---
 
@@ -72,16 +74,16 @@ These blueprints describe the dual-layer network, mesh tunnels, firewall rules, 
 
 These guides explain how to build, deploy, boot, and optimize cluster nodes and core AI software.
 
-*   **[iPXE Boot Server Setup (Debian)](PXE_BOOT_SETUP.md)**
-    *   *Description:* Step-by-step setup of the local DHCP/TFTP/HTTP PXE server to automate headless Debian 13 installations.
-*   **[NixOS-based PXE Boot Server Setup](NIXOS_PXE_BOOT_SETUP.md)**
-    *   *Description:* Experimental Netboot setup for PXE-booting NixOS configurations across the hardware cluster.
-*   **[Deploying and Profiling AI Services](DEPLOYMENT_AND_PROFILING.md)**
-    *   *Description:* Detailed deployment playbooks for LLM experts (vLLM and llama.cpp rpc-servers) and software performance profiling (CPU/Memory/GPU).
-*   **[Performance & I/O Optimization](PERFORMANCE_OPTIMIZATION.md)**
-    *   *Description:* Identifies performance bottlenecks, proposing syscall reductions for heavy tools, git command optimizations, and Btrfs snapshot-based disaster recovery rollbacks.
-*   **[Improving Remote Workflows](REMOTE_WORKFLOW.md)**
-    *   *Description:* Best practices for optimizing remote cluster development using Mosh and Tmux.
+* **[iPXE Boot Server Setup (Debian)](PXE_BOOT_SETUP.md)**
+  * *Description:* Step-by-step setup of the local DHCP/TFTP/HTTP PXE server to automate headless Debian 13 installations.
+* **[NixOS-based PXE Boot Server Setup](NIXOS_PXE_BOOT_SETUP.md)**
+  * *Description:* Experimental Netboot setup for PXE-booting NixOS configurations across the hardware cluster.
+* **[Deploying and Profiling AI Services](DEPLOYMENT_AND_PROFILING.md)**
+  * *Description:* Detailed deployment playbooks for LLM experts (vLLM and llama.cpp rpc-servers) and software performance profiling (CPU/Memory/GPU).
+* **[Performance & I/O Optimization](PERFORMANCE_OPTIMIZATION.md)**
+  * *Description:* Identifies performance bottlenecks, proposing syscall reductions for heavy tools, git command optimizations, and Btrfs snapshot-based disaster recovery rollbacks.
+* **[Improving Remote Workflows](REMOTE_WORKFLOW.md)**
+  * *Description:* Best practices for optimizing remote cluster development using Mosh and Tmux.
 
 ---
 
@@ -89,11 +91,11 @@ These guides explain how to build, deploy, boot, and optimize cluster nodes and 
 
 These operational playbooks outline self-healing scripts, failure handling, troubleshooting, and front-end user verification.
 
-*   **[Cluster Health Probing and Self-Healing](CLUSTER_HEALTH_AND_HEALING.md)**
-    *   *Description:* Describes the interactive health-check command CLI (`probe` and `heal`) that acts as a standalone operational agent to diagnose and repair failed Nomad jobs and systemd daemons.
-*   **[Automated Ansible Exception Handler & Git PR Loop](ANSIBLE_EXCEPTION_HANDLER_GUIDE.md)**
-    *   *Description:* Documents "Jules", an autonomous debugging loop that parses failed Ansible playbooks, replicates failure contexts, generates fixes using LLMs, runs local linting/syntax checks, and creates Opengist pull request summaries.
-*   **[Troubleshooting Guide](TROUBLESHOOTING.md)**
-    *   *Description:* Resolving common operational issues, including stale Consul service registries, locked cache issues, and failed network bindings.
-*   **[Frontend Verification via Playwright](FRONTEND_VERIFICATION.md)**
-    *   *Description:* Detailed instructions on running headless accessibility audits, focusing interactive outlines, and capturing audit screenshots using Playwright.
+* **[Cluster Health Probing and Self-Healing](CLUSTER_HEALTH_AND_HEALING.md)**
+  * *Description:* Describes the interactive health-check command CLI (`probe` and `heal`) that acts as a standalone operational agent to diagnose and repair failed Nomad jobs and systemd daemons.
+* **[Automated Ansible Exception Handler & Git PR Loop](ANSIBLE_EXCEPTION_HANDLER_GUIDE.md)**
+  * *Description:* Documents "Jules", an autonomous debugging loop that parses failed Ansible playbooks, replicates failure contexts, generates fixes using LLMs, runs local linting/syntax checks, and creates Opengist pull request summaries.
+* **[Troubleshooting Guide](TROUBLESHOOTING.md)**
+  * *Description:* Resolving common operational issues, including stale Consul service registries, locked cache issues, and failed network bindings.
+* **[Frontend Verification via Playwright](FRONTEND_VERIFICATION.md)**
+  * *Description:* Detailed instructions on running headless accessibility audits, focusing interactive outlines, and capturing audit screenshots using Playwright.


### PR DESCRIPTION
This PR introduces documentation for setting up the Tailscale Android client to connect with our internal Headscale setup.

- Created `docs/manual/HEADSCALE_ANDROID_SETUP.md` outlining the steps for Android clients.
- Addressed connecting via both Web Authentication and Pre-Auth Key.
- Clarified that the Ansible provisioning run automatically generates an initial 24h pre-auth key for the default namespace, which can be found in the provisioning logs.
- Added instructions for admins to manually create pre-auth keys.
- Added the guide to the central index in `docs/manual/README.md`.

---
*PR created automatically by Jules for task [8239636663025812696](https://jules.google.com/task/8239636663025812696) started by @LokiMetaSmith*