### PR TITLE
Refactor LLM config loading in reflection scripts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -413,6 +413,7 @@ This section tracks actionable ideas derived from the `docs/analysis/FLOWISE_ANA
 
 - [x] **Review and Implement MCP Migration Plan:** Execute the phases outlined in `docs/manual/MCP_MIGRATION_PLAN.md` to transition custom tools to the Model Context Protocol. (Note: Completed Phase 1 and a portion of Phase 2)
 
+- [x] **Remove `load_llm_config` file fallback:** Update `reflection/reflect.py` to remove the hardcoded file reading fallback, update `scripts/supervisor.py` to pass the config from memory, and update `reflection/adaptation_manager.py` and its tests to accept `--llm-config`.
 - [x] **Fix Missing Test Dependencies:** Update requirements-dev.txt to include `pytest`, `pytest-asyncio`, and `httpx` to fix the test suite.
 - [x] **Fix FastAPI Mocking:** Ensure FastAPI and `fastapi.responses` are properly mocked in test collection so `app.py` doesn't crash test discovery.
 - [x] **Implement Mobile UI Fixes for LiteGraph:** As noted in `litegraph.js` TODOs, improve the `dialog_close_on_mouse_leave` logic to work nicely on touch devices.

--- a/reflection/adaptation_manager.py
+++ b/reflection/adaptation_manager.py
@@ -6,7 +6,7 @@ import sys
 import yaml
 from datetime import datetime
 
-def generate_test_case(diagnostic_data):
+def generate_test_case(diagnostic_data, llm_config=None):
     """Creates a structured YAML test case from diagnostic information.
 
     This function transforms the raw JSON output from a diagnostic run into a
@@ -16,12 +16,20 @@ def generate_test_case(diagnostic_data):
 
     Args:
         diagnostic_data (dict): The parsed JSON data from the diagnostic file.
+        llm_config (str, optional): JSON string containing LLM configuration to be passed to reflect.py.
 
     Returns:
         str: A string containing the formatted YAML test case.
     """
     job_id = diagnostic_data.get("job_id", "unknown_job")
     error_logs = diagnostic_data.get("logs", {}).get("stderr", "No stderr logs.")
+
+    parameters = {
+        # The parameter is the diagnostic data itself, representing the input
+        "diagnostic_data": diagnostic_data
+    }
+    if llm_config:
+        parameters["llm_config"] = llm_config
 
     test_case = {
         "test_name": f"test_failure_reproduction_{job_id}",
@@ -34,10 +42,7 @@ def generate_test_case(diagnostic_data):
             {
                 "type": "run_script",
                 "name": "reflection/reflect.py",
-                "parameters": {
-                    # The parameter is the diagnostic data itself, representing the input
-                    "diagnostic_data": diagnostic_data
-                },
+                "parameters": parameters,
                 "expected_outcome": {
                     "action_not_equals": "error"
                 },
@@ -63,6 +68,12 @@ def main():
         type=str,
         help="Path to the JSON diagnostic file for the failed job."
     )
+    parser.add_argument(
+        "--llm-config",
+        type=str,
+        default=None,
+        help="JSON string containing LLM configuration."
+    )
     args = parser.parse_args()
 
     # 1. Read and parse the diagnostic file
@@ -76,7 +87,7 @@ def main():
     # 2. Generate the YAML test case content
     job_id = diagnostic_data.get("job_id", "unknown")
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    test_case_yaml = generate_test_case(diagnostic_data)
+    test_case_yaml = generate_test_case(diagnostic_data, llm_config=args.llm_config)
 
     # 3. Write the test case to a new file
     # Ensure the target directory exists

--- a/reflection/reflect.py
+++ b/reflection/reflect.py
@@ -13,8 +13,6 @@ def load_llm_config(config_dict=None):
     """Loads and caches the LLM configuration.
 
     If a configuration dictionary is provided, it is used directly.
-    Otherwise, it attempts to read `group_vars/external_experts.yaml` and `group_vars/all.yaml`
-    to find the configuration for the external expert (OpenAI GPT-4).
     It caches the result in a global variable.
 
     Args:
@@ -32,29 +30,7 @@ def load_llm_config(config_dict=None):
         LLM_CONFIG = config_dict
         return LLM_CONFIG
 
-    # Fallback to file reading if no config passed
-    # TODO: This fallback logic can be removed once all callers (e.g., adaptation_manager.py)
-    # are updated to pass the configuration via command line arguments.
-    base_dir = os.path.join(os.path.dirname(__file__), '..')
-    try:
-        # Load external experts config
-        experts_path = os.path.join(base_dir, 'group_vars/external_experts.yaml')
-        with open(experts_path, 'r') as f:
-            ext_experts = yaml.safe_load(f)
-            config = ext_experts['external_experts_config']['openai_gpt4']
-
-        # Load API key from all.yaml
-        all_vars_path = os.path.join(base_dir, 'group_vars/all.yaml')
-        with open(all_vars_path, 'r') as f:
-            all_vars = yaml.safe_load(f)
-            config['api_key_plaintext'] = all_vars.get('openai_api_key')
-
-        LLM_CONFIG = config
-        return LLM_CONFIG
-
-    except (IOError, yaml.YAMLError, KeyError) as e:
-        print(f"Error loading LLM config from files: {e}", file=sys.stderr)
-        return None
+    return None
 
 def call_openai_llm(messages, reasoning_config=None):
     """Sends a request to the OpenAI Chat Completions API.

--- a/scripts/supervisor.py
+++ b/scripts/supervisor.py
@@ -190,7 +190,10 @@ def main():
             if action == "error":
                 # 5a. If reflection fails, trigger self-adaptation AND notify the agent
                 print(f"--- Reflection could not find a direct solution. Triggering self-adaptation for job {job_id}. ---")
-                run_script("reflection/adaptation_manager.py", [diagnostics_file])
+                adapt_script_args = [diagnostics_file]
+                if llm_config_json:
+                    adapt_script_args.extend(["--llm-config", llm_config_json])
+                run_script("reflection/adaptation_manager.py", adapt_script_args)
 
                 # Notify TwinService
                 try:

--- a/tests/unit/test_adaptation_manager.py
+++ b/tests/unit/test_adaptation_manager.py
@@ -23,7 +23,7 @@ class TestAdaptationManager(unittest.TestCase):
         from adaptation_manager import main
 
         # Mock the command-line arguments
-        with patch.object(sys, 'argv', ['adaptation_manager.py', 'dummy_diagnostics.json']):
+        with patch.object(sys, 'argv', ['adaptation_manager.py', 'dummy_diagnostics.json', '--llm-config', '{"model": "test-model"}']):
             main()
 
         # Verify that the test case file was written
@@ -36,6 +36,10 @@ class TestAdaptationManager(unittest.TestCase):
             if mode == 'w' and 'failure_test_job_' in os.path.basename(filepath):
                 self.assertIn('prompt_engineering/generated_evaluators', filepath)
                 written_filepath = filepath
+                # Verify that llm_config is in the written YAML
+                written_content = mock_file().write.call_args[0][0]
+                self.assertIn('llm_config', written_content)
+                self.assertIn('{"model": "test-model"}', written_content)
                 break
 
         self.assertIsNotNone(written_filepath, "Did not find the call to write the test case file.")

--- a/tests/unit/test_reflection.py
+++ b/tests/unit/test_reflection.py
@@ -75,6 +75,14 @@ class TestReflection(unittest.TestCase):
         self.assertEqual(solution["parameters"]["job_id"], "job1")
         self.assertEqual(solution["parameters"]["memory_mb"], 512)
 
+    @patch('reflection.reflect.load_llm_config', return_value=None)
+    def test_call_openai_llm_missing_config(self, mock_load_config):
+        messages = [{"role": "user", "content": "hello"}]
+        result_json = reflect.call_openai_llm(messages)
+        result = json.loads(result_json)
+        self.assertEqual(result["action"], "error")
+        self.assertEqual(result["analysis"], "LLM configuration is missing or invalid.")
+
     @patch('reflection.reflect.load_llm_config', return_value=MOCK_LLM_CONFIG)
     @patch('requests.post')
     def test_analyze_failure_simple_restart(self, mock_requests_post, mock_load_config):


### PR DESCRIPTION
This PR addresses the TODO item to remove the hardcoded file-reading fallback for LLM configurations in `reflection/reflect.py`. The configuration is now explicitly passed via the `--llm-config` command-line argument from the supervisor to `adaptation_manager.py`, which then correctly embeds it in the generated YAML test case. Unit tests have been updated and verified to ensure that missing configurations are handled gracefully without raising cryptic exceptions.

---
*PR created automatically by Jules for task [2234676978829632952](https://jules.google.com/task/2234676978829632952) started by @LokiMetaSmith*