### PR TITLE
Enhance USB Flashing with Multi-drive, Checksums, and Config Injection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -248,12 +248,12 @@ This section tracks identified placeholder files, corrupted binaries, and code t
 - [x] **Remove or Implement Empty Handler:**
   - [x] `ansible/roles/bootstrap_agent/handlers/main.yaml` is currently empty.
 
-- [ ] **Enhance USB Flashing in `build_iso.sh`:**
+- [x] **Enhance USB Flashing in `build_iso.sh`:**
   - **Goal:** Improve the `--flash` utility to support cluster provisioning workflows.
   - **Tasks:**
-    1. **Flashing Multiple Drives:** Allow the user to input multiple device paths separated by spaces to flash multiple USB sticks sequentially.
-    2. **Post-flash Verification:** Add checksum validation (e.g. `md5sum` or `sha256sum`) that reads back from the flashed USB stick to verify data integrity and throw an error if corrupted.
-    3. **Auto-mounting / File Injection:** Add an `--inject <folder_path>` flag to automatically create a new `CONFIGS` partition on the USB stick and copy configuration files into it.
+    1. [x] **Flashing Multiple Drives:** Allow the user to input multiple device paths separated by spaces to flash multiple USB sticks sequentially.
+    2. [x] **Post-flash Verification:** Add checksum validation (e.g. `md5sum` or `sha256sum`) that reads back from the flashed USB stick to verify data integrity and throw an error if corrupted.
+    3. [x] **Auto-mounting / File Injection:** Add an `--inject <folder_path>` flag to automatically create a new `CONFIGS` partition on the USB stick and copy configuration files into it.
 
 - [x] **Reconcile Stale Artifacts:**
   - [x] `pipecatapp/app.py` contains code and TODOs (e.g., vision model failover). Determine if these changes should be merged or if the artifact should be regenerated.

--- a/os-image/build_iso.sh
+++ b/os-image/build_iso.sh
@@ -6,22 +6,33 @@ set -euo pipefail
 # --- Arguments ---
 KEEP_CACHE=0
 FLASH=0
+INJECT_DIR=""
+INJECT_NEXT=0
 
 for arg in "$@"; do
+    if [ "$INJECT_NEXT" -eq 1 ]; then
+        INJECT_DIR="$arg"
+        INJECT_NEXT=0
+        continue
+    fi
+
     if [ "$arg" = "-h" ] || [ "$arg" = "--help" ]; then
-        echo "Usage: ./build_iso.sh [--keep-cache] [--flash]"
+        echo "Usage: ./build_iso.sh [--keep-cache] [--flash] [--inject <folder_path>]"
         echo ""
         echo "Builds a custom, bootable, headless Debian ISO for the Pipecat agent cluster."
         echo "Automatically spins up a Debian Trixie Docker container to ensure native live-build compatibility."
         echo ""
         echo "Options:"
-        echo "  --keep-cache  Preserve the package cache and build artifacts to speed up subsequent runs"
-        echo "  --flash       Interactively select a USB drive and flash the built ISO to it"
+        echo "  --keep-cache             Preserve the package cache and build artifacts to speed up subsequent runs"
+        echo "  --flash                  Interactively select a USB drive and flash the built ISO to it"
+        echo "  --inject <folder_path>   Inject a folder into a new CONFIGS partition on the flashed USB drive"
         exit 0
     elif [ "$arg" = "--keep-cache" ]; then
         KEEP_CACHE=1
     elif [ "$arg" = "--flash" ]; then
         FLASH=1
+    elif [ "$arg" = "--inject" ]; then
+        INJECT_NEXT=1
     fi
 done
 
@@ -83,21 +94,17 @@ if [ ! -f /.dockerenv ]; then
         fi
 
         echo ""
-        read -p "Enter the full path to the USB drive you want to flash (e.g., /dev/sdb or /dev/disk2): " USB_DRIVE
+        read -p "Enter the full path to the USB drive(s) you want to flash (e.g., /dev/sdb /dev/sdc): " USB_DRIVES
 
