### PR TITLE
fix: resolve 504 Gateway Timeout during IPFS artifact pulls in Nomad

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -219,7 +219,7 @@
   become: yes
   register: ipfs_add_result_mosquitto
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   changed_when: false
   delegate_to: "{{ controller_host }}"
   run_once: true


### PR DESCRIPTION
The IPFS Ansible roles and Nomad tasks were crashing due to 504 Gateway Timeouts when the daemon was not fully booted or loaded.

- Replaced the brittle Nomad `artifact` stanza with a highly resilient Bash script in `load_image_task.nomad.j2` using `raw_exec`. The script checks the local cache first, validates docker images, and falls back to a `curl` loop with retries and exponential backoff when pulling the CID.
- Added `meta: flush_handlers` to the MQTT and IPFS Ansible roles before executing the gateway status checks.
- Altered `uri` status checks to gracefully loop on `502` and `504` timeouts, but fail fast if the connection is refused (`-1`).