### PR TITLE
Fix Consul cleanup timeout race condition

### DIFF
--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -9,6 +9,23 @@
   tags:
     - consul_configure
 
+- name: Remove Consul systemd service file if cleanup requested
+  become: true
+  ansible.builtin.file:
+    path: /etc/systemd/system/consul.service
+    state: absent
+  when: cleanup_services | default(false) | bool
+  tags:
+    - consul_configure
+
+- name: Reload systemd to forget Consul if cleanup requested
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: yes
+  when: cleanup_services | default(false) | bool
+  tags:
+    - consul_configure
+
 - name: Force kill stuck Consul processes if cleanup requested
   become: true
   ansible.builtin.command: pkill -9 consul


### PR DESCRIPTION
Fixed an issue in `ansible/roles/consul/tasks/main.yaml` where the `wait_for` task timed out on port 8500 because systemd was continuously restarting `consul` due to `Restart=always`.

---
*PR created automatically by Jules for task [15514172148421956945](https://jules.google.com/task/15514172148421956945) started by @LokiMetaSmith*