### PR TITLE
Fix Jinja2 template syntax error in vector.nomad.j2

### DIFF
--- a/ansible/roles/vector/tasks/main.yaml
+++ b/ansible/roles/vector/tasks/main.yaml
@@ -7,6 +7,14 @@
   ansible.builtin.set_fact:
     nomad_protocol: "{{ \"https\" if nomad_cli_cert_stat.stat.exists else \"http\" }}"
 
+- name: Ensure nomad jobs directory exists
+  ansible.builtin.file:
+    path: "{{ nomad_jobs_dir | default('/opt/nomad/jobs') }}"
+    state: directory
+    mode: '0755'
+  become: yes
+  run_once: true
+
 - name: Template vector job
   ansible.builtin.template:
     src: vector.nomad.j2

--- a/ansible/roles/vector/templates/vector.nomad.j2
+++ b/ansible/roles/vector/templates/vector.nomad.j2
@@ -107,7 +107,7 @@ sinks:
       codec: "json"
     mode: "tcp"
     # We will use the Nomad service variable to resolve the host and port
-    address: "{% raw %}{{ range service \"security-agent\" }}{{ .Address }}:{{ .Port }}{{ end }}{% end raw %}"
+    address: "{% raw %}{{ range service \"security-agent\" }}{{ .Address }}:{{ .Port }}{{ end }}{% endraw %}"
 
   # Archive to decentralized cluster storage
   fs_archive:


### PR DESCRIPTION
Fixed a Jinja2 template rendering error in `ansible/roles/vector/templates/vector.nomad.j2` caused by incorrectly formatting the closing tag of a raw block. Added a task to create the target directory to improve idempotency.

---
*PR created automatically by Jules for task [6336066991461313374](https://jules.google.com/task/6336066991461313374) started by @LokiMetaSmith*