### PR TITLE
fix(mqtt): pre-warm gateway cache and align IPFS_PATH

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -219,7 +219,7 @@
   become: yes
   register: ipfs_add_result_mosquitto
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   changed_when: false
   delegate_to: "{{ controller_host }}"
   run_once: true


### PR DESCRIPTION
1. Set `IPFS_PATH` to `{{ ipfs_path }}` so `ipfs add` interacts with the running daemon instead of an offline shadow repository.
2. Add a pre-warming Ansible URI GET task right before job deployment to ensure the Mosquitto tarball is fully cached in the gateway.