### PR TITLE
fix(commanddeck): enable proper exit to KDE Plasma desktop

### DIFF
--- a/command_deck/backend/app.py
+++ b/command_deck/backend/app.py
@@ -307,6 +307,15 @@ class CommandDeckAPIHandler(BaseHTTPRequestHandler):
                 # Terminate python process in a separate thread to allow response to client first
                 def terminate_app():
                     time.sleep(1)
+
+                    # Try to set SDDM autologin session to plasmawayland and restart SDDM
+                    if os.path.exists('/etc/sddm.conf.d/autologin.conf'):
+                        try:
+                            subprocess.run(['sudo', 'sed', '-i', 's/Session=command-deck/Session=plasmawayland/g', '/etc/sddm.conf.d/autologin.conf'], check=True)
+                            subprocess.run(['sudo', 'systemctl', 'restart', 'sddm'], check=True)
+                        except Exception as e:
+                            print(f"Failed to configure or restart SDDM: {e}", flush=True)
+
                     os.kill(os.getpid(), signal.SIGTERM)
                 threading.Thread(target=terminate_app).start()
                 return


### PR DESCRIPTION
The NERV console "Go to Desktop" button wasn't working. When it exited the CommandDeck GUI loop, SDDM's autologin was statically configured to respawn the `command-deck` session, which just trapped the user in a kiosk-like loop. 

This PR modifies the `/api/exit` backend handler to dynamically update `/etc/sddm.conf.d/autologin.conf` with a `sed` command to switch the session from `command-deck` to `plasmawayland` (the standard KDE session), and restarts the `sddm` service to apply the change immediately.

---
*PR created automatically by Jules for task [8812118269744162351](https://jules.google.com/task/8812118269744162351) started by @LokiMetaSmith*