### PR TITLE
feat(build_iso): Add interactive USB flashing functionality with dd

### DIFF
--- a/os-image/build_iso.sh
+++ b/os-image/build_iso.sh
@@ -109,10 +109,11 @@ if [ ! -f /.dockerenv ]; then
         echo "Flashing $ISO_FILE to $USB_DRIVE..."
 
         # Check if status=progress is supported (GNU dd vs BSD dd)
+        # Using raw bytes (4194304 = 4MB) to avoid BSD vs GNU suffix discrepancies (e.g., '4m' vs '4M')
         if dd --help 2>&1 | grep -q 'status=progress'; then
-            sudo dd if="$ISO_FILE" of="$USB_DRIVE" bs=4M status=progress oflag=sync
+            sudo dd if="$ISO_FILE" of="$USB_DRIVE" bs=4194304 status=progress oflag=sync
         else
-            sudo dd if="$ISO_FILE" of="$USB_DRIVE" bs=4m
+            sudo dd if="$ISO_FILE" of="$USB_DRIVE" bs=4194304
         fi
 
         echo "Syncing filesystem..."


### PR DESCRIPTION
- Adds a `--flash` flag to `build_iso.sh` arguments parser.
- Uses `lsblk` or `diskutil` to list available USB/removable drives.
- Prompts the user for a device path and requires explicitly typing `yes` to prevent accidental data loss.
- Uses standard FOSS command-line `dd` (with progress if supported) to write the built ISO directly to the selected drive on the host machine.
- Uses raw bytes `bs=4194304` for cross-platform compatibility between GNU and BSD dd.
- Gracefully skips flashing if the flag is omitted.