### PR TITLE
Fix missing atproto_crypto module deployment

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -604,6 +604,15 @@
     - deploy_app
 
 
+- name: Copy atproto_crypto module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/atproto_crypto.py"
+    dest: "{{ pipecat_app_dir }}/atproto_crypto.py"
+  become: yes
+  tags:
+    - deploy_app
+
 - name: Copy __init__ module
   ansible.builtin.copy:
     mode: '0644'


### PR DESCRIPTION
Fixes an issue where `pipecatapp.atproto_crypto` was missing on deployed nodes, causing the app startup check to fail.

---
*PR created automatically by Jules for task [14690897586658193954](https://jules.google.com/task/14690897586658193954) started by @LokiMetaSmith*