### PR TITLE
Fix IPFS_PATH configuration in MQTT Ansible role

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -220,7 +220,7 @@
   become: yes
   register: ipfs_add_result_mosquitto
   environment:
-    IPFS_PATH: "/opt/unified_fs_backend/ipfs/{{ controller_host }}"
+    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
   changed_when: false
   delegate_to: "{{ controller_host }}"
   run_once: true


### PR DESCRIPTION
Aligned the `IPFS_PATH` environment variable in `ansible/roles/mqtt/tasks/main.yaml` with the shared network mount pattern used throughout the rest of the project. This fixes a 504 Gateway Timeout that occurred during the Mosquitto tarball IPFS gateway cache warmup due to the daemon not finding the pinned CID.

---
*PR created automatically by Jules for task [5113030979604162680](https://jules.google.com/task/5113030979604162680) started by @LokiMetaSmith*