### PR TITLE
Fix missing python files in ansible deploy

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -159,6 +159,15 @@
   tags:
     - deploy_app
 
+- name: Copy onecli_proxy module
+  ansible.builtin.copy:
+    mode: '0644'
+    src: "{{ inventory_dir }}/pipecatapp/onecli_proxy.py"
+    dest: "{{ pipecat_app_dir }}/onecli_proxy.py"
+  become: yes
+  tags:
+    - deploy_app
+
 - name: Copy gossip_discovery module
   ansible.builtin.copy:
     mode: '0644'


### PR DESCRIPTION
The `atproto_crypto.py` and `onecli_proxy.py` modules were recently added but missed being included in the Ansible deployment tasks for copying the source code to the destination node. This led to a `ModuleNotFoundError` during the pipecat-app startup pre-flight check.

This commit updates the `ansible/roles/pipecatapp/tasks/main.yaml` playbook to explicitly copy these files to `{{ pipecat_app_dir }}` alongside the other modules, resolving the deployment failure.