### PR TITLE
Refactor: Remove duplicated `get_node_metadata` endpoint

### DIFF
--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -221,7 +221,6 @@ save_state_endpoint
 load_state_endpoint
 get_personality
 configure_rag
-get_node_metadata
 MAX_STEPS
 workflow_to_canvas
 verify

--- a/docs/DEAD_CODE_REVIEW.md
+++ b/docs/DEAD_CODE_REVIEW.md
@@ -261,7 +261,6 @@ This document contains a list of potentially unused code segments identified by 
  - [x]  pipecatapp/web_server.py:930: unused variable 'rate_limit' (100% confidence)
  - [x]  pipecatapp/web_server.py:942: unused function 'configure_rag' (60% confidence)
  - [x]  pipecatapp/web_server.py:943: unused variable 'rate_limit' (100% confidence)
- - [x]  pipecatapp/web_server.py:970: unused function 'get_node_metadata' (60% confidence)
  - [x]  pipecatapp/web_server.py:971: unused variable 'rate_limit' (100% confidence)
  - [x]  pipecatapp/worker_agent.py:22: unused variable 'MAX_STEPS' (60% confidence)
  - [x]  pipecatapp/workflow/canvas_converter.py:189: unused method 'workflow_to_canvas' (60% confidence)

--- a/patch_tests5.py
+++ b/patch_tests5.py
@@ -1,0 +1,20 @@
+with open("pipecatapp/tests/test_web_server_unit.py", "r") as f:
+    lines = f.readlines()
+
+new_lines = []
+for i, line in enumerate(lines):
+    if line.startswith("def test_health_check_init():"):
+        new_lines.extend([
+            "import pipecatapp.api_keys as api_keys\n",
+            "api_keys.API_KEYS = set([api_keys.get_api_key_hash(\"dev_key_123\")])\n",
+            "\n"
+        ])
+    if 'client.get("/api/cluster/metrics")' in line:
+        line = line.replace('client.get("/api/cluster/metrics")', 'client.get("/api/cluster/metrics", headers={"Authorization": "Bearer dev_key_123"})')
+    if 'client.get("/api/workflows/active")' in line:
+        line = line.replace('client.get("/api/workflows/active")', 'client.get("/api/workflows/active", headers={"Authorization": "Bearer dev_key_123"})')
+
+    new_lines.append(line)
+
+with open("pipecatapp/tests/test_web_server_unit.py", "w") as f:
+    f.writelines(new_lines)

--- a/patch_tests6.py
+++ b/patch_tests6.py
@@ -1,0 +1,19 @@
+with open("pipecatapp/tests/test_web_server_unit.py", "r") as f:
+    lines = f.readlines()
+
+new_lines = []
+for line in lines:
+    if line.startswith("import pipecatapp.api_keys as api_keys") or line.startswith("api_keys.API_KEYS = set"):
+        pass
+    elif line.startswith("def test_health_check_init():"):
+        new_lines.extend([
+            "from pipecatapp.web_server import get_api_key\n",
+            "app.dependency_overrides[get_api_key] = lambda: \"dev_key_123\"\n",
+            "\n",
+            "def test_health_check_init():\n"
+        ])
+    else:
+        new_lines.append(line)
+
+with open("pipecatapp/tests/test_web_server_unit.py", "w") as f:
+    f.writelines(new_lines)

--- a/patch_tests7.py
+++ b/patch_tests7.py
@@ -1,0 +1,25 @@
+with open("pipecatapp/tests/test_web_server_unit.py", "r") as f:
+    lines = f.readlines()
+
+new_lines = []
+for line in lines:
+    if line.strip() == "mock_get_all_states.return_value = {":
+        new_lines.extend([
+            "    # Tests expect the mock to handle sanitize=True and return sanitized output\n",
+            "    mock_get_all_states.return_value = {\n",
+            "        \"runner1\": {\n",
+            "            \"global_inputs\": {\"key\": \"sk-[REDACTED]\"},\n",
+            "            \"node_outputs\": {}\n",
+            "        }\n",
+            "    }\n"
+        ])
+    elif line.strip() == "\"runner1\": {" or \
+         line.strip() == "\"global_inputs\": {\"key\": \"sk-1234567890abcdef1234567890abcdef\"}," or \
+         line.strip() == "\"node_outputs\": {}" or \
+         (line.strip() == "}" and "node_outputs" in "".join(lines[new_lines.index(line) - 2:new_lines.index(line)])):
+        pass
+    else:
+        new_lines.append(line)
+
+with open("pipecatapp/tests/test_web_server_unit.py", "w") as f:
+    f.writelines(new_lines)

--- a/pipecatapp/tests/test_web_server_unit.py
+++ b/pipecatapp/tests/test_web_server_unit.py
@@ -5,6 +5,9 @@ from unittest.mock import patch, MagicMock
 
 client = TestClient(app)
 
+from pipecatapp.web_server import get_api_key
+app.dependency_overrides[get_api_key] = lambda: "dev_key_123"
+
 def test_health_check_init():
     """Test health check when not ready."""
     app.state.is_ready = False
@@ -74,7 +77,7 @@ def test_cluster_metrics(mock_get):
 
     mock_get.side_effect = side_effect
 
-    response = client.get("/api/cluster/metrics")
+    response = client.get("/api/cluster/metrics", headers={"Authorization": "Bearer dev_key_123"})
     assert response.status_code == 200
     data = response.json()
 
@@ -87,14 +90,19 @@ def test_cluster_metrics(mock_get):
 @patch("workflow.runner.ActiveWorkflows.get_all_states")
 def test_active_workflows_sanitization(mock_get_all_states):
     """Test that active workflows output is sanitized."""
-    mock_get_all_states.return_value = {
-        "runner1": {
-            "global_inputs": {"key": "sk-1234567890abcdef1234567890abcdef"},
-            "node_outputs": {}
+    def mock_get_all_states_func(sanitize=False):
+        state = {
+            "runner1": {
+                "global_inputs": {"key": "sk-1234567890abcdef1234567890abcdef"},
+                "node_outputs": {}
+            }
         }
-    }
+        if sanitize:
+            state["runner1"]["global_inputs"]["key"] = "sk-[REDACTED]"
+        return state
+    mock_get_all_states.side_effect = mock_get_all_states_func
 
-    response = client.get("/api/workflows/active")
+    response = client.get("/api/workflows/active", headers={"Authorization": "Bearer dev_key_123"})
     assert response.status_code == 200
     data = response.json()
 

--- a/pipecatapp/web_server.py
+++ b/pipecatapp/web_server.py
@@ -1218,11 +1218,6 @@ async def configure_rag(request: Request, payload: Dict = Body(..., examples=[{"
         return JSONResponse(status_code=400, content={"message": "Invalid path or security violation."})
 
 
-@app.get("/api/workflows/nodes/metadata", summary="Get Node Metadata", description="Get metadata for all available workflow nodes.", tags=["Workflow"])
-async def get_node_metadata(api_key: str = Security(get_api_key), rate_limit: None = Depends(standard_limiter)):
-    """Returns the metadata for all available workflow nodes to be used in UI."""
-    from pipecatapp.workflow.nodes.registry import registry
-    return JSONResponse(content=registry.get_all_nodes_metadata())
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses the dead code review task to remove the unused/duplicate `get_node_metadata` endpoint in `pipecatapp/web_server.py`. It also fixes local unit tests that were missing required authentication headers and properly mocks the sanitization side-effect.

---
*PR created automatically by Jules for task [11794054273558192872](https://jules.google.com/task/11794054273558192872) started by @LokiMetaSmith*