### PR TITLE
fix(mqtt): Fix Ansible idempotency issue when loading cached mosquitto image

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -189,6 +189,7 @@
   when: mosquitto_cache_stat.stat.exists
   register: load_mosquitto_cache
   ignore_errors: yes
+  changed_when: false
   delegate_to: "{{ controller_host }}"
   run_once: true
 


### PR DESCRIPTION
Fixes an idempotency issue where the "Load Mosquitto image from local cache" task always reported as 'changed' during playbook runs.

---
*PR created automatically by Jules for task [17177052256519268382](https://jules.google.com/task/17177052256519268382) started by @LokiMetaSmith*