### PR TITLE
Fix Nomad Job Placement Constraints and Host Volumes

### DIFF
--- a/ansible/roles/nomad/templates/nomad.hcl.server.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.server.j2
@@ -24,6 +24,7 @@ server {
 }
 
 client {
+  node_class = "{{ nomad_node_class | default('controller') }}"
   enabled = true
   servers = ["{{ cluster_ip }}"]
 
@@ -96,7 +97,33 @@ client {
     path      = "{{ nomad_volumes_dir }}/authentik/certs"
     read_only = false
   }
+
+  host_volume "influxdb-data" {
+    path      = "{{ nomad_volumes_dir }}/influxdb-data"
+    read_only = false
+  }
+
+  host_volume "openclaw-config" {
+    path      = "{{ nomad_volumes_dir }}/openclaw-config"
+    read_only = false
+  }
+
+  host_volume "openclaw-data" {
+    path      = "{{ nomad_volumes_dir }}/openclaw-data"
+    read_only = false
+  }
+
+  host_volume "cluster-infra" {
+    path      = "{{ cluster_infra_dir }}"
+    read_only = true
+  }
+
+  host_volume "mcp-config" {
+    path      = "{{ mcp_dir }}"
+    read_only = false
+  }
 }
+
 
 plugin "docker" {
   config {


### PR DESCRIPTION
This submission implements an infrastructure-level fix for Nomad job placement failures. Instead of modifying individual `.nomad.j2` templates, it injects the missing `node_class` property and defines required `host_volume` bindings in the core Nomad client configuration (`ansible/roles/nomad/templates/nomad.hcl.server.j2`). This ensures that jobs demanding specific host volumes (like `tool-server` and `influxdb`) and constraints (like `controller` or `edge`) can successfully schedule.

---
*PR created automatically by Jules for task [16744980954342837925](https://jules.google.com/task/16744980954342837925) started by @LokiMetaSmith*