### PR TITLE
Fix Consul service startup failure via explicit daemon reload

### DIFF
--- a/ansible/roles/consul/tasks/main.yaml
+++ b/ansible/roles/consul/tasks/main.yaml
@@ -430,6 +430,7 @@
     name: consul
     state: started
     enabled: yes
+    daemon_reload: yes
   when: not ansible_check_mode
   tags:
     - consul_configure


### PR DESCRIPTION
Fixes the Ansible task failure where starting the Consul service fails with an EBUSY "Device or resource busy" error because systemd has not been reloaded since the Consul unit file was copied. Adds `daemon_reload: yes` directly to the `systemd` task that starts and enables the service.

---
*PR created automatically by Jules for task [499467629881611270](https://jules.google.com/task/499467629881611270) started by @LokiMetaSmith*