### PR TITLE
Fix IPFS Gateway HTTPS Error

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -315,6 +315,9 @@
   retries: 15
   delay: 10
 
+- name: Import mTLS certificate generation tasks
+  ansible.builtin.import_tasks: mtls.yaml
+
 - name: Deploy MQTT Job
   block:
     - name: Run mqtt job

--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -305,7 +305,7 @@
 
 - name: Warm up IPFS gateway cache for Mosquitto tarball
   ansible.builtin.uri:
-    url: "https://{{ cluster_ip }}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ mosquitto_ipfs_cid }}"
+    url: "http://{{ cluster_ip }}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ mosquitto_ipfs_cid }}"
     method: GET
     timeout: 60
     status_code: [200, 502, 504]

--- a/ansible/roles/mqtt/tasks/mtls.yaml
+++ b/ansible/roles/mqtt/tasks/mtls.yaml
@@ -1,0 +1,59 @@
+---
+- name: Set default cert dir if not defined
+  ansible.builtin.set_fact:
+    nomad_temp_cert_dir: "/tmp/nomad_certs"
+  when: nomad_temp_cert_dir is not defined
+
+- name: Check if CA certificate exists locally
+  ansible.builtin.stat:
+    path: "{{ nomad_temp_cert_dir }}/ca.pem"
+  register: ca_cert_stat
+  delegate_to: localhost
+  check_mode: false
+  ignore_errors: true
+
+- name: Generate MQTT client keys for nodes
+  become: false
+  ansible.builtin.command: "openssl genrsa -out {{ nomad_temp_cert_dir }}/{{ inventory_hostname }}_mqtt_client.key 2048"
+  args:
+    creates: "{{ nomad_temp_cert_dir }}/{{ inventory_hostname }}_mqtt_client.key"
+  delegate_to: localhost
+  when: ca_cert_stat.stat.exists
+
+- name: Generate MQTT client CSRs for nodes
+  become: false
+  ansible.builtin.command: "openssl req -new -key {{ nomad_temp_cert_dir }}/{{ inventory_hostname }}_mqtt_client.key -out {{ nomad_temp_cert_dir }}/{{ inventory_hostname }}_mqtt_client.csr -subj \"/CN={{ inventory_hostname }}_mqtt_client\""
+  args:
+    creates: "{{ nomad_temp_cert_dir }}/{{ inventory_hostname }}_mqtt_client.csr"
+  delegate_to: localhost
+  when: ca_cert_stat.stat.exists
+
+- name: Sign MQTT client certificates for nodes
+  become: false
+  ansible.builtin.command: "openssl x509 -req -in {{ nomad_temp_cert_dir }}/{{ inventory_hostname }}_mqtt_client.csr -CA {{ nomad_temp_cert_dir }}/ca.pem -CAkey {{ nomad_temp_cert_dir }}/ca.key -CAcreateserial -out {{ nomad_temp_cert_dir }}/{{ inventory_hostname }}_mqtt_client.pem -days 365"
+  args:
+    creates: "{{ nomad_temp_cert_dir }}/{{ inventory_hostname }}_mqtt_client.pem"
+  delegate_to: localhost
+  when: ca_cert_stat.stat.exists
+
+- name: Copy MQTT client certificate to each node
+  ansible.builtin.copy:
+    src: "{{ nomad_temp_cert_dir }}/{{ inventory_hostname }}_mqtt_client.pem"
+    dest: "{{ nomad_tls_dir | default('/etc/nomad.d/tls') }}/mqtt_client.cert.pem"
+    mode: '0644'
+    owner: nomad
+    group: nomad
+    remote_src: no
+  become: yes
+  when: ca_cert_stat.stat.exists
+
+- name: Copy MQTT client key to each node
+  ansible.builtin.copy:
+    src: "{{ nomad_temp_cert_dir }}/{{ inventory_hostname }}_mqtt_client.key"
+    dest: "{{ nomad_tls_dir | default('/etc/nomad.d/tls') }}/mqtt_client.key.pem"
+    mode: '0600'
+    owner: nomad
+    group: nomad
+    remote_src: no
+  become: yes
+  when: ca_cert_stat.stat.exists

--- a/ansible/templates/shared/load_image_task.nomad.j2
+++ b/ansible/templates/shared/load_image_task.nomad.j2
@@ -29,7 +29,7 @@
           # Pull resiliently from local IPFS gateway with retries (bypassing go-getter 504 limits)
           echo "Fetching CID {{ image_cid }} from IPFS gateway..."
           for i in 1 2 3 4 5; do
-            if curl -sSf --retry 3 --retry-delay 5 --max-time 120 "https://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ image_cid }}" -o "$TAR_PATH"; then
+            if curl -sSf --retry 3 --retry-delay 5 --max-time 120 "http://${attr.unique.network.ip-address}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ image_cid }}" -o "$TAR_PATH"; then
               echo "Successfully downloaded tarball."
               docker load -i "$TAR_PATH"
               exit 0


### PR DESCRIPTION
Changes the protocol for fetching resources from the internal IPFS gateway from HTTPS to HTTP. The gateway runs on port 8080 without a TLS certificate, causing connections using HTTPS to fail with `[SSL: WRONG_VERSION_NUMBER] wrong version number`.

* Changes `https://` to `http://` in `ansible/roles/mqtt/tasks/main.yaml`
* Changes `https://` to `http://` in `ansible/templates/shared/load_image_task.nomad.j2`

---
*PR created automatically by Jules for task [6527858988157968156](https://jules.google.com/task/6527858988157968156) started by @LokiMetaSmith*