### PR TITLE
🔒 Fix overly permissive CORS wildcard in production

### DIFF
--- a/pipecatapp/web_server.py
+++ b/pipecatapp/web_server.py
@@ -71,6 +71,9 @@ else:
     allowed_origins = []  # Secure default: Block all Cross-Origin requests
 
 if "*" in allowed_origins:
+    env_mode = os.getenv("ENV", "development").lower()
+    if env_mode == "production":
+        raise RuntimeError("Insecure CORS Configuration: Wildcard origin ('*') is not allowed in production mode. Set ALLOWED_ORIGINS to a specific list of trusted domains.")
     logging.warning("⚠️  Security Warning: CORS is configured to allow all origins ('*'). This is acceptable for development but insecure for production. Set 'ALLOWED_ORIGINS' environment variable to a comma-separated list of trusted domains.")
 
 app.add_middleware(

--- a/tests/unit/test_cors_security.py
+++ b/tests/unit/test_cors_security.py
@@ -1,0 +1,82 @@
+import os
+import sys
+import unittest.mock
+import pytest
+import subprocess
+
+def test_cors_production_wildcard_rejection():
+    """
+    Test that running the web_server in 'production' mode with a wildcard CORS
+    origin correctly raises a RuntimeError at startup to prevent insecure deployment.
+    """
+    env = os.environ.copy()
+    env["ENV"] = "production"
+    env["ALLOWED_ORIGINS"] = "*"
+
+    mock_script = """
+import sys
+import unittest.mock
+import os
+
+sys.modules['workflow'] = unittest.mock.MagicMock()
+sys.modules['workflow.runner'] = unittest.mock.MagicMock()
+sys.modules['workflow.history'] = unittest.mock.MagicMock()
+sys.modules['api_keys'] = unittest.mock.MagicMock()
+sys.modules['security'] = unittest.mock.MagicMock()
+sys.modules['models'] = unittest.mock.MagicMock()
+sys.modules['rate_limiter'] = unittest.mock.MagicMock()
+sys.modules['net_utils'] = unittest.mock.MagicMock()
+
+sys.path.insert(0, os.path.abspath('.'))
+
+import pipecatapp.web_server
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", mock_script],
+        env=env,
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode != 0
+    assert "RuntimeError: Insecure CORS Configuration: Wildcard origin ('*') is not allowed in production mode" in result.stderr
+
+def test_cors_development_wildcard_warning():
+    """
+    Test that running the web_server in 'development' mode with a wildcard CORS
+    origin successfully starts but issues a warning.
+    """
+    env = os.environ.copy()
+    env["ENV"] = "development"
+    env["ALLOWED_ORIGINS"] = "*"
+
+    # To test without importing heavy dependencies in a separate process,
+    # we can run a custom script that mocks the heavy parts.
+    mock_script = """
+import sys
+import unittest.mock
+import os
+
+sys.modules['workflow'] = unittest.mock.MagicMock()
+sys.modules['workflow.runner'] = unittest.mock.MagicMock()
+sys.modules['workflow.history'] = unittest.mock.MagicMock()
+sys.modules['api_keys'] = unittest.mock.MagicMock()
+sys.modules['security'] = unittest.mock.MagicMock()
+sys.modules['models'] = unittest.mock.MagicMock()
+sys.modules['rate_limiter'] = unittest.mock.MagicMock()
+sys.modules['net_utils'] = unittest.mock.MagicMock()
+
+sys.path.insert(0, os.path.abspath('.'))
+
+import pipecatapp.web_server
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", mock_script],
+        env=env,
+        capture_output=True,
+        text=True
+    )
+
+    # It should exit gracefully
+    assert result.returncode == 0
+    assert "⚠️  Security Warning: CORS is configured to allow all origins" in result.stderr


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an overly permissive CORS wildcard (`*`) that was allowed to persist regardless of the environment.
⚠️ **Risk:** If left unfixed, the application could be deployed into production with `*` as an allowed origin. This would allow any malicious third-party domain to make cross-origin HTTP requests and potentially compromise sensitive endpoints or user data.
🛡️ **Solution:** The application now checks the `ENV` environment variable at startup. If the environment is set to `production` and the `*` wildcard is present in `ALLOWED_ORIGINS`, it raises a `RuntimeError` immediately to prevent startup. Development environments still issue a warning but are allowed to start. Test cases were written in `tests/unit/test_cors_security.py` to ensure this behavior is correct.

---
*PR created automatically by Jules for task [16605722954139843829](https://jules.google.com/task/16605722954139843829) started by @LokiMetaSmith*