### PR TITLE
feat(ansible): Implement Traefik ForwardAuth SSO with Authentik

### DIFF
--- a/ansible/roles/nanochat/templates/nanochat.nomad.j2
+++ b/ansible/roles/nanochat/templates/nanochat.nomad.j2
@@ -63,7 +63,16 @@ job "nanochat" {
       service {
         name = "nanochat"
         port = "http"
-        tags = ["ai", "nanochat", "training"]
+        tags = [
+          "ai",
+          "nanochat",
+          "training",
+          "traefik.enable=true",
+          "traefik.http.routers.nanochat.rule=Host(`nanochat.{{ cluster_domain | default('local.mesh') }}`)",
+          "traefik.http.routers.nanochat.entrypoints=websecure",
+          "traefik.http.routers.nanochat.tls=true",
+          "traefik.http.routers.nanochat.middlewares=authentik@file"
+        ]
 
         check {
           type     = "http"

--- a/ansible/roles/opengist/templates/opengist.nomad.j2
+++ b/ansible/roles/opengist/templates/opengist.nomad.j2
@@ -40,7 +40,16 @@ job "opengist" {
       service {
         name = "opengist-http"
         port = "http"
-        tags = ["opengist", "git", "web"]
+        tags = [
+          "opengist",
+          "git",
+          "web",
+          "traefik.enable=true",
+          "traefik.http.routers.opengist.rule=Host(`opengist.{{ cluster_domain | default('local.mesh') }}`)",
+          "traefik.http.routers.opengist.entrypoints=websecure",
+          "traefik.http.routers.opengist.tls=true",
+          "traefik.http.routers.opengist.middlewares=authentik@file"
+        ]
 
         check {
           type     = "http"

--- a/ansible/roles/paperless/templates/paperless-app.nomad.j2
+++ b/ansible/roles/paperless/templates/paperless-app.nomad.j2
@@ -17,6 +17,14 @@ job "paperless-app" {
       name     = "paperless"
       port     = "http"
       provider = "consul"
+      tags     = [
+        "paperless",
+        "traefik.enable=true",
+        "traefik.http.routers.paperless.rule=Host(`paperless.{{ cluster_domain | default('local.mesh') }}`)",
+        "traefik.http.routers.paperless.entrypoints=websecure",
+        "traefik.http.routers.paperless.tls=true",
+        "traefik.http.routers.paperless.middlewares=authentik@file"
+      ]
 
       check {
         name     = "Paperless Web UI"

--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -85,7 +85,8 @@ job "{{ job_name | default('pipecat-app') }}" {
         "traefik.enable=true",
         "traefik.http.routers.pipecatapp.rule=Host(`pipecatapp.{{ cluster_domain | default('local.mesh') }}`)",
         "traefik.http.routers.pipecatapp.entrypoints=websecure",
-        "traefik.http.routers.pipecatapp.tls=true"
+        "traefik.http.routers.pipecatapp.tls=true",
+        "traefik.http.routers.pipecatapp.middlewares=authentik@file"
       ]
 
       check {

--- a/ansible/roles/traefik/templates/authentik-forwardauth.yaml.j2
+++ b/ansible/roles/traefik/templates/authentik-forwardauth.yaml.j2
@@ -1,0 +1,18 @@
+http:
+  middlewares:
+    authentik:
+      forwardAuth:
+        address: "http://{{ hostvars[groups['controller_nodes'][0]]['ansible_host'] | default(hostvars[groups['controller_nodes'][0]]['ansible_facts']['default_ipv4']['address'] | default('127.0.0.1')) }}:9000/outpost.goauthentik.io/auth/traefik"
+        trustForwardHeader: true
+        authResponseHeaders:
+          - X-authentik-username
+          - X-authentik-groups
+          - X-authentik-email
+          - X-authentik-name
+          - X-authentik-uid
+          - X-authentik-jwt
+          - X-authentik-meta-jwks
+          - X-authentik-meta-outpost
+          - X-authentik-meta-provider
+          - X-authentik-meta-app
+          - X-authentik-meta-version

--- a/ansible/roles/traefik/templates/traefik.nomad.j2
+++ b/ansible/roles/traefik/templates/traefik.nomad.j2
@@ -107,6 +107,15 @@ EOF
 
       template {
         data = <<-EOF
+{{ lookup('template', 'authentik-forwardauth.yaml.j2') }}
+
+EOF
+
+        destination = "local/dynamic/authentik-forwardauth.yaml"
+      }
+
+      template {
+        data = <<-EOF
 tls:
   certificates:
     - certFile: "/etc/traefik/certs/mesh/tls.crt"

--- a/docs/manual/SECURITY_KEY_BOOTSTRAPPING.md
+++ b/docs/manual/SECURITY_KEY_BOOTSTRAPPING.md
@@ -28,6 +28,12 @@ The cluster utilizes two distinct authentication flows depending on the context:
 
 For administrators and developers, services are integrated with Authentik via OIDC. Authentik is configured to enforce multi-factor authentication (MFA) utilizing FIDO2/WebAuthn.
 
+This provides three layers of identity and access management for humans:
+
+1. **SSO and Authorization Injection:** Authentik seamlessly injects authorization headers, preventing the need to manually enter application API keys.
+2. **FIDO2 Hardware Key Registration:** Users can independently register and provision new FIDO2 security keys through the internal Authentik user portal.
+3. **Fallback Authentication:** In the event a hardware key is lost or unavailable, users can securely fall back to an Authentik-managed password paired with TOTP.
+
 ### 2.1. Headscale (Tailnet) Enrollment
 
 When a user attempts to join a new device to the cluster mesh network:
@@ -45,6 +51,15 @@ Consul's ACL system is configured with an OIDC Auth Method mapping back to Authe
 1. Accessing the Consul UI or requesting a CLI token using `consul login -type=oidc` triggers an OIDC flow.
 2. The user is redirected to Authentik, where they must authenticate and provide physical presence via their FIDO2 key.
 3. Consul grants a time-bound ACL token based on the user's mapped roles in Authentik.
+
+### 2.3. Internal Web Services (Traefik ForwardAuth)
+
+Internal application UIs (such as the Pipecat App, Nanochat, OpenGist, and Paperless) do not expose their own authentication barriers. Instead, they are protected at the mesh edge via a **Traefik ForwardAuth** middleware constraint.
+
+1. A user navigates to an internal service (e.g., `https://pipecatapp.local.mesh`).
+2. The Traefik reverse proxy intercepts the request and forwards it to the Authentik outpost.
+3. Authentik challenges the user (FIDO2 tap).
+4. Upon success, Authentik redirects the traffic back to the destination service, injecting identity headers (`X-authentik-username`, etc.) to facilitate zero-touch application access.
 
 ---
 


### PR DESCRIPTION
This commit implements Single Sign-On (SSO) and FIDO2 enforcement for internal services by integrating Traefik ForwardAuth with Authentik.

1. Added `authentik-forwardauth.yaml.j2` to the Traefik dynamic configuration.
2. Injected the `authentik@file` middleware into the Traefik router tags for Pipecat App, Nanochat, OpenGist, and Paperless.
3. Updated `SECURITY_KEY_BOOTSTRAPPING.md` to document the SSO capabilities and Traefik ForwardAuth protection architecture.