### PR TITLE
Fix 504 Gateway Timeout during IPFS cache warmup in MQTT role

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -300,11 +300,13 @@
   ansible.builtin.uri:
     url: "http://{{ cluster_ip }}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ mosquitto_ipfs_cid }}"
     method: GET
+    status_code: [200, 502, 504]
+    timeout: 60
   register: ipfs_warmup
-  until: ipfs_warmup.status is defined and ipfs_warmup.status == 200
-  retries: 3
-  delay: 5
-  ignore_errors: true
+  until: ipfs_warmup.status == 200 or ipfs_warmup.status == -1
+  failed_when: ipfs_warmup.status == -1
+  retries: 15
+  delay: 10
 
 - name: Deploy MQTT Job
   block:


### PR DESCRIPTION
Resolves a playbook failure during the `mqtt` role execution where the initial IPFS warmup attempt timed out (HTTP 504), causing the subsequent Nomad deployment to crash because it could not find the artifact. The fix implements an explicit retry loop handling expected 502/504 cache misses while immediately failing on connection refused.

---
*PR created automatically by Jules for task [16336781449774593204](https://jules.google.com/task/16336781449774593204) started by @LokiMetaSmith*