### PR TITLE
Fix pipecatapp pip dependency installation for Python 3.13 by requiring pillow>=10.4.0

### DIFF
--- a/pipecatapp/requirements.txt
+++ b/pipecatapp/requirements.txt
@@ -33,7 +33,7 @@ onnxruntime
 opencv-python-headless
 pandas
 paramiko
-pillow
+pillow>=10.4.0
 pipecat-ai[openai,local]
 pipecat-ai-whisker
 piper-tts


### PR DESCRIPTION
The ansible playbook was failing on `Install python dependencies` step because some package allows older `pillow` versions (like `10.3.0`), which `pip`'s resolver tries to build from source on Python 3.13, resulting in `fatal error: portaudio.h: No such file or directory` or `ERROR: Failed to build 'pillow' when getting requirements to build wheel` errors due to Python 3.13 incompatibility.

Enforcing `pillow>=10.4.0` in `pipecatapp/requirements.txt` ensures that `pip` uses versions with proper Python 3.13 support and pre-built wheels, preventing the build failures.

---
*PR created automatically by Jules for task [314719894027044711](https://jules.google.com/task/314719894027044711) started by @LokiMetaSmith*