### PR TITLE
feat(ansible): Implement FIDO2 hardware security key bootstrapping and OIDC

### DIFF
--- a/ansible/roles/common-tools/tasks/main.yaml
+++ b/ansible/roles/common-tools/tasks/main.yaml
@@ -46,3 +46,12 @@
   when: github_ssh_users | length > 0
   become: yes
   become_user: user
+
+- name: Add FIDO/FIDO2 SSH keys to authorized_keys
+  ansible.posix.authorized_key:
+    user: user
+    state: present
+    key: "{{ item }}"
+  loop: "{{ fido_ssh_keys | default([]) }}"
+  when: fido_ssh_keys is defined and fido_ssh_keys | length > 0
+  become: yes

--- a/ansible/roles/headscale/defaults/main.yaml
+++ b/ansible/roles/headscale/defaults/main.yaml
@@ -7,3 +7,9 @@ headscale_namespace: "default"
 headscale_ip_prefix: "100.64.0.0/10"
 headscale_nameservers:
   - 1.1.1.1
+
+# OIDC Integration (for FIDO2/WebAuthn human access via Authentik)
+headscale_oidc_enabled: false
+headscale_oidc_issuer: "https://authentik.local.mesh/application/o/headscale/"
+headscale_oidc_client_id: "headscale-client-id"
+headscale_oidc_client_secret: "headscale-client-secret"

--- a/ansible/roles/headscale/templates/config.yaml.j2
+++ b/ansible/roles/headscale/templates/config.yaml.j2
@@ -32,6 +32,13 @@ db_path: /var/lib/headscale/db.sqlite
 unix_socket: /var/run/headscale/headscale.sock
 unix_socket_permission: "0770"
 
+{% if headscale_oidc_enabled %}
+oidc:
+  issuer: "{{ headscale_oidc_issuer }}"
+  client_id: "{{ headscale_oidc_client_id }}"
+  client_secret: "{{ headscale_oidc_client_secret }}"
+{% endif %}
+
 dns_config:
   magic_dns: true
   base_domain: {{ cluster_domain | default('local.mesh') }}

--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -99,3 +99,5 @@ These operational playbooks outline self-healing scripts, failure handling, trou
   * *Description:* Resolving common operational issues, including stale Consul service registries, locked cache issues, and failed network bindings.
 * **[Frontend Verification via Playwright](FRONTEND_VERIFICATION.md)**
   * *Description:* Detailed instructions on running headless accessibility audits, focusing interactive outlines, and capturing audit screenshots using Playwright.
+* **[Security Key Bootstrapping](SECURITY_KEY_BOOTSTRAPPING.md)**
+  * *Description:* Details the hybrid architecture for incorporating FIDO/FIDO2 hardware security keys into cluster provisioning, covering human OIDC access and automated machine bootstrapping.

