### PR TITLE
Gracefully handle Connection Refused during IPFS gateway warmup

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -308,7 +308,7 @@
     url: "http://{{ cluster_ip }}:{{ ipfs_gateway_port | default(8080) }}/ipfs/{{ mosquitto_ipfs_cid }}"
     method: GET
     timeout: 60
-    status_code: [200, 502, 504]
+    status_code: [200, 502, 504, -1]
   register: ipfs_warmup
   until: ipfs_warmup.status is defined and ipfs_warmup.status == 200
   failed_when: false

--- a/ansible/tests/verify_uri_module_graceful_failure.yaml
+++ b/ansible/tests/verify_uri_module_graceful_failure.yaml
@@ -1,0 +1,24 @@
+---
+- name: Verify URI module handles -1 status gracefully
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Test uri connection refused handles gracefully
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:9999/ipfs/xyz"
+        method: GET
+        timeout: 2
+        status_code: [200, 502, 504, -1]
+      register: _test_uri
+      until: _test_uri.status is defined and _test_uri.status == 200
+      failed_when: false
+      retries: 3
+      delay: 1
+
+    - name: Assert URI module handled the -1 status gracefully
+      ansible.builtin.assert:
+        that:
+          - "_test_uri.status == -1"
+          - "_test_uri.failed == false or _test_uri.failed_when_result == false"
+        fail_msg: "URI module failed unexpectedly."
+        success_msg: "URI module gracefully handled connection refused (-1)."


### PR DESCRIPTION
The Ansible `uri` module throws a verbose traceback error for `Connection refused` (represented as `-1`) before it evaluates `failed_when`. Adding `-1` to the `status_code` list when testing connection availability during an `until` retry loop allows it to retry silently without failing the playbook with messy output. A standardized test playbook `ansible/tests/verify_uri_module_graceful_failure.yaml` was also created to verify this behavior.

---
*PR created automatically by Jules for task [9093097445958734757](https://jules.google.com/task/9093097445958734757) started by @LokiMetaSmith*