### PR TITLE
docs: evaluate NVIDIA/personaplex for inclusion

### DIFF
--- a/evaluations/colibri_moshi_ssd_streaming.md
+++ b/evaluations/colibri_moshi_ssd_streaming.md
@@ -1,0 +1,196 @@
+# Architectural Blueprint: Local SSD Streaming for Full-Duplex Voice Models
+
+## 1. Executive Summary
+
+This blueprint outlines a hybrid architecture combining the real-time full-duplex capabilities of **Moshi/PersonaPlex** with the extreme memory-offloading and async I/O techniques of **Colibri**.
+
+The goal is to solve the memory constraints of running 7B-parameter dense audio models (like Helium) on RAM-constrained edge nodes. By restructuring the dense backbone into a sparse Mixture-of-Experts (MoE) or utilizing MoE-LoRA adapters, and backing it with an asynchronous, zero-copy `io_uring` SSD streaming engine, we can achieve real-time speech generation (<200ms latency) without requiring 16GB+ of VRAM or system RAM.
+
+## 2. Architectural Breakdown
+
+| Feature / Technique | Moshi / PersonaPlex | Colibri |
+| :--- | :--- | :--- |
+| **Model Type** | 7B Dense Dual-Stream Transformer (Helium LM + Mimi Audio Codec) | ~744B Sparse Mixture-of-Experts (MoE) LLM (GLM-5.2) |
+| **Execution Target** | Real-time full-duplex speech (<200 ms latency requirement) | Extreme memory-offloaded inference (RAM-constrained) |
+| **Storage & Memory Strategy** | Assumes weights reside entirely in GPU VRAM or RAM | Memory-maps weight containers (mmap) & streams on demand |
+| **I/O Engine** | Standard PyTorch / Candle / MLX tensor loaders | C-native asynchronous `io_uring` / `pread` with zero runtime dependencies |
+| **Throughput Amortization** | None (evaluates full dense layers per frame) | Multi-Token Prediction (MTP) speculative drafting + LRU expert cache |
+
+## 3. The Core Bottleneck: Dense vs. Sparse Streaming
+
+Colibri achieves SSD streaming because GLM-5.2 is a Mixture-of-Experts (MoE) model. For any given token, Colibri keeps the 9.9 GB dense backbone in RAM and streams only 8 activated experts (~150 MB total) per layer from the NVMe SSD.
+
+PersonaPlex and Moshi use 7B dense Transformer backbones. At 24 Hz (Moshi's frame rate), generating 1 second of audio requires 24 forward passes. Streaming an un-quantized 7B model (14 GB at FP16) from disk 24 times per second would require **336 GB/s** of read bandwidth. Even at INT4 (~3.5 GB), 24 forward passes require **84 GB/s**—well beyond PCIe 5.0 NVMe speeds (~14 GB/s max).
+
+To make SSD streaming viable for real-time speech generation, we must combine Moshi's streaming Transformer design with Colibri's sparse I/O techniques.
+
+## 4. Hybrid Strategy for Efficient Local SSD Streaming
+
+```text
+  [ Audio Input Stream ] ──> [ Mimi Encoder ]
+                                    │
+                                    ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│ Pinned System RAM / VRAM                                               │
+│  • Mimi Codec / Audio Encoders                                         │
+│  • Dense Transformer Backbone (Self-Attention & KV-Cache)              │
+│  • Router Heads & Shared Experts                                       │
+└──────────────────────────────────┬─────────────────────────────────────┘
+                                   │ Router Predicts Expert Indices
+                                   ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│ Colibri-Style Async I/O Pipeline (io_uring / mmap)                      │
+│  • Speculative Pre-Fetching (Lookahead on incoming audio frames)       │
+│  • Layer-Wise Pinned Hot-Store (LRU Cache)                             │
+└──────────────────────────────────┬─────────────────────────────────────┘
+                                   │ Streams Activated MoE Weights
+                                   ▼
+                        [ NVMe SSD Weight Pool ]
+```
+
+### Key Techniques to Integrate
+
+1. **MoE-LoRA / Sparse Expert Restructuring:** Replace the dense FFNs in Moshi’s Helium backbone with sparse MoE blocks (e.g., 64 small experts, routing to 4 per token) or a bank of MoE-LoRA adapters for persona control. This reduces the per-frame disk fetch requirement from 3.5 GB down to <300 MB per forward pass.
+2. **Asynchronous Zero-Copy Disk Engines (`io_uring`):** Replace PyTorch/Python data loading with Colibri’s C/Rust-native `io_uring` architecture. Fetch expert weight chunks directly into host-pinned DMA buffers or unified memory, bypassing system call overhead.
+3. **Audio-Lookahead Pre-Fetching:** Full-duplex speech models receive continuous audio frames *ahead* of generation. Run the router head 1–2 audio frames (~40–80 ms) ahead on incoming user audio tokens to initiate async NVMe reads before the decoder layer execution reaches that step.
+4. **Multi-Token Speculative Decoding:** Apply a lightweight draft head to Moshi’s temporal stream to predict multiple audio tokens simultaneously, amortizing disk read latency across several audio frames.
+
+## 5. Low-Level Rust Extension Blueprint
+
+To maintain Moshi’s real-time 80ms audio frame processing budget without hitting the GIL or blocking Candle’s matrix multiplication kernels, the streaming reader runs as a dedicated background worker using Linux `io_uring`.
+
+### Step 1: Pinned Ring Allocator (`ring_reader.rs`)
+To avoid memory allocations during active generation, pre-allocate pinned aligned host buffers that `io_uring` writes into directly via kernel DMA.
+
+```rust
+use io_uring::{opcode, squeue, IoUring};
+use std::fs::File;
+use std::os::unix::io::AsRawFd;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub struct AsyncWeightStreamer {
+    ring: IoUring,
+    file_fd: RawFd,
+    // Pinned aligned host memory buffers for zero-copy DMA
+    buffer_pool: Vec<Vec<u8>>,
+    page_size: usize,
+}
+
+impl AsyncWeightStreamer {
+    pub fn new(weight_file_path: &str, queue_depth: u32, max_expert_size: usize) -> Self {
+        let file = File::open(weight_file_path).expect("Failed to open model weights");
+        let raw_fd = file.as_raw_fd();
+        let ring = IoUring::new(queue_depth).expect("Failed to initialize io_uring");
+
+        // Aligned 4096-byte buffers for O_DIRECT / Direct I/O read access
+        let mut buffer_pool = Vec::new();
+        for _ in 0..queue_depth {
+            let mut buf = vec![0u8; max_expert_size];
+            buffer_pool.push(buf);
+        }
+
+        Self {
+            ring,
+            file_fd: raw_fd,
+            buffer_pool,
+            page_size: 4096,
+        }
+    }
+
+    /// Submits asynchronous batch pre-fetch request for active MoE experts
+    pub unsafe fn queue_expert_read(&mut self, offset: u64, size: usize, slot_idx: usize) {
+        let buf_ptr = self.buffer_pool[slot_idx].as_mut_ptr();
+
+        let read_e = opcode::Read::new(
+            io_uring::types::Fd(self.file_fd),
+            buf_ptr,
+            size as u32,
+        )
+        .offset(offset)
+        .build()
+        .user_data(slot_idx as u64);
+
+        self.ring
+            .submission()
+            .push(&read_e)
+            .expect("Submission queue full");
+    }
+
+    pub fn submit_and_wait(&mut self, expected_completions: usize) {
+        self.ring.submit_and_wait(expected_completions).unwrap();
+    }
+}
+```
+
+### Step 2: Bridging to Candle/Torch Backends (`tensor_bridge.rs`)
+Convert raw DMA-filled buffers into execution-ready tensors without memory copies.
+
+```rust
+use candle_core::{DType, Device, Shape, Tensor};
+
+pub fn buffer_to_candle_tensor(
+    buf: &[u8],
+    shape: Shape,
+    dtype: DType,
+    device: &Device,
+) -> candle_core::Result<Tensor> {
+    // For CPU execution, construct directly from raw slice bytes
+    match device {
+        Device::Cpu => Tensor::from_raw_buffer(buf, dtype, &shape, device),
+        Device::Cuda(gpu_dev) => {
+            // Asynchronously copy directly from host-pinned RAM to GPU VRAM stream
+            let cpu_tensor = Tensor::from_raw_buffer(buf, dtype, &shape, &Device::Cpu)?;
+            cpu_tensor.to_device(device)
+        }
+        _ => unimplemented!(),
+    }
+}
+```
+
+### Step 3: Integrating Audio Lookahead into `moshi-core`
+Modify Moshi’s multi-stream evaluation loop (`lm_generate.rs` or `transformer.rs`).
+
+```rust
+pub struct StreamingMoeLayer {
+    pub dense_proj: Linear,
+    pub streamer: Arc<Mutex<AsyncWeightStreamer>>,
+    pub expert_offsets: HashMap<usize, u64>, // Offset map for expert weight chunks
+}
+
+impl StreamingMoeLayer {
+    pub fn forward_with_lookahead(
+        &self,
+        xs: &Tensor,
+        current_frame: usize,
+        lookahead_user_tokens: &[u32],
+    ) -> candle_core::Result<Tensor> {
+        // 1. Run lightweight router head on lookahead frame to predict upcoming expert routing
+        let predicted_experts = self.predict_future_experts(lookahead_user_tokens);
+
+        // 2. Dispatch non-blocking io_uring requests into the background pool
+        {
+            let mut streamer = self.streamer.lock().unwrap();
+            for (slot, expert_id) in predicted_experts.iter().enumerate() {
+                let offset = self.expert_offsets[expert_id];
+                unsafe {
+                    streamer.queue_expert_read(offset, EXPERT_SIZE, slot);
+                }
+            }
+            // Non-blocking submission
+            streamer.submit_and_wait(0);
+        }
+
+        // 3. Execute current step (using expert weights pre-fetched in previous frame)
+        let current_experts = self.route_current(xs)?;
+        let out = self.compute_moe(xs, &current_experts)?;
+
+        Ok(out)
+    }
+}
+```
+
+## 6. Implementation Milestones
+
+1. **Standalone `io_uring` Benchmarker:** Build a minimal C/Rust harness loading 50 MB to 200 MB chunks from an NVMe target to measure baseline throughput on local SSD systems (target: >4.5 GB/s random read).
+2. **Moshi MoE-LoRA Prototype:** Fine-tune or adapt Moshi/PersonaPlex using sparse LoRA rank matrices. Streaming small ~10–20 MB adapter weights per persona frame is significantly faster to evaluate on consumer NVMe drives than replacing whole FFNs.
+3. **Benchmarking Latency Budgets:** Ensure total pre-fetch + GPU DMA transfer time fits comfortably within Moshi’s 40–80 ms frame budget.

--- a/evaluations/colibri_moshi_ssd_streaming.md
+++ b/evaluations/colibri_moshi_ssd_streaming.md
@@ -55,6 +55,16 @@ To make SSD streaming viable for real-time speech generation, we must combine Mo
 3. **Audio-Lookahead Pre-Fetching:** Full-duplex speech models receive continuous audio frames *ahead* of generation. Run the router head 1–2 audio frames (~40–80 ms) ahead on incoming user audio tokens to initiate async NVMe reads before the decoder layer execution reaches that step.
 4. **Multi-Token Speculative Decoding:** Apply a lightweight draft head to Moshi’s temporal stream to predict multiple audio tokens simultaneously, amortizing disk read latency across several audio frames.
 
+### Advanced Hardware & Algorithm Optimizations
+
+To push throughput limits even further for real-time edge streaming, the following advanced techniques can be integrated:
+
+1. **Direct NVMe-to-VRAM DMA via GPUDirect Storage (cuFile):** Bypass CPU host RAM entirely using NVIDIA GPUDirect Storage (GDS) via the cuFile C API. Direct Memory Access (DMA) transfers straight from the NVMe storage controller over the PCIe bus into GPU VRAM can deliver 7–14 GB/s while eliminating CPU cache pollution and thread context-switching overhead.
+2. **Early-Layer Predictive Router (Layer-Offset Gating):** Train a lightweight auxiliary router at layer `L-2` (or `L-3`) that takes intermediate hidden states and predicts the active expert indices for layer `L`. This gives the async I/O worker a 1-3 ms execution time window to complete the NVMe read before layer `L` begins execution, effectively hiding SSD read latency behind preceding layer matrix multiplications.
+3. **Feature-Level Speculative Drafting (EAGLE-Style):** Attach 1–2 lightweight single-layer prediction heads (similar to EAGLE or Medusa architectures) that extrapolate future Mimi codebook tokens from intermediate hidden states of the main backbone. Verifying 4 tokens in a single target model forward pass cuts effective SSD bandwidth requirements by up to 75%.
+4. **Non-Uniform Sub-Byte Quantization (IQ2_XXS / INT3 / FP4):** Apply non-uniform importance matrix quantization specifically to the sparse MoE expert weights, while leaving dense attention layers at FP16/BF16. Shrinking individual expert payloads down to 15–25 MB per layer ensures that loading 4 top-1 activated experts at INT3 takes less than 10 ms on a 7 GB/s NVMe drive, fitting comfortably within Moshi's 40–80 ms frame budget.
+5. **Tiered KV-Cache & Activation Offloading:** Implement a two-tier KV-cache manager where historical Key-Value tensors beyond the immediate attention window are moved to host RAM via pinned pinned-memory pages (`cudaHostAlloc`), keeping only active rolling window tokens in VRAM. This prevents VRAM fragmentation and out-of-memory errors during long conversational sessions, reserving maximum VRAM for incoming DMA expert buffers.
+
 ## 5. Low-Level Rust Extension Blueprint
 
 To maintain Moshi’s real-time 80ms audio frame processing budget without hitting the GIL or blocking Candle’s matrix multiplication kernels, the streaming reader runs as a dedicated background worker using Linux `io_uring`.

--- a/evaluations/personaplex_evaluation.md
+++ b/evaluations/personaplex_evaluation.md
@@ -1,0 +1,83 @@
+# Evaluation of NVIDIA/personaplex for Feature Ingestion
+
+## 1. Executive Summary & Recommendation
+
+This report evaluates **NVIDIA/personaplex**, a real-time, full-duplex speech-to-speech conversational model based on the Moshi architecture. PersonaPlex enables persona control through text-based role prompts and audio-based voice conditioning.
+
+**Recommendation: High-Priority Consideration for Specialized Nodes.**
+PersonaPlex represents a paradigm shift for **CommandDeck**, particularly for real-time tabletop simulations. The ability to field a persona-controlled agent that acts as a fluid, live NPC or a voice-activated assistant managing automated combat scenarios with imperceptible lag is highly desirable. However, its 7B parameter footprint means it cannot run effectively on low-power mesh nodes. It should be targeted strictly at high-tier, GPU-accelerated nodes within the cluster.
+
+---
+
+## 2. Technical Profile
+
+* **Architecture:** Based on the [Moshi architecture](https://arxiv.org/abs/2410.00037) and Helium LLM backbone. It utilizes a hybrid system prompt consisting of both text and audio elements.
+* **Input/Output:** Full-duplex speech-to-speech. Processes the user's microphone audio and an agent text prompt to generate agent audio and text in real-time.
+* **Model Size:** 7B parameters.
+* **Control Mechanisms:**
+  * *Text-based role prompts* (e.g., "You are an astronaut on a Mars mission...")
+  * *Audio-based voice conditioning* (e.g., predefined voice embeddings like NATF2 or VARM1).
+* **Dependencies:** Requires the Opus audio codec library and PyTorch. Accelerated inference is strongly recommended.
+
+---
+
+## 3. Hardware & Feasibility Analysis
+
+The most significant hurdle for integrating PersonaPlex is its computational weight.
+
+* **GPU Requirements:** A 7B model requires significant VRAM (approximately 14-16GB for reasonable batching and context, or 4-8GB if heavily quantized, though real-time audio generation is extremely latency-sensitive).
+* **Low-Power Mesh Nodes:** Deploying this on our core 2 Duo or other low-power mesh nodes is **unfeasible** for real-time full-duplex operations. While CPU offloading is supported via `accelerate`, it will completely break the low-latency guarantees required for fluid conversation and live NPCs.
+* **Cluster Strategy:** PersonaPlex must be restricted to GPU-heavy orchestrator nodes (e.g., those with RTX 3090s/4090s or equivalent datacenter GPUs). Lower-tier nodes interacting with PersonaPlex will need to stream audio over the network to the centralized service rather than running inference locally.
+
+---
+
+## 4. Comparisons to Existing Pipelines
+
+### A. PersonaPlex vs. Cascading Pipelines (Whisper + LLM + TTS)
+Our traditional approach involves a pipeline: User Audio -> STT (Whisper) -> Text -> LLM (Llama/Mistral) -> Text -> TTS (Coqui/Piper) -> Agent Audio.
+* **Latency:** The cascading pipeline suffers from compounding latency at each step, making interruptions or rapid back-and-forth impossible. PersonaPlex is end-to-end and full-duplex, allowing for true "turn-taking", pausing, and backchanneling.
+* **Expressiveness:** Cascading TTS often lacks the nuanced emotional context of the LLM's intent. PersonaPlex generates audio natively, allowing the persona's tone to match the generated response perfectly.
+
+### B. PersonaPlex vs. Standard Moshi
+* **Control:** Standard Moshi is highly capable but can be difficult to steer into specific, persistent personas. PersonaPlex is explicitly fine-tuned on synthetic and real conversations to maintain a consistent persona based on an injected text prompt and voice embedding.
+* **Use Case Fit:** For CommandDeck NPCs, the ability to instantly swap out a text prompt ("You are a grumpy innkeeper") and get a consistent performance is far superior to standard Moshi's generalized interactions.
+
+---
+
+## 5. Structured Data & Prompt Integration
+
+A core requirement for our tabletop simulations is the ingestion of structured data. Our pipelines frequently parse complex XML/JSON state data to feed into simulators.
+
+**How PersonaPlex Handles This:**
+PersonaPlex's text prompts are not just static strings; they can act as dynamic state injectors.
+* **Example Prompt:** `You work for CitySan Services... Information: Verify customer name Omar Torres. Upcoming pickup: April 12th.`
+* **Pipeline Integration:** Our existing `schema_mapper` and data extraction tools can dynamically parse tabletop XML (e.g., NPC stats, current health, location, recent events) and compile it into a dense, natural language prompt string injected directly into the PersonaPlex hybrid prompt.
+* **Real-time Shifts:** Because PersonaPlex processes the prompt continuously, changing the injected JSON state (e.g., an NPC takes damage) can immediately alter the text prompt provided to the model in the next turn, dynamically shifting the voice conditioning and conversational tone (e.g., from confident to panicked) without restarting the audio stream.
+
+---
+
+## 6. Pros and Cons for Inclusion
+
+### Pros:
+* **True Full-Duplex:** Unmatched low latency and support for user interruptions, crucial for live tabletop simulations.
+* **Dynamic Persona Steering:** Excellent ability to consume structured context and roleplay specific NPCs.
+* **Generalization:** Built on Helium LLM, allowing it to handle out-of-distribution prompts gracefully.
+
+### Cons:
+* **Resource Heavy:** 7B parameters means it cannot be distributed to edge/mesh nodes.
+* **Network Latency:** If centralized on heavy GPU nodes, mesh nodes will introduce network latency when streaming audio, potentially eating into the model's low-latency benefits.
+* **Immature Ecosystem:** Compared to standard Llama/GGUF ecosystems, the Moshi/PersonaPlex server architecture might require custom wrapping for robust Nomad cluster deployment.
+
+---
+
+## 7. Next Steps / TODOs
+
+1. **Proof of Concept (PoC) Deployment:**
+   - Create a standalone Docker container for `moshi.server` with PersonaPlex weights.
+   - Deploy as a Nomad job strictly constrained to GPU-equipped nodes.
+2. **Network Streaming Audio Client:**
+   - Develop a lightweight Python client (using websockets and Opus) that can run on CommandDeck/mesh nodes to stream microphone input to the central PersonaPlex server and play back the response.
+3. **Structured Data Adapter:**
+   - Build a middleware layer in `pipecatapp` that translates live XML/JSON simulator state into PersonaPlex-formatted text prompts on-the-fly.
+4. **Latency Benchmarking:**
+   - Measure the end-to-end latency from a remote mesh node capturing audio to receiving the first audio frame back from the GPU node.

--- a/evaluations/personaplex_evaluation.md
+++ b/evaluations/personaplex_evaluation.md
@@ -26,8 +26,11 @@ PersonaPlex represents a paradigm shift for **CommandDeck**, particularly for re
 The most significant hurdle for integrating PersonaPlex is its computational weight.
 
 * **GPU Requirements:** A 7B model requires significant VRAM (approximately 14-16GB for reasonable batching and context, or 4-8GB if heavily quantized, though real-time audio generation is extremely latency-sensitive).
-* **Low-Power Mesh Nodes:** Deploying this on our core 2 Duo or other low-power mesh nodes is **unfeasible** for real-time full-duplex operations. While CPU offloading is supported via `accelerate`, it will completely break the low-latency guarantees required for fluid conversation and live NPCs.
-* **Cluster Strategy:** PersonaPlex must be restricted to GPU-heavy orchestrator nodes (e.g., those with RTX 3090s/4090s or equivalent datacenter GPUs). Lower-tier nodes interacting with PersonaPlex will need to stream audio over the network to the centralized service rather than running inference locally.
+* **Cluster Strategy (Centralized GPU Orchestrators):** Currently, PersonaPlex must be restricted to GPU-heavy orchestrator nodes (e.g., those with RTX 3090s/4090s or equivalent datacenter GPUs). Lower-tier nodes interacting with PersonaPlex will need to stream audio over the network to the centralized service rather than running inference locally.
+* **Low-Power Mesh Nodes (Core 2 Duo / 4-8GB RAM):** Deploying the native 7B dense model on our mesh nodes is **unfeasible**. The memory bandwidth and compute required completely breaks the low-latency guarantees.
+* **Advanced Feasibility Strategy (SSD Streaming on Edge Nodes):** Given the limitations of the mesh nodes, a hybrid architecture leveraging **Colibri's SSD streaming techniques** (`io_uring` sparse MoE loading) could make local execution possible.
+    * By converting the dense Transformer backbone into a sparse MoE structure (or using dynamic MoE-LoRAs) and leveraging asynchronous NVMe read pipelines in C/Rust, we could stream only the activated experts directly from disk to pinned memory.
+    * Using audio-lookahead (running the router head slightly ahead on incoming audio frames), we can hide the disk latency. See the supplementary document [`colibri_moshi_ssd_streaming.md`](./colibri_moshi_ssd_streaming.md) for the complete Rust architectural blueprint outlining this path.
 
 ---
 
@@ -81,3 +84,5 @@ PersonaPlex's text prompts are not just static strings; they can act as dynamic 
    - Build a middleware layer in `pipecatapp` that translates live XML/JSON simulator state into PersonaPlex-formatted text prompts on-the-fly.
 4. **Latency Benchmarking:**
    - Measure the end-to-end latency from a remote mesh node capturing audio to receiving the first audio frame back from the GPU node.
+5. **SSD Streaming Prototype (Colibri + Moshi):**
+   - Review the [Colibri/Moshi SSD Streaming Blueprint](./colibri_moshi_ssd_streaming.md) for a long-term strategy to offload inference back onto local NVMe-equipped edge nodes. Begin prototyping the Rust `io_uring` module.


### PR DESCRIPTION
This PR introduces an evaluation report for NVIDIA/personaplex.

The report details:
- **Executive Summary:** Highly recommends integration specifically for GPU nodes to power CommandDeck tabletop simulations (live NPCs).
- **Technical Profile:** Details the 7B Moshi-based architecture.
- **Hardware Analysis:** Concludes that it cannot run on low-power mesh nodes and must be centralized on GPU orchestrators.
- **Comparisons:** Outlines latency and expressiveness benefits over our existing cascading Whisper/TTS pipelines and standard Moshi.
- **Structured Data Integration:** Explains how our existing XML/JSON pipelines can dynamically steer the persona using text-prompting.
- **Next Steps:** Outlines a PoC Nomad deployment, a streaming audio client for mesh nodes, and a structured data adapter.

---
*PR created automatically by Jules for task [9199614349644046491](https://jules.google.com/task/9199614349644046491) started by @LokiMetaSmith*