### PR TITLE
feat(ansible): federate nomad and consul over headscale mesh

### DIFF
--- a/ansible/roles/consul/templates/consul.hcl.j2
+++ b/ansible/roles/consul/templates/consul.hcl.j2
@@ -60,10 +60,18 @@ bootstrap_expect = 1
 {% else %}
 # For multi-node setups, we expect a quorum of controller nodes.
 bootstrap_expect = {{ groups['controller_nodes'] | length }}
-retry_join = ["{{ hostvars[groups['controller_nodes'][0]]['cluster_ip'] }}"]
+retry_join = [
+  {% for host in groups['controller_nodes'] %}
+  "{{ hostvars[host]['cluster_ip'] }}"{% if not loop.last %},{% endif %}
+  {% endfor %}
+]
 {% endif %}
 {% else %}
 # This is a client node, so it should try to join the controller.
 server = false
-retry_join = ["{{ hostvars[groups['controller_nodes'][0]]['cluster_ip'] }}"]
+retry_join = [
+  {% for host in groups['controller_nodes'] %}
+  "{{ hostvars[host]['cluster_ip'] }}"{% if not loop.last %},{% endif %}
+  {% endfor %}
+]
 {% endif %}

--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -52,7 +52,11 @@ telemetry {
 
 client {
   enabled = true
-  servers = ["{{ hostvars[groups['controller_nodes'][0]]['cluster_ip'] }}"]
+  servers = [
+    {% for host in groups['controller_nodes'] %}
+    "{{ hostvars[host]['cluster_ip'] }}"{% if not loop.last %},{% endif %}
+    {% endfor %}
+  ]
   
   env {
     PIP_INDEX_URL = "http://127.0.0.1:{{ pypi_proxy_port | default(3141) }}/simple/"

--- a/ansible/roles/nomad/templates/nomad.hcl.server.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.server.j2
@@ -17,16 +17,24 @@ advertise {
 
 server {
   enabled = true
-
+  bootstrap_expect = {{ groups['controller_nodes'] | length }}
   server_join {
-    retry_join = ["{{ cluster_ip }}"]
+    retry_join = [
+      {% for host in groups['controller_nodes'] %}
+      "{{ hostvars[host]['cluster_ip'] }}"{% if not loop.last %},{% endif %}
+      {% endfor %}
+    ]
   }
 }
 
 client {
   node_class = "{{ nomad_node_class | default('controller') }}"
   enabled = true
-  servers = ["{{ cluster_ip }}"]
+  servers = [
+    {% for host in groups['controller_nodes'] %}
+    "{{ hostvars[host]['cluster_ip'] }}"{% if not loop.last %},{% endif %}
+    {% endfor %}
+  ]
 
   meta {
     node_type = "controller"

--- a/ansible/roles/nomad/templates/server.hcl.j2
+++ b/ansible/roles/nomad/templates/server.hcl.j2
@@ -18,6 +18,14 @@ advertise {
 {% if is_controller is defined and is_controller %}
 server {
   enabled = true
+  bootstrap_expect = {{ groups['controller_nodes'] | length }}
+  server_join {
+    retry_join = [
+      {% for host in groups['controller_nodes'] %}
+      "{{ hostvars[host]['cluster_ip'] }}"{% if not loop.last %},{% endif %}
+      {% endfor %}
+    ]
+  }
 }
 {% endif %}
 
@@ -50,7 +58,11 @@ plugin "raw_exec" {
 
 client {
   enabled = true
-  servers = ["{{ cluster_ip }}"]
+  servers = [
+    {% for host in groups['controller_nodes'] %}
+    "{{ hostvars[host]['cluster_ip'] }}"{% if not loop.last %},{% endif %}
+    {% endfor %}
+  ]
 
   meta {
     node_type = "controller"


### PR DESCRIPTION
Update Nomad server, Nomad client, and Consul configurations to dynamically populate their `retry_join` arrays with all nodes in the `controller_nodes` group. Also updates `bootstrap_expect` to dynamically scale with the number of controllers based on the inventory size.

---
*PR created automatically by Jules for task [11829552569382955784](https://jules.google.com/task/11829552569382955784) started by @LokiMetaSmith*