### PR TITLE
Harden Headscale Zero Trust architecture with ephemeral single-use keys

### DIFF
--- a/ansible/roles/headscale/tasks/main.yaml
+++ b/ansible/roles/headscale/tasks/main.yaml
@@ -80,13 +80,6 @@
     - create_user_result.rc != 0
     - "'already exists' not in create_user_result.stderr"
 
-- name: Create pre-auth key
-  command: /usr/local/bin/headscale --user {{ headscale_namespace }} preauthkeys create --reusable --expiration 24h
-  register: headscale_auth_key_output
-  changed_when: true
-
-- name: Set headscale auth key fact
+- name: Set headscale server url fact
   set_fact:
-    headscale_auth_key: "{{ headscale_auth_key_output.stdout_lines[-1] }}"
     headscale_server_url: "http://{{ ansible_facts['default_ipv4'].address }}:{{ headscale_port }}"
-  when: headscale_auth_key_output.stdout_lines is defined and headscale_auth_key_output.stdout_lines | length > 0

--- a/ansible/roles/tailscale/tasks/main.yaml
+++ b/ansible/roles/tailscale/tasks/main.yaml
@@ -50,9 +50,24 @@
   set_fact:
     resolved_login_server: "{{ imprinted_headscale_url.stdout if imprinted_headscale_url_file.stat.exists else hostvars[groups['controller_nodes'][0]]['headscale_server_url'] }}"
 
+- name: Generate single-use Headscale auth key for this node
+  ansible.builtin.command: /usr/local/bin/headscale --user {{ headscale_namespace | default('default') }} preauthkeys create --expiration 10m
+  delegate_to: "{{ groups['controller_nodes'][0] }}"
+  register: dynamic_headscale_auth_key_output
+  changed_when: true
+  when: >
+    tailscale_status.rc != 0 and
+    not imprinted_headscale_auth_key_file.stat.exists
+
 - name: Set dynamic Tailscale authkey
   set_fact:
-    resolved_authkey: "{{ imprinted_headscale_auth_key.stdout if imprinted_headscale_auth_key_file.stat.exists else hostvars[groups['controller_nodes'][0]]['headscale_auth_key'] }}"
+    resolved_authkey: >-
+      {%- if imprinted_headscale_auth_key_file.stat.exists -%}
+      {{ imprinted_headscale_auth_key.stdout }}
+      {%- else -%}
+      {{ dynamic_headscale_auth_key_output.stdout_lines[-1] }}
+      {%- endif -%}
+  when: tailscale_status.rc != 0
 
 - name: Connect to Headscale
   command: >

