### PR TITLE
Fix GRUB installation failure for UEFI nodes by removing legacy MBR config and forcing GPT

### DIFF
--- a/os-image/config/includes.installer/preseed.cfg
+++ b/os-image/config/includes.installer/preseed.cfg
@@ -34,13 +34,14 @@ d-i partman/early_command string \
     for dev in /dev/nvme0n1 /dev/sda /dev/sdb /dev/vda /dev/xvda; do \
         if [ -b "$dev" ] && [ "$dev" != "$USBDEV" ]; then \
             debconf-set partman-auto/disk "$dev"; \
-            debconf-set grub-installer/bootdev "$dev"; \
             break; \
         fi; \
     done
 
 d-i partman-auto/method string regular
 d-i partman-auto/choose_recipe select atomic
+d-i partman-partitioning/choose_label string gpt
+d-i partman-partitioning/default_label string gpt
 d-i partman-partitioning/confirm_write_new_label boolean true
 d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
@@ -66,7 +67,10 @@ popularity-contest popularity-contest/participate boolean false
 # Boot loader installation
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
-d-i grub-installer/bootdev string default
+# Ensure UEFI boot via EFI partition instead of legacy MBR
+d-i grub-installer/update-nvram boolean true
+# For some UEFI firmwares, force installation to the removable media path
+d-i grub-installer/force-efi-extra-removable boolean true
 
 # Late command: disable password authentication and enable passwordless sudo
 d-i preseed/late_command string \


### PR DESCRIPTION
The cluster machines failed during OS installation at the GRUB bootloader step because `preseed.cfg` forced an MBR legacy boot device (`debconf-set grub-installer/bootdev "$dev"` and `d-i grub-installer/bootdev string default`). On UEFI systems, this crashes GRUB since it attempts to write to the master boot record rather than the EFI System Partition.

This commit updates `os-image/config/includes.installer/preseed.cfg` to:
- Remove legacy MBR GRUB targeting.
- Enforce the GUID Partition Table (GPT) layout natively.
- Set `force-efi-extra-removable` and `update-nvram` to ensure unattended, reliable booting in headless UEFI environments.

---
*PR created automatically by Jules for task [12811014485388888160](https://jules.google.com/task/12811014485388888160) started by @LokiMetaSmith*