-        if [ -z "$USB_DRIVE" ]; then
-            echo "Error: No drive specified. Aborting."
-            exit 1
-        fi
-
-        if [ ! -b "$USB_DRIVE" ] && [ ! -c "$USB_DRIVE" ]; then
-            echo "Error: $USB_DRIVE is not a valid block or character device."
+        if [ -z "$USB_DRIVES" ]; then
+            echo "Error: No drives specified. Aborting."
             exit 1
         fi
 
         echo ""
         echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-        echo "WARNING: ALL DATA ON $USB_DRIVE WILL BE PERMANENTLY DESTROYED."
+        echo "WARNING: ALL DATA ON THE FOLLOWING DRIVES WILL BE PERMANENTLY DESTROYED:"
+        echo "$USB_DRIVES"
         echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
         read -p "Type 'yes' to proceed: " CONFIRM
 
@@ -106,19 +113,98 @@ if [ ! -f /.dockerenv ]; then
             exit 1
         fi
 
-        echo "Flashing $ISO_FILE to $USB_DRIVE..."
+        for USB_DRIVE in $USB_DRIVES; do
+            echo "=== Processing $USB_DRIVE ==="
+            if [ ! -b "$USB_DRIVE" ] && [ ! -c "$USB_DRIVE" ]; then
+                echo "Error: $USB_DRIVE is not a valid block or character device. Skipping."
+                continue
+            fi
 
-        # Check if status=progress is supported (GNU dd vs BSD dd)
-        # Using raw bytes (4194304 = 4MB) to avoid BSD vs GNU suffix discrepancies (e.g., '4m' vs '4M')
-        if dd --help 2>&1 | grep -q 'status=progress'; then
-            sudo dd if="$ISO_FILE" of="$USB_DRIVE" bs=4194304 status=progress oflag=sync
-        else
-            sudo dd if="$ISO_FILE" of="$USB_DRIVE" bs=4194304
-        fi
+            echo "Flashing $ISO_FILE to $USB_DRIVE..."
 