--- a/docs/manual/FILE_MAP.json
+++ b/docs/manual/FILE_MAP.json
@@ -17087,7 +17087,7 @@
       ]
     },
     "scripts/generate_tailscale_key.sh": {
-      "description": "Generate a reusable Headscale pre-auth key valid for 24 hours",
+      "description": "Generate a single-use Headscale pre-auth key valid for 24 hours",
       "classes": [],
       "functions": [],
       "status": "Entry Point",

--- a/docs/manual/FILE_MAP.md
+++ b/docs/manual/FILE_MAP.md
@@ -1168,7 +1168,7 @@ This document maps every file in the repository, their description, and utilizat
 | `scripts/generate_file_map.py` | 🟢 Referenced | usr/bin/env python3 | **Functions:** get_rel_path, is_ignored, extract_python_info, extract_shell_info, extract_generic_desc... |
 | `scripts/generate_issue_script.py` | 🟢 Referenced | File: generate_issue_script.py | **Functions:** parse_todo_file, create_issue_script |
 | `scripts/generate_signatures.py` | 🔵 Entry Point | File: generate_signatures.py | **Functions:** to_hex, create_ldb_sig |
-| `scripts/generate_tailscale_key.sh` | 🔵 Entry Point | Generate a reusable Headscale pre-auth key valid for 24 hours |  |
+| `scripts/generate_tailscale_key.sh` | 🔵 Entry Point | Generate a single-use Headscale pre-auth key valid for 24 hours |  |
 | `scripts/git-cleanup.sh` | 🔵 Entry Point | Default to 'main', but allow the user to specify a target branch (e.g., ./git-cleanup.sh master) |  |
 | `scripts/heal_cluster.sh` | 🟢 Referenced | Wrapper script to run the cluster healing playbook. This ensures core infrastructure (LlamaRPC, Pip |  |
 | `scripts/healer.py` | 🟢 Referenced | File: healer.py | **Classes:** NomadWatcher, HealerAgent<br>**Functions:** run_local_mode, main, __init__, get_failed_allocs, get_logs... |

--- a/docs/manual/HEADSCALE_ANDROID_SETUP.md
+++ b/docs/manual/HEADSCALE_ANDROID_SETUP.md
@@ -45,16 +45,12 @@ You can authenticate the Android client using either web authentication or a pre
 
 If you are an administrator, you need to provide users with a pre-authenticated key to use Option B.
 
-### During Ansible Provisioning
-
-The Ansible playbook automatically generates an initial 24-hour reusable pre-auth key for the default namespace during the cluster bootstrapping process. You can find this key by reviewing the output logs of the Ansible provisioning run, specifically during the `headscale` role execution under the task `Create pre-auth key` or `Set headscale auth key fact`.
-
 ### Generating Manually via CLI
 
-If the initial key has expired or you need to generate a new one, log in to the node running Headscale and execute the following command:
+You can generate a single-use pre-auth key by logging in to the node running Headscale (the controller) and executing the following command:
 
 ```bash
-headscale --user default preauthkeys create --reusable --expiration 24h
+headscale --user default preauthkeys create --expiration 24h
 ```
 
 *(Note: Replace `default` with your specific namespace if you have customized the `headscale_namespace` variable in the Ansible configuration).*

--- a/docs/manual/SECURITY_KEY_BOOTSTRAPPING.md
+++ b/docs/manual/SECURITY_KEY_BOOTSTRAPPING.md
@@ -101,13 +101,22 @@ When deploying new nodes, you can bypass the manual OIDC enrollment by securely 
 
 Run `scripts/imprint_usb_keychain.sh` to:
 1. Trigger a FIDO physical touch challenge via SSH to the controller.
-2. Generate a long-lived, reusable Headscale pre-auth key.
+2. Generate a long-lived, reusable Headscale pre-auth key with the `usb-bootstrap` tag.
 3. Collect your FIDO SSH public key and the controller's IP address.
 4. Stage these credentials and optionally run `os-image/build_iso.sh --flash --inject` to write them into a secure `CONFIGS` partition on the USB drive.
 
 During the initial boot of the live installer, the `00-usb-imprint.sh` module mounts this partition, injects the credentials into the local configuration, and automatically joins the cluster mesh network.
 
-### 5.2. Migrating FIDO Keys
+### 5.2. USB Bootstrap Key Revocation
+
+Because the USB key is a physical fallback, it represents a risk if lost or stolen. You can instantly revoke the `tag:usb-bootstrap` key using the provided revocation script:
+
+Run `scripts/revoke_usb_key.sh` to:
+1. Connect to the controller node.
+2. Locate the specific pre-auth key with the `tag:usb-bootstrap` tag.
+3. Automatically expire it to instantly revoke access to any future nodes trying to use the physical backup.
+
+### 5.3. Migrating FIDO Keys
 
 If you need to rotate or upgrade your hardware security key, you must update the cluster's declarative state and ensure you do not lose SSH access during the transition.
 

--- a/scripts/alert_usb_bootstrap_usage.sh
+++ b/scripts/alert_usb_bootstrap_usage.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script can be set up as a cron job on the controller to monitor and alert
+# if nodes join the tailnet using the physical USB bootstrap key.
+
+WEBHOOK_URL="${SLACK_WEBHOOK_URL:-}"
+if [ -z "$WEBHOOK_URL" ]; then
+    echo "Warning: SLACK_WEBHOOK_URL is not set. Alerts will only be logged."
+fi
+
+# Get all nodes that authenticated using the usb-bootstrap tag
+BOOTSTRAP_NODES=$(sudo headscale nodes list -o json | jq -r '.[] | select(.preAuthKey != null and .preAuthKey.tags != null and (.preAuthKey.tags[] == "tag:usb-bootstrap")) | .name')
+
+if [ -n "$BOOTSTRAP_NODES" ]; then
+    MESSAGE="🚨 *SECURITY ALERT*: The physical USB bootstrap key was used to enroll the following node(s):\n$BOOTSTRAP_NODES\n\nIf this was not an intentional bare-metal provisioning event, revoke the key immediately using \`scripts/revoke_usb_key.sh\`."
+
+    echo -e "$MESSAGE"
+
+    if [ -n "$WEBHOOK_URL" ]; then
+        curl -s -X POST -H 'Content-type: application/json' --data "{\"text\": \"$MESSAGE\"}" "$WEBHOOK_URL" > /dev/null
+    fi
+fi

--- a/scripts/enroll-admin.sh
+++ b/scripts/enroll-admin.sh
@@ -10,7 +10,7 @@ ssh -o "ControlMaster=no" controller "headscale nodes list" > /dev/null
 
 if [ $? -eq 0 ]; then
     echo "Step 2: Generating Pre-Auth Key..."
-    AUTH_KEY=$(ssh controller "sudo headscale --user default preauthkeys create --reusable --expiration 1h 2>/dev/null | tail -n 1")
+    AUTH_KEY=$(ssh controller "sudo headscale --user default preauthkeys create --expiration 1h 2>/dev/null | tail -n 1")
 
     echo "Step 3: Joining Tailnet via $DOMAIN..."
     sudo tailscale up --login-server=https://$DOMAIN --authkey=$AUTH_KEY

--- a/scripts/generate_tailscale_key.sh
+++ b/scripts/generate_tailscale_key.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# Generate a reusable Headscale pre-auth key valid for 24 hours
+# Generate a single-use Headscale pre-auth key valid for 24 hours
 
 if ! command -v headscale &> /dev/null; then
   echo "Headscale is not installed on this system."
   return 1 2>/dev/null || true
 fi
 
-echo "Generating a new reusable pre-auth key for user 'default'..."
-AUTH_KEY=$(headscale --user default preauthkeys create --reusable --expiration 24h 2>/dev/null | tail -n 1)
+echo "Generating a new single-use pre-auth key for user 'default'..."
+AUTH_KEY=$(headscale --user default preauthkeys create --expiration 24h 2>/dev/null | tail -n 1)
 
 if [ -z "$AUTH_KEY" ]; then
     echo "Failed to generate key. Ensure you are running this as root or the headscale service is running."

--- a/scripts/imprint_usb_keychain.sh
+++ b/scripts/imprint_usb_keychain.sh
@@ -25,8 +25,8 @@ if [ -n "$CONTROLLER_SSH" ]; then
     fi
 
     # 3. Generate Pre-Auth Key
-    echo "Generating reusable Headscale pre-auth key (valid for 30 days)..."
-    AUTH_KEY=$(ssh -o "ControlMaster=no" "$CONTROLLER_SSH" "sudo headscale --user default preauthkeys create --reusable --expiration 720h 2>/dev/null | tail -n 1")
+    echo "Generating reusable Headscale pre-auth key (valid for 30 days) with tag 'usb-bootstrap'..."
+    AUTH_KEY=$(ssh -o "ControlMaster=no" "$CONTROLLER_SSH" "sudo headscale --user default preauthkeys create --reusable --tags tag:usb-bootstrap --expiration 720h 2>/dev/null | tail -n 1")
 
     if [ -n "$AUTH_KEY" ]; then
         # 4. Get FIDO SSH Public Key

--- a/scripts/revoke_usb_key.sh
+++ b/scripts/revoke_usb_key.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+echo "=== USB Bootstrap Key Revocation ==="
+echo "This script will revoke the physical USB bootstrap key (tag:usb-bootstrap)."
+echo ""
+read -p "Enter Controller SSH alias/IP (e.g. 'controller'): " CONTROLLER_SSH
+if [ -z "$CONTROLLER_SSH" ]; then
+    echo "Controller SSH is required."
+    return 1 2>/dev/null || true
+fi
+echo "Authenticating to controller..."
+KEY_ID=$(ssh -o "ControlMaster=no" "$CONTROLLER_SSH" "sudo headscale --user default preauthkeys list -o json | jq -r '.[] | select(.tags != null) | select(.tags[] == \"tag:usb-bootstrap\") | .id'")
+if [ -z "$KEY_ID" ] || [ "$KEY_ID" == "null" ]; then
+    echo "No active key found with tag 'tag:usb-bootstrap'."
+    return 0 2>/dev/null || true
+fi
+echo "Found USB bootstrap key with ID: $KEY_ID"
+read -p "Are you sure you want to expire this key? (y/n): " CONFIRM
+if [[ "$CONFIRM" == "y" || "$CONFIRM" == "Y" ]]; then
+    ssh -o "ControlMaster=no" "$CONTROLLER_SSH" "sudo headscale --user default preauthkeys expire $KEY_ID"
+    echo "Key $KEY_ID has been successfully revoked."
+else
+    echo "Revocation cancelled."
+fi


### PR DESCRIPTION
This submission replaces long-lived, reusable Headscale authentication keys with ephemeral, single-use keys to mitigate the risk of lateral movement attacks (as seen in the Hugging Face breach).

Key changes:
- `scripts/enroll-admin.sh` and `scripts/generate_tailscale_key.sh` now generate single-use keys.
- `ansible/roles/headscale` no longer generates a static cluster-wide key.
- `ansible/roles/tailscale` now dynamically generates a 10-minute single-use key per node just before joining the tailnet.
- The physical fallback key in `scripts/imprint_usb_keychain.sh` retains the `--reusable` flag but is now strictly tagged with `tag:usb-bootstrap`.
- Added `scripts/alert_usb_bootstrap_usage.sh` to monitor and alert on the usage of the physical bootstrap key.
- Added `scripts/revoke_usb_key.sh` to provide a one-click kill switch for the physical bootstrap key.
- Updated relevant documentation to match the new security architecture.

---
*PR created automatically by Jules for task [7319374695536934575](https://jules.google.com/task/7319374695536934575) started by @LokiMetaSmith*