### PR TITLE
Refactor: Migrate external URLs from HTTP to HTTPS

### DIFF
--- a/ansible/roles/gpu_setup/tasks/main.yaml
+++ b/ansible/roles/gpu_setup/tasks/main.yaml
@@ -41,7 +41,7 @@
   block:
     - name: Ensure non-free component is in apt sources (for NVIDIA drivers on Debian)
       ansible.builtin.apt_repository:
-        repo: "deb http://deb.debian.org/debian trixie main contrib non-free non-free-firmware"
+        repo: "deb https://deb.debian.org/debian trixie main contrib non-free non-free-firmware"
         state: present
       become: yes
 

--- a/ansible/roles/pxe_server/defaults/main.yaml
+++ b/ansible/roles/pxe_server/defaults/main.yaml
@@ -1,5 +1,5 @@
 debian_version: "12.5.0"
-debian_mirror: "http://deb.debian.org/debian"
+debian_mirror: "https://deb.debian.org/debian"
 netboot_url: "{{ debian_mirror }}/dists/bookworm/main/installer-amd64/current/images/netboot/netboot.tar.gz"
 tftp_root: "/srv/tftp"
 nfs_root: "/srv/nfs/debian"

--- a/ansible/roles/pxe_server/tasks/main.yaml
+++ b/ansible/roles/pxe_server/tasks/main.yaml
@@ -16,7 +16,7 @@
 
 - name: Download and extract Debian netboot files
   unarchive:
-    src: "http://ftp.debian.org/debian/dists/stable/main/installer-amd64/current/images/netboot/netboot.tar.gz"
+    src: "https://ftp.debian.org/debian/dists/stable/main/installer-amd64/current/images/netboot/netboot.tar.gz"
     dest: /srv/tftp
     remote_src: yes
   become: yes
@@ -24,13 +24,13 @@
 
 - name: Download iPXE BIOS bootloader
   get_url:
-    url: http://boot.ipxe.org/undionly.kpxe
+    url: https://boot.ipxe.org/undionly.kpxe
     dest: "{{ tftp_root }}/undionly.kpxe"
   become: yes
 
 - name: Download iPXE UEFI bootloader
   get_url:
-    url: http://boot.ipxe.org/ipxe.efi
+    url: https://boot.ipxe.org/ipxe.efi
     dest: "{{ tftp_root }}/ipxe.efi"
   become: yes
 

--- a/ansible/roles/term_everything/tasks/main.yml
+++ b/ansible/roles/term_everything/tasks/main.yml
@@ -67,11 +67,6 @@
 
     - name: Build term.everything AppImage
       block:
-        - name: Fix alpineCompile.sh https to http
-          ansible.builtin.replace:
-            path: /tmp/term.everything/resources/alpineCompile.sh
-            regexp: 'https://dl-cdn.alpinelinux.org/'
-            replace: 'http://dl-cdn.alpinelinux.org/'
 
         - name: Add --network host and remove -it from podman run in distribute.sh
           ansible.builtin.replace:

--- a/os-image/build_iso.sh
+++ b/os-image/build_iso.sh
@@ -268,14 +268,14 @@ lb config \
   --distribution "$DISTRIBUTION" \
   --architecture "$ARCHITECTURE" \
   --mode debian \
-  --parent-mirror-bootstrap "http://deb.debian.org/debian/" \
-  --mirror-bootstrap "http://deb.debian.org/debian/" \
-  --parent-mirror-chroot "http://deb.debian.org/debian/" \
-  --mirror-chroot "http://deb.debian.org/debian/" \
-  --parent-mirror-binary "http://deb.debian.org/debian/" \
-  --mirror-binary "http://deb.debian.org/debian/" \
-  --parent-mirror-debian-installer "http://deb.debian.org/debian/" \
-  --mirror-debian-installer "http://deb.debian.org/debian/" \
+  --parent-mirror-bootstrap "https://deb.debian.org/debian/" \
+  --mirror-bootstrap "https://deb.debian.org/debian/" \
+  --parent-mirror-chroot "https://deb.debian.org/debian/" \
+  --mirror-chroot "https://deb.debian.org/debian/" \
+  --parent-mirror-binary "https://deb.debian.org/debian/" \
+  --mirror-binary "https://deb.debian.org/debian/" \
+  --parent-mirror-debian-installer "https://deb.debian.org/debian/" \
+  --mirror-debian-installer "https://deb.debian.org/debian/" \
   --archive-areas "main contrib non-free non-free-firmware" \
   --apt-indices true \
   --apt-recommends false \

--- a/playbooks/common_setup.yaml
+++ b/playbooks/common_setup.yaml
@@ -20,9 +20,9 @@
     - name: Ensure Debian repositories are configured (needed for minimal/live ISOs)
       raw: |
         cat <<EOF > /etc/apt/sources.list
-        deb http://deb.debian.org/debian trixie main contrib non-free-firmware
-        deb http://security.debian.org/debian-security trixie-security main contrib non-free-firmware
-        deb http://deb.debian.org/debian trixie-updates main contrib non-free-firmware
+        deb https://deb.debian.org/debian trixie main contrib non-free-firmware
+        deb https://security.debian.org/debian-security trixie-security main contrib non-free-firmware
+        deb https://deb.debian.org/debian trixie-updates main contrib non-free-firmware
         EOF
       changed_when: false
 
@@ -31,11 +31,11 @@
         mkdir -p /etc/apt/trusted.gpg.d
         for key in 6ED0E7B82643E131 78DBA3BC47EF2265 762F67A0B2C39DE4 BDE6D2B9216EC7A8 8E9F831205B4BA95; do
           if command -v wget >/dev/null 2>&1; then
-            wget -qO- "http://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x$key" > "/etc/apt/trusted.gpg.d/$key.asc"
+            wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x$key" > "/etc/apt/trusted.gpg.d/$key.asc"
           elif command -v curl >/dev/null 2>&1; then
-            curl -sL "http://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x$key" > "/etc/apt/trusted.gpg.d/$key.asc"
+            curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x$key" > "/etc/apt/trusted.gpg.d/$key.asc"
           else
-            python3 -c "import urllib.request; urllib.request.urlretrieve('http://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x$key', '/etc/apt/trusted.gpg.d/' + '$key' + '.asc')"
+            python3 -c "import urllib.request; urllib.request.urlretrieve('https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&search=0x$key', '/etc/apt/trusted.gpg.d/' + '$key' + '.asc')"
           fi
         done
       changed_when: false


### PR DESCRIPTION
This PR updates all standard external package repositories, mirrors, and downloads to enforce secure connections (HTTPS) across Ansible playbooks and OS bootstrapping scripts. Local and internal cluster HTTP references remain unchanged.

---
*PR created automatically by Jules for task [6261331132549874251](https://jules.google.com/task/6261331132549874251) started by @LokiMetaSmith*