### PR TITLE
feat: configure Rust io_uring NVMe throughput benchmarker

### DIFF
--- a/colibri_io_uring/src/bin/benchmarker.rs
+++ b/colibri_io_uring/src/bin/benchmarker.rs
@@ -11,8 +11,8 @@ struct Args {
     #[arg(short, long, default_value_t = 64)]
     num_experts: usize,
 
-    /// Size of each expert in bytes (default: 25MB to simulate INT3 7B MoE experts)
-    #[arg(short, long, default_value_t = 25 * 1024 * 1024)]
+    /// Size of each expert in bytes (default: 100MB to simulate 50MB-200MB chunks for baseline NVMe testing)
+    #[arg(short, long, default_value_t = 100 * 1024 * 1024)]
     expert_size: usize,
 
     /// Queue depth for io_uring (batch size for speculative pre-fetching)


### PR DESCRIPTION
- Adjusted the default `expert_size` in `colibri_io_uring/src/bin/benchmarker.rs` to 100MB to test baseline NVMe throughput for 50MB-200MB chunks as requested.
- Verified local execution, generating a synthetic file and measuring throughput successfully.