### PR TITLE
Fix heal_cluster.sh crashing on deploy_llama_cpp_model.yaml

### DIFF
--- a/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
@@ -7,6 +7,12 @@
   ansible.builtin.set_fact:
     nomad_protocol: "{{ \"https\" if nomad_cli_cert_stat.stat.exists else \"http\" }}"
 
+- name: Ensure Nomad jobs directory exists
+  ansible.builtin.file:
+    path: "{{ nomad_jobs_dir }}"
+    state: directory
+    mode: '0755'
+
 - name: Render the Llama.cpp RPC Nomad job from template for bootstrap
   ansible.builtin.template:
     src: "{{ inventory_dir }}/ansible/jobs/llamacpp-rpc.nomad.j2"
@@ -34,7 +40,7 @@
     NOMAD_CLIENT_KEY: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.key.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
 - name: Deploy the main Llama.cpp RPC service to Nomad
   ansible.builtin.command:
-    cmd: "nomad job run -detach {{ nomad_jobs_dir }}/llamacpp-rpc.nomad"
+    cmd: "/usr/local/bin/nomad job run -detach {{ nomad_jobs_dir }}/llamacpp-rpc.nomad"
   environment:
     NOMAD_ADDR: "{{ nomad_protocol | default('https') }}://{{ cluster_ip | default('127.0.0.1') }}:{{ nomad_http_port | default(4646) }}"
     NOMAD_CACERT: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/ca.pem') if nomad_cli_cert_stat.stat.exists else omit }}"


### PR DESCRIPTION
Ensures the directory dependency is met for standalone runs and uses absolute binary paths for execution robustness.

---
*PR created automatically by Jules for task [15267163577655471643](https://jules.google.com/task/15267163577655471643) started by @LokiMetaSmith*