--- a/docs/manual/SECURITY_KEY_BOOTSTRAPPING.md
+++ b/docs/manual/SECURITY_KEY_BOOTSTRAPPING.md
@@ -1,0 +1,79 @@
+# Security Key Bootstrapping and Cluster Access
+
+This document details the hybrid architecture for incorporating FIDO/FIDO2 hardware security keys into the cluster provisioning and access workflow. It provides robust security for both interactive human administrators and automated, machine-to-machine interactions.
+
+## Table of Contents
+
+- [1. Overview](#1-overview)
+- [2. Human Access: OIDC & FIDO2 Enforcement](#2-human-access-oidc--fido2-enforcement)
+  - [2.1. Headscale (Tailnet) Enrollment](#21-headscale-tailnet-enrollment)
+  - [2.2. Consul ACL Authentication](#22-consul-acl-authentication)
+- [3. Machine-to-Machine: Automated Bootstrapping](#3-machine-to-machine-automated-bootstrapping)
+  - [3.1. Headscale Pre-Auth Keys](#31-headscale-pre-auth-keys)
+  - [3.2. Consul ACL Tokens](#32-consul-acl-tokens)
+- [4. Direct Node Access: Declarative SSH Keys](#4-direct-node-access-declarative-ssh-keys)
+
+---
+
+## 1. Overview
+
+The cluster utilizes two distinct authentication flows depending on the context:
+
+1. **Human/Interactive Flow:** Leverages OpenID Connect (OIDC) through Authentik, mandating the use of physical FIDO2 keys (like YubiKeys or Google Titan keys) via WebAuthn for enrolling user devices onto the Tailnet or accessing management interfaces like Consul.
+2. **Machine/Automated Flow:** Relies on robust, securely generated tokens (Headscale Pre-Auth keys, Consul ACL tokens) stored in Ansible Vault to completely bypass human interaction during bare-metal provisioning and Nomad job deployments.
+
+---
+
+## 2. Human Access: OIDC & FIDO2 Enforcement
+
+For administrators and developers, services are integrated with Authentik via OIDC. Authentik is configured to enforce multi-factor authentication (MFA) utilizing FIDO2/WebAuthn.
+
+### 2.1. Headscale (Tailnet) Enrollment
+
+When a user attempts to join a new device to the cluster mesh network:
+
+1. The user runs `tailscale up --login-server=https://headscale.local.mesh`.
+2. Tailscale generates an interactive authentication link.
+3. The user visits the link, which redirects them to Authentik (via OIDC).
+4. The user authenticates with their credentials and taps their physical FIDO2 key.
+5. Upon successful WebAuthn verification, Headscale registers the node and it joins the overlay network.
+
+### 2.2. Consul ACL Authentication
+
+Consul's ACL system is configured with an OIDC Auth Method mapping back to Authentik:
+
+1. Accessing the Consul UI or requesting a CLI token using `consul login -type=oidc` triggers an OIDC flow.
+2. The user is redirected to Authentik, where they must authenticate and provide physical presence via their FIDO2 key.
+3. Consul grants a time-bound ACL token based on the user's mapped roles in Authentik.
+
+---
+
+## 3. Machine-to-Machine: Automated Bootstrapping
+
+Physical key taps are impossible during automated provisioning (e.g., PXE booting a new worker node). The system uses pre-generated, strict credentials managed by Ansible to ensure security without human intervention.
+
+### 3.1. Headscale Pre-Auth Keys
+
+During the `tailscale` Ansible role execution, new nodes must join the mesh network to establish the `cluster_ip`.
+
+- **Mechanism:** Headscale pre-auth keys are generated (e.g., via the Headscale CLI on a controller node) and stored securely (ideally within Ansible Vault).
+- **Execution:** The provisioning playbook executes `tailscale up --authkey <PRE_AUTH_KEY>`, silently authenticating the machine and joining it to the tailnet without triggering the OIDC flow.
+- **Security:** These keys are typically ephemeral, scoped to specific namespaces, and heavily restricted in lifespan.
+
+### 3.2. Consul ACL Tokens
+
+Similarly, Nomad jobs and automated scripts require communication with the Consul service mesh.
+
+- **Mechanism:** The initial Consul bootstrap process generates a master token. This token is used programmatically to create scoped, role-specific ACL tokens for internal infrastructure traffic.
+- **Execution:** These specific tokens are injected into Nomad job definitions and systemd unit files via Ansible templates.
+- **Security:** This isolates machine traffic from the human OIDC flow, ensuring the cluster can self-heal and orchestrate jobs without requiring manual FIDO2 validation for internal actions.
+
+---
+
+## 4. Direct Node Access: Declarative SSH Keys
+
+While Tailscale provides the secure overlay, direct SSH access to nodes is governed declaratively via Ansible. This includes support for FIDO2-backed OpenSSH keys.
+
+1. Administrators generate a FIDO2 SSH key locally: `ssh-keygen -t ed25519-sk`.
+2. The resulting public key string (e.g., `sk-ssh-ed25519@openssh.com AAAA...`) is added to the `fido_ssh_keys` list in `group_vars/all.yaml`.
+3. The `common-tools` Ansible role ensures that any defined FIDO keys are appended to the `authorized_keys` file for the primary `target_user` on every node, allowing hardware-backed SSH authentication.

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -175,6 +175,10 @@ target_user_home: "/home/{{ target_user }}"
 # GitHub usernames to automatically import SSH keys for via ssh-import-id
 github_ssh_users: []
 
+# A list of declarative FIDO/FIDO2 OpenSSH public keys to be provisioned for target_user
+# Example: ["sk-ssh-ed25519@openssh.com AAAA..."]
+fido_ssh_keys: []
+
 # --- Exo Configuration ---
 # By default, Exo is disabled. To enable it, set this to true.
 exo_enable: false

--- a/test_common_tools.yaml
+++ b/test_common_tools.yaml
@@ -1,0 +1,6 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Syntax check
+      include_role:
+        name: ansible/roles/common-tools

--- a/test_headscale.yaml
+++ b/test_headscale.yaml
@@ -1,0 +1,6 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Syntax check
+      include_role:
+        name: ansible/roles/headscale


### PR DESCRIPTION
This pull request implements the requested feature to allow the use of FIDO/FIDO2 hardware security keys for provisioning and accessing the cluster.

It introduces a hybrid architecture documented in a new `SECURITY_KEY_BOOTSTRAPPING.md` manual.

For interactive human users, the `headscale` role has been updated to conditionally support OIDC integration (e.g., via Authentik), enabling WebAuthn/FIDO2 enforcement for enrolling on the mesh network.

For machine automation, the documentation explains the existing patterns of using Ansible Vault and pre-auth tokens.

Additionally, standard FIDO2 OpenSSH declarative keys (`sk-ssh-ed25519@openssh.com`) can now be securely rolled out across all nodes via the `fido_ssh_keys` list in `group_vars/all.yaml`.

---
*PR created automatically by Jules for task [7032484398939333](https://jules.google.com/task/7032484398939333) started by @LokiMetaSmith*