### PR TITLE
Fix IPFS path for mosquitto upload to use standard mount path

### DIFF
--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -220,7 +220,7 @@
   become: yes
   register: ipfs_add_result_mosquitto
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs/{{ controller_host }}"
+    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
   changed_when: false
   delegate_to: "{{ controller_host }}"
   run_once: true


### PR DESCRIPTION
Fix IPFS path for mosquitto upload to use standard mount path

The `IPFS_PATH` environment variable in the MQTT role incorrectly appended the `controller_host` to the path when running `ipfs add`.
This caused the task to fail with an error `Error: no IPFS repo found in /opt/unified_fs/ipfs/localhost` since the path hadn't been initialized as an IPFS repo. This fixes the path by removing the `{{ controller_host }}` variable interpolation.

---
*PR created automatically by Jules for task [10054794286578217076](https://jules.google.com/task/10054794286578217076) started by @LokiMetaSmith*