### PR TITLE
feat: implement ATProto payload signing and fail-close verification

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -318,6 +318,30 @@
 - name: Import mTLS certificate generation tasks
   ansible.builtin.import_tasks: mtls.yaml
 
+- name: Ensure Mosquitto certs directory exists on host
+  ansible.builtin.file:
+    path: /opt/mqtt/certs
+    state: directory
+    owner: "1883"
+    group: "1883"
+    mode: '0755'
+  become: yes
+
+- name: Copy TLS certificates for Mosquitto to accessible directory
+  ansible.builtin.copy:
+    src: "{{ nomad_tls_dir | default('/etc/nomad.d/tls') }}/{{ item }}"
+    dest: "/opt/mqtt/certs/{{ item }}"
+    owner: "1883"
+    group: "1883"
+    mode: '0600'
+    remote_src: yes
+  loop:
+    - ca.pem
+    - cert.pem
+    - key.pem
+  become: yes
+  ignore_errors: yes
+
 - name: Deploy MQTT Job
   block:
     - name: Run mqtt job

--- a/ansible/roles/mqtt/templates/mqtt.nomad.j2
+++ b/ansible/roles/mqtt/templates/mqtt.nomad.j2
@@ -77,7 +77,7 @@ job "mqtt" {
       config {
         image = "eclipse-mosquitto:2"
         network_mode = "host"
-        volumes = ["/etc/nomad.d/tls:/mosquitto/certs:ro"]
+        volumes = ["/opt/mqtt/certs:/mosquitto/certs:ro"]
         # Host mode networking requires no port map here
         cap_add = ["SETUID", "SETGID", "CHOWN", "NET_BIND_SERVICE"]
         command = "mosquitto"


### PR DESCRIPTION
Implements Phase 2 of the ATProto Verification (Application layer) and merges Phase 1.

- Added `pipecatapp/atproto_crypto.py` which provides deterministic JSON signing and verification using `cryptography` (ECDSA SECP256R1).
- Updated the security agent script to natively read the private key and DID from the environment, signing all `publish_alert()` MQTT payloads.
- Injected `ATPROTO_PRIVATE_KEY_HEX`, `ATPROTO_DID` and `AUTHORIZED_DIDS` across the Nomad job templates.
- Enforced strict fail-close security in `WorkerAgent`. Messages missing a signature, from an unauthorized DID, or containing an invalid signature are immediately dropped. If the `AUTHORIZED_DIDS` config is empty or missing, all messages are dropped by default (fail-close).
- Explicitly added `cryptography` to `pyproject.toml` and `ansible/roles/security_agent/files/requirements.txt` to prevent runtime crashes.
- Fixed a permission issue when mounting host TLS certificates into the Mosquitto Docker container. Certificates are now copied to `/opt/mqtt/certs` with owner `1883` so Mosquitto can read them.