-        echo "Syncing filesystem..."
-        sync
-        echo "=== Flashing Complete! ==="
+            # Check if status=progress is supported (GNU dd vs BSD dd)
+            # Using raw bytes (4194304 = 4MB) to avoid BSD vs GNU suffix discrepancies (e.g., '4m' vs '4M')
+            if dd --help 2>&1 | grep -q 'status=progress'; then
+                sudo dd if="$ISO_FILE" of="$USB_DRIVE" bs=4194304 status=progress oflag=sync
+            else
+                sudo dd if="$ISO_FILE" of="$USB_DRIVE" bs=4194304
+            fi
+
+            echo "Syncing filesystem..."
+            sync
+
+            echo "Verifying checksum..."
+            # Cross-platform file size
+            ISO_SIZE=$(wc -c < "$ISO_FILE" | tr -d ' ')
+
+            # Cross-platform sha256 checksumming (macOS has shasum, Linux has sha256sum)
+            if command -v sha256sum >/dev/null 2>&1; then
+                ISO_CHECKSUM=$(sha256sum "$ISO_FILE" | awk '{print $1}')
+                USB_CHECKSUM=$(sudo dd if="$USB_DRIVE" bs=4194304 count=$(( (ISO_SIZE + 4194303) / 4194304 )) 2>/dev/null | head -c "$ISO_SIZE" | sha256sum | awk '{print $1}')
+            else
+                ISO_CHECKSUM=$(shasum -a 256 "$ISO_FILE" | awk '{print $1}')
+                USB_CHECKSUM=$(sudo dd if="$USB_DRIVE" bs=4194304 count=$(( (ISO_SIZE + 4194303) / 4194304 )) 2>/dev/null | head -c "$ISO_SIZE" | shasum -a 256 | awk '{print $1}')
+            fi
+
+            if [ "$ISO_CHECKSUM" != "$USB_CHECKSUM" ]; then
+                echo "Error: Checksum mismatch for $USB_DRIVE!"
+                echo "Expected: $ISO_CHECKSUM"
+                echo "Got:      $USB_CHECKSUM"
+                echo "The flash may have failed or the drive is corrupted."
+                exit 1
+            fi
+            echo "Checksum verification passed for $USB_DRIVE."
+
+            if [ -n "$INJECT_DIR" ]; then
+                if [ ! -d "$INJECT_DIR" ]; then
+                    echo "Error: Injection directory '$INJECT_DIR' not found. Skipping injection for $USB_DRIVE."
+                else
+                    if [ "$(uname -s)" = "Darwin" ]; then
+                        echo "Warning: Automated partition injection is not supported on macOS due to missing Linux-native tools (fdisk, mkfs.vfat, partprobe)."
+                        echo "Skipping injection for $USB_DRIVE."
+                    else
+                        echo "Injecting files from $INJECT_DIR into a new CONFIGS partition..."
+
+                        PART_COUNT_BEFORE=$(lsblk -rno NAME "$USB_DRIVE" | grep -v "$(basename "$USB_DRIVE")$" | wc -l)
+
+                        # Create a new primary FAT32 partition using fdisk.
+                        # 'n' for new, newlines to accept defaults (primary, partition number, start, end),
+                        # 't' for type, 'c' for W95 FAT32 (LBA), 'w' to write.
+                        echo -e "n\n\n\n\n\nt\n\nc\nw" | sudo fdisk "$USB_DRIVE" || true
+                        sudo partprobe "$USB_DRIVE"
+
+                        PART_COUNT_AFTER=$(lsblk -rno NAME "$USB_DRIVE" | grep -v "$(basename "$USB_DRIVE")$" | wc -l)
+
+                        if [ "$PART_COUNT_AFTER" -le "$PART_COUNT_BEFORE" ]; then
+                            echo "Error: Failed to safely create a new partition on $USB_DRIVE. Skipping injection."
+                        else
+                            # Find the newly created partition (highest partition number on the device)
+                            NEW_PART_NUM=$(lsblk -lno NAME "$USB_DRIVE" | grep -Eo "[0-9]+$" | sort -n | tail -1)
+                            NEW_PART="${USB_DRIVE}${NEW_PART_NUM}"
+                            if [ ! -b "$NEW_PART" ]; then NEW_PART="${USB_DRIVE}p${NEW_PART_NUM}"; fi
+
+                            if [ -b "$NEW_PART" ]; then
+                                echo "Formatting $NEW_PART as FAT32..."
+                                sudo wipefs -a "$NEW_PART" || true
+                                sudo mkfs.vfat -n "CONFIGS" "$NEW_PART"
+
+                                MNT_DIR=$(mktemp -d)
+                                sudo mount "$NEW_PART" "$MNT_DIR"
+                                sudo cp -a "$INJECT_DIR"/. "$MNT_DIR"/
+                                sudo umount "$MNT_DIR"
+                                rm -rf "$MNT_DIR"
+                                echo "Files injected successfully."
+                            else
+                                echo "Error: Could not find the newly created partition on $USB_DRIVE."
+                            fi
+                        fi
+                    fi
+                fi
+            fi
+
+            echo "--- Flashing Complete for $USB_DRIVE ---"
+        done
+        echo "=== All Flashing Operations Complete! ==="
     fi
 
     exit 0


### PR DESCRIPTION
Closes #TODO

Implements the "Enhance USB Flashing in build_iso.sh" task from `TODO.md`.

*   **Flashing Multiple Drives:** Users can now specify multiple space-separated drives to flash sequentially in a single run.
*   **Post-flash Verification:** The script now calculates the exact byte size of the built ISO and automatically reads back that exact amount from the flashed block device to verify data integrity using `sha256sum` (or `shasum` on macOS).
*   **Auto-mounting / File Injection:** Added an `--inject <folder_path>` flag. When run on a Linux host, this safely uses `fdisk` and `mkfs.vfat` to append a new FAT32 partition to the remaining free space of the USB stick, then automatically mounts and copies the configuration files (including hidden files) into it.

Tested successfully by running `uv run pytest -v tests/unit/test_provisioning.py` and `bash -n os-image/build_iso.sh`.

---
*PR created automatically by Jules for task [12129752999608429996](https://jules.google.com/task/12129752999608429996) started by @LokiMetaSmith*