### PR TITLE
Fix 504 Gateway Timeout by pre-warming local IPFS gateway cache for Mosquitto job

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -293,6 +293,16 @@
   changed_when: false
   ignore_errors: yes
 
+- name: Warm up IPFS gateway cache for Mosquitto tarball
+  ansible.builtin.uri:
+    url: "http://{{ cluster_ip }}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ mosquitto_ipfs_cid }}"
+    method: GET
+    status_code: 200
+  register: ipfs_warmup
+  retries: 5
+  delay: 3
+  until: ipfs_warmup is success
+
 - name: Deploy MQTT Job
   block:
     - name: Run mqtt job


### PR DESCRIPTION
Added an IPFS cache warming task in ansible/roles/mqtt/tasks/main.yaml right before running the Nomad job. This fetches the Mosquitto tarball CID using the ansible.builtin.uri module to ensure the gateway cache is fully populated with the tarball blocks, preventing go-getter artifact fetch timeout (504 Gateway Timeout) on Nomad clients while preserving offline caching architecture. Verified correct syntax and successfully ran unit tests.

---
*PR created automatically by Jules for task [1556969288907826714](https://jules.google.com/task/1556969288907826714) started by @LokiMetaSmith*