### PR TITLE
Fix ARCHIVIST_PORT environment variable setup in archivist service

### DIFF
--- a/pipecatapp/archivist_service.py
+++ b/pipecatapp/archivist_service.py
@@ -34,9 +34,7 @@ logger = logging.getLogger("Archivist")
 DB_PATH = os.getenv("DB_PATH", os.path.expanduser("~/.config/pipecat/pypicat_memory.db"))
 INDEX_DIR = os.getenv("INDEX_DIR", os.path.expanduser("~/.config/pipecat/archivist_data"))
 
-if not os.getenv("ARCHIVIST_PORT"):
-    raise ValueError("ARCHIVIST_PORT environment variable must be set")
-PORT = int(os.getenv("ARCHIVIST_PORT"))
+PORT = int(os.getenv("ARCHIVIST_PORT", 8008))
 
 CONSUL_HOST = os.getenv("CONSUL_HOST", os.getenv("CLUSTER_IP", "127.0.0.1"))
 CONSUL_PORT = int(os.getenv("CONSUL_PORT", 8500))

--- a/pipecatapp/start_archivist.sh
+++ b/pipecatapp/start_archivist.sh
@@ -23,8 +23,8 @@ fi
 echo "Starting Archivist Service from $TARGET_SCRIPT"
 # Use uvicorn CLI to start the service to avoid port binding issues and ensure clean signal handling
 if [ -z "$ARCHIVIST_PORT" ]; then
-    echo "Error: ARCHIVIST_PORT is not set."
-    exit 1
+    echo "WARNING: ARCHIVIST_PORT is not set. Defaulting to 8008."
+    ARCHIVIST_PORT=8008
 fi
 
 echo "DEBUG: HOST_IP=${HOST_IP:-0.0.0.0}"


### PR DESCRIPTION
Added default 8008 port fallback for ARCHIVIST_PORT in `start_archivist.sh` and `archivist_service.py` to allow the service to be run manually without failing on a missing env var.

---
*PR created automatically by Jules for task [12914926647148343133](https://jules.google.com/task/12914926647148343133) started by @LokiMetaSmith*