### PR TITLE
Add automated gradual cluster update mechanism

### DIFF
--- a/ansible/roles/auto_update/handlers/main.yaml
+++ b/ansible/roles/auto_update/handlers/main.yaml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: yes

--- a/ansible/roles/auto_update/tasks/main.yaml
+++ b/ansible/roles/auto_update/tasks/main.yaml
@@ -1,0 +1,40 @@
+---
+- name: Deploy auto-update systemd service
+  ansible.builtin.template:
+    src: auto-update.service.j2
+    dest: /etc/systemd/system/cluster-auto-update.service
+    mode: '0644'
+  when: auto_update_enabled | default(false)
+
+- name: Deploy auto-update systemd timer
+  ansible.builtin.template:
+    src: auto-update.timer.j2
+    dest: /etc/systemd/system/cluster-auto-update.timer
+    mode: '0644'
+  when: auto_update_enabled | default(false)
+
+- name: Enable and start auto-update timer
+  ansible.builtin.systemd:
+    name: cluster-auto-update.timer
+    state: started
+    enabled: yes
+    daemon_reload: yes
+  when: auto_update_enabled | default(false)
+
+- name: Stop and disable auto-update timer if disabled
+  ansible.builtin.systemd:
+    name: cluster-auto-update.timer
+    state: stopped
+    enabled: no
+  when: not (auto_update_enabled | default(false))
+  ignore_errors: yes
+
+- name: Remove auto-update systemd units if disabled
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/systemd/system/cluster-auto-update.service
+    - /etc/systemd/system/cluster-auto-update.timer
+  when: not (auto_update_enabled | default(false))
+  notify: Reload systemd daemon

--- a/ansible/roles/auto_update/templates/auto-update.service.j2
+++ b/ansible/roles/auto_update/templates/auto-update.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=Cluster Auto-Update Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+WorkingDirectory=/opt/cluster-infra
+# We use a wrapper script or call the update script directly
+ExecStart=/opt/cluster-infra/scripts/update_cluster.sh -y
+# Optional: if you want output to go to a specific file or syslog
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/auto_update/templates/auto-update.timer.j2
+++ b/ansible/roles/auto_update/templates/auto-update.timer.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Timer for Cluster Auto-Update
+After=network-online.target
+
+[Timer]
+# Run once a day. You can adjust this to e.g., OnUnitActiveSec=12h
+OnCalendar={{ auto_update_schedule | default('*-*-* 03:00:00') }}
+# Add random jitter up to 4 hours to avoid all nodes updating at once
+RandomizedDelaySec={{ auto_update_jitter_sec | default('14400') }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -153,6 +153,10 @@ jules_api_key: "your_jules_api_key_here"
 enable_nanochat: false
 nanochat_platform: "gpu"
 
+# Cluster Auto-Update
+# Enable gradual, automated in-place upgrades of the cluster via systemd timer
+auto_update_enabled: false
+
 # Service Enablement Flags
 enable_influxdb: true
 enable_telegraf: true

--- a/playbooks/common_setup.yaml
+++ b/playbooks/common_setup.yaml
@@ -6,6 +6,10 @@
       tags:
         - tpm_ssh
         - common
+    - role: auto_update
+      tags:
+        - auto_update
+        - common
 
   tasks:
     - name: Ensure leftover APT proxy configuration is removed before bootstrap

--- a/scripts/update_cluster.sh
+++ b/scripts/update_cluster.sh
@@ -66,6 +66,15 @@ if [ $? -ne 0 ]; then
      exit 1
 fi
 
+# Compare local branch against remote before pulling/resetting
+LOCAL_HEAD=$(git rev-parse HEAD 2>/dev/null)
+REMOTE_HEAD=$(git rev-parse "origin/$CURRENT_BRANCH" 2>/dev/null)
+
+if [ -n "$LOCAL_HEAD" ] && [ -n "$REMOTE_HEAD" ] && [ "$LOCAL_HEAD" = "$REMOTE_HEAD" ]; then
+    echo -e "${GREEN}✅ No new updates found. The cluster is already up-to-date.${NC}"
+    exit 0
+fi
+
 echo "Resetting local state to match remote origin/$CURRENT_BRANCH..."
 # Explicitly force the local branch name to match what we pulled to prevent master/main drift
 git checkout -B "$CURRENT_BRANCH" "origin/$CURRENT_BRANCH"


### PR DESCRIPTION
This feature adds a mechanism to safely and gradually perform in-place updates of the live swarm nodes without causing cluster-wide downtime.

By introducing a randomized delay to a daily systemd timer and a check to ensure `bootstrap.sh` only runs if there are actual new commits on the tracked remote branch, the rollout process can happen automatically and evenly across all workers over a defined period (e.g., 4 hours).

---
*PR created automatically by Jules for task [6642327819579622481](https://jules.google.com/task/6642327819579622481) started by @LokiMetaSmith*