### PR TITLE
Aggressive system cleanup for unused docker images and tmp files

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -24,13 +24,13 @@ echo -e "${BOLD}${YELLOW}⚠️  Starting Aggressive System Cleanup...${NC}"
 if command -v docker &> /dev/null; then
     echo -e "\n${BOLD}🐳 Cleaning Docker System...${NC}"
     echo "Pruning stopped containers, unused networks, and dangling images..."
-    docker system prune --force
+    docker system prune --all --force --volumes
 
     echo "Pruning build cache..."
-    docker builder prune --force
+    docker builder prune --all --force
 
     # Optional: Remove all unused images, not just dangling ones
-    # docker image prune --all --force
+    docker image prune --all --force
 else
     echo "Docker not found, skipping Docker cleanup."
 fi
@@ -70,18 +70,12 @@ if command -v snap &> /dev/null; then
         done
 fi
 
-# 5. Bootstrap Artifacts Cleanup
-echo -e "\n${BOLD}🧹 Cleaning Bootstrap Artifacts...${NC}"
-# Remove downloaded archives
-rm -f /tmp/consul.zip
-rm -f /tmp/nomad.zip
-rm -f /tmp/cni-plugins.tgz
-rm -f /tmp/get-docker.sh
-rm -f /tmp/pipecatapp.tar
+# 5. Temporary Files and Bootstrap Artifacts Cleanup
+echo -e "\n${BOLD}🧹 Cleaning Temporary Files...${NC}"
+sudo rm -rf /tmp/* /var/tmp/* 2>/dev/null || true
 
-# Remove extracted directories
-rm -rf /tmp/consul
-rm -rf /tmp/nomad
+echo -e "\n${BOLD}🧹 Cleaning UV Cache...${NC}"
+sudo rm -rf /var/tmp/ansible_pip_build/uv_cache 2>/dev/null || true
 
 # 6. Log Files
 echo -e "\n${BOLD}📝 Cleaning Log Files...${NC}"


### PR DESCRIPTION
Modified `scripts/cleanup.sh` to properly execute the user's request for a full system cleanup.

- Switched `docker system prune --force` to `docker system prune --all --force --volumes` to aggressively clean everything.
- Switched `docker builder prune --force` to `docker builder prune --all --force`.
- Uncommented `docker image prune --all --force` as requested to clear unused images.
- Replaced the hardcoded 'Bootstrap Artifacts Cleanup' with a generic wipe of `/tmp/*` and `/var/tmp/*` to clean up *all* lingering files.
- Explicitly delete `/var/tmp/ansible_pip_build/uv_cache` to clean the UV cache.

---
*PR created automatically by Jules for task [7656211422772103474](https://jules.google.com/task/7656211422772103474) started by @LokiMetaSmith*