### PR TITLE
feat: add desktop shortcut to reload CommandDeck

### DIFF
--- a/os-image/config/hooks/live/03-setup-command-deck.chroot
+++ b/os-image/config/hooks/live/03-setup-command-deck.chroot
@@ -3,6 +3,15 @@
 # Make CommandDeck session wrapper script executable inside the chroot
 chmod +x /usr/local/bin/command-deck-session
 
+# Make the reload-console script executable
+chmod +x /usr/local/bin/reload-console
+
+# Copy the desktop shortcut to the user's desktop
+mkdir -p /home/pipecatapp/Desktop
+cp "/etc/skel/Desktop/Reload Console.desktop" "/home/pipecatapp/Desktop/Reload Console.desktop"
+chmod +x "/home/pipecatapp/Desktop/Reload Console.desktop"
+chown -R pipecatapp:pipecatapp /home/pipecatapp/Desktop
+
 # Ensure command_deck files have the correct ownership for pipecatapp user
 if [ -d "/opt/pipecat-cluster/command_deck" ]; then
     chown -R pipecatapp:pipecatapp /opt/pipecat-cluster/command_deck

--- a/os-image/config/includes.chroot/etc/skel/Desktop/Reload Console.desktop
+++ b/os-image/config/includes.chroot/etc/skel/Desktop/Reload Console.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Reload Console
+Comment=Switch back to NERV CommandDeck
+Exec=/usr/local/bin/reload-console
+Icon=utilities-terminal
+Terminal=false
+Type=Application
+Categories=System;

--- a/os-image/config/includes.chroot/usr/local/bin/reload-console
+++ b/os-image/config/includes.chroot/usr/local/bin/reload-console
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# reload-console
+# Switches the SDDM autologin session back to the CommandDeck kiosk and restarts SDDM.
+
+set -euo pipefail
+
+if [ -f "/etc/sddm.conf.d/autologin.conf" ]; then
+    pkexec sed -i 's/Session=plasmawayland/Session=command-deck/g' /etc/sddm.conf.d/autologin.conf
+    pkexec systemctl restart sddm
+else
+    echo "SDDM autologin configuration not found."
+    exit 1
+fi


### PR DESCRIPTION
Adds a `reload-console` bash script that modifies the SDDM autologin configuration back to the `command-deck` session and restarts SDDM. Also creates a `.desktop` shortcut deployed to the user's Desktop during the live-build process to allow easy transition from the Plasma environment back into the console kiosk.