### PR TITLE
fix(build_iso): Prevent installer network hang and document flashing …

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -248,6 +248,13 @@ This section tracks identified placeholder files, corrupted binaries, and code t
 - [x] **Remove or Implement Empty Handler:**
   - [x] `ansible/roles/bootstrap_agent/handlers/main.yaml` is currently empty.
 
+- [ ] **Enhance USB Flashing in `build_iso.sh`:**
+  - **Goal:** Improve the `--flash` utility to support cluster provisioning workflows.
+  - **Tasks:**
+    1. **Flashing Multiple Drives:** Allow the user to input multiple device paths separated by spaces to flash multiple USB sticks sequentially.
+    2. **Post-flash Verification:** Add checksum validation (e.g. `md5sum` or `sha256sum`) that reads back from the flashed USB stick to verify data integrity and throw an error if corrupted.
+    3. **Auto-mounting / File Injection:** Add an `--inject <folder_path>` flag to automatically create a new `CONFIGS` partition on the USB stick and copy configuration files into it.
+
 - [x] **Reconcile Stale Artifacts:**
   - [x] `pipecatapp/app.py` contains code and TODOs (e.g., vision model failover). Determine if these changes should be merged or if the artifact should be regenerated.
 - [x] **Vision Model Failover**: Implement failover or selection logic for vision models (see `pipecatapp/app.py`).

--- a/os-image/build_iso.sh
+++ b/os-image/build_iso.sh
@@ -145,12 +145,12 @@ lb config \
   --mirror-binary "http://deb.debian.org/debian/" \
   --parent-mirror-debian-installer "http://deb.debian.org/debian/" \
   --mirror-debian-installer "http://deb.debian.org/debian/" \
-  --archive-areas "main contrib non-free-firmware" \
+  --archive-areas "main contrib non-free non-free-firmware" \
   --apt-indices true \
   --apt-recommends false \
   --security false \
-  --firmware-chroot false \
-  --firmware-binary false \
+  --firmware-chroot true \
+  --firmware-binary true \
   --linux-packages "linux-image" \
   --linux-flavours "amd64" \
   --bootloader "syslinux,grub-efi" \
@@ -160,7 +160,7 @@ lb config \
   --debian-installer live \
   --win32-loader false \
   --bootappend-live "boot=live components quiet splash nomodeset locales=en_US.UTF-8 keyboard-layouts=us live-config.username=pipecatapp live-config.user-fullname=PipecatApp" \
-  --bootappend-install "auto=true priority=critical file=/preseed.cfg nomodeset netcfg/choose_interface=auto"
+  --bootappend-install "auto=true priority=critical file=/preseed.cfg nomodeset netcfg/choose_interface=auto netcfg/link_wait_timeout=5 netcfg/dhcp_timeout=15 netcfg/prompt_for_interface=false"
 
 echo "=== Injecting project files ==="
 # Explicitly install live-config inside the chroot so autologin functions correctly


### PR DESCRIPTION
…enhancements

- Adds `non-free` firmware support to `build_iso.sh` (`--firmware-chroot true`, `--firmware-binary true`) to ensure proprietary network drivers like Wi-Fi are included.
- Appends network timeouts (`netcfg/link_wait_timeout=5`, `netcfg/dhcp_timeout=15`, `netcfg/prompt_for_interface=false`) to the `--bootappend-install` parameters to prevent the installer from hanging indefinitely while searching for network devices.
- Records future USB flashing enhancements (multi-drive, verification, file injection) in `TODO.md`.