### PR TITLE
Fix IPFS initialization race condition

### DIFF
--- a/ansible/roles/ipfs/tasks/main.yaml
+++ b/ansible/roles/ipfs/tasks/main.yaml
@@ -70,6 +70,22 @@
     mode: '0755'
   become: yes
 
+- name: Initialize IPFS repository on host
+  ansible.builtin.command: /usr/local/bin/ipfs init --profile server,local-discovery
+  args:
+    creates: "{{ ipfs_path }}/config"
+  environment:
+    IPFS_PATH: "{{ ipfs_path }}"
+  become: yes
+
+- name: Set IPFS directory ownership for Kubo container
+  ansible.builtin.file:
+    path: "{{ ipfs_path }}"
+    owner: "1000"
+    group: "100"
+    recurse: yes
+  become: yes
+
 - name: Template ipfs job
   ansible.builtin.template:
     src: ipfs.nomad.j2

--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -51,6 +51,14 @@
         - python_deps
         - deploy_app
 
+    - name: Deploy IPFS Storage Backend
+      tags:
+        - ipfs
+      block:
+        - name: Run ipfs role
+          ansible.builtin.include_role:
+            name: ipfs
+
     - name: Deploy MQTT
       tags:
         - mqtt


### PR DESCRIPTION
This PR addresses an execution failure in the `llama-cluster-upbringing-script` repository where the `mqtt` role failed due to the IPFS repository not being initialized locally. By establishing IPFS as a top-level infrastructure service and explicitly running `ipfs init` with the correct host directory permissions before starting the Nomad job, we prevent race conditions and ensure robust deployment of dependent app services.

---
*PR created automatically by Jules for task [16504747478108649474](https://jules.google.com/task/16504747478108649474) started by @LokiMetaSmith*