### PR TITLE
Fix IPFS Gateway HTTP connection timeouts and refused connections by enforcing HTTPS

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -298,7 +298,7 @@
 
 - name: Warm up IPFS gateway cache for Mosquitto tarball
   ansible.builtin.uri:
-    url: "http://{{ cluster_ip }}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ mosquitto_ipfs_cid }}"
+    url: "https://{{ cluster_ip }}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ mosquitto_ipfs_cid }}"
     method: GET
     timeout: 60
     status_code: [200, 502, 504]

--- a/ansible/templates/shared/load_image_task.nomad.j2
+++ b/ansible/templates/shared/load_image_task.nomad.j2
@@ -29,7 +29,7 @@
           # Pull resiliently from local IPFS gateway with retries (bypassing go-getter 504 limits)
           echo "Fetching CID {{ image_cid }} from IPFS gateway..."
           for i in 1 2 3 4 5; do
-            if curl -sSf --retry 3 --retry-delay 5 --max-time 120 "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ image_cid }}" -o "$TAR_PATH"; then
+            if curl -sSf --retry 3 --retry-delay 5 --max-time 120 "https://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ image_cid }}" -o "$TAR_PATH"; then
               echo "Successfully downloaded tarball."
               docker load -i "$TAR_PATH"
               exit 0


### PR DESCRIPTION
When hitting the IPFS gateway via `http://` over `100.64.0.1` and `127.0.0.1`, `curl` and Ansible's `uri` module encounter a "Connection refused" error because the IPFS gateway is expected to be served securely via TLS locally (or behind a load balancer that forwards `https`). This commit selectively switches the specific `ipfs_gateway_port` queries in `load_image_task.nomad.j2` and `ansible/roles/mqtt/tasks/main.yaml` from `http://` to `https://` to correctly query the cache.

---
*PR created automatically by Jules for task [5787493115979068927](https://jules.google.com/task/5787493115979068927) started by @LokiMetaSmith*