### PR TITLE
feat: implement tap_orchestrator for DESFire EV2 events and Ansible role

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -476,7 +476,7 @@ This section tracks the integration of Aleph Alpha's "Model Training as Code" (M
 
 ## Tap Orchestrator Integration
 
-- [ ] **Ansible Deployment Role:** Create an Ansible role (`ansible/roles/tap_orchestrator`) and a Nomad job template (`tap_orchestrator.nomad.j2`) so that the cluster's upbringing script automatically deploys this service to the controller node.
+- [x] **Ansible Deployment Role:** Create an Ansible role (`ansible/roles/tap_orchestrator`) and a Nomad job template (`tap_orchestrator.nomad.j2`) so that the cluster's upbringing script automatically deploys this service to the controller node.
 - [ ] **Automated Authentik Configuration:** Update the existing Authentik Ansible roles to automatically provision the M2M OAuth2 application, client ID, and service account required by the orchestrator during cluster bootstrap.
 - [ ] **Flesh out the Dry-Runs (Nomad/Vault):** Replace the dry-run HTTP stubs in `orchestrator.py` with actual API calls to the Vault PKI/SSH secrets engine (for short-lived certificates) and Nomad (for dispatching parameterized jobs with vector store mounts).
 - [ ] **End-to-End Cluster Tests:** Write an integration test playbook that stands up the orchestrator, publishes a mock MQTT event, and verifies that the correct Nomad allocations are triggered.

--- a/TODO.md
+++ b/TODO.md
@@ -473,3 +473,10 @@ This section tracks the integration of Aleph Alpha's "Model Training as Code" (M
 ## Security Hardening & Zero-Touch Provisioning
 
 - [x] **FIDO Security Key Onboarding & USB Keychain Imprinting:** Implement an automated onboarding flow using FIDO/FIDO2 hardware security keys. The goal is to imprint keys securely onto the USB bootstrap OS image during generation, allowing any new node provisioned from that flash drive to seamlessly and securely auto-enroll into the swarm mesh network without manual credential intervention.
+
+## Tap Orchestrator Integration
+
+- [ ] **Ansible Deployment Role:** Create an Ansible role (`ansible/roles/tap_orchestrator`) and a Nomad job template (`tap_orchestrator.nomad.j2`) so that the cluster's upbringing script automatically deploys this service to the controller node.
+- [ ] **Automated Authentik Configuration:** Update the existing Authentik Ansible roles to automatically provision the M2M OAuth2 application, client ID, and service account required by the orchestrator during cluster bootstrap.
+- [ ] **Flesh out the Dry-Runs (Nomad/Vault):** Replace the dry-run HTTP stubs in `orchestrator.py` with actual API calls to the Vault PKI/SSH secrets engine (for short-lived certificates) and Nomad (for dispatching parameterized jobs with vector store mounts).
+- [ ] **End-to-End Cluster Tests:** Write an integration test playbook that stands up the orchestrator, publishes a mock MQTT event, and verifies that the correct Nomad allocations are triggered.

--- a/ansible/roles/authentik/tasks/bootstrap_m2m.yml
+++ b/ansible/roles/authentik/tasks/bootstrap_m2m.yml
@@ -1,0 +1,112 @@
+---
+- name: Wait for Authentik to become available
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ authentik_http_port | default(9000) }}/-/health/ready/"
+    method: GET
+    status_code: 204
+  register: authentik_ready
+  until: authentik_ready.status == 204
+  retries: 30
+  delay: 10
+  ignore_errors: yes
+
+# Note: Authentik bootstrap involves using its internal python manage.py commands or terraform.
+# We will use the authentik command line inside the server container to create the app and token.
+
+- name: Generate random Authentik Client ID for Tap Orchestrator
+  ansible.builtin.command: openssl rand -hex 16
+  register: authentik_m2m_client_id
+  when: authentik_ready is success
+
+- name: Generate random Authentik Client Secret for Tap Orchestrator
+  ansible.builtin.command: openssl rand -hex 32
+  register: authentik_m2m_client_secret
+  when: authentik_ready is success
+
+- name: Create M2M bootstrap script
+  ansible.builtin.copy:
+    dest: "{{ nomad_volumes_dir }}/authentik/bootstrap_m2m.py"
+    mode: '0755'
+    content: |
+      import os
+      from django.contrib.auth import get_user_model
+      from authentik.core.models import User, Token, TokenIntents
+      from authentik.providers.oauth2.models import OAuth2Provider
+      from authentik.core.models import Application
+
+      # 1. Ensure a service account user exists
+      User = get_user_model()
+      sa_user, created = User.objects.get_or_create(
+          username="tap-orchestrator-sa",
+          defaults={
+              "name": "Tap Orchestrator Service Account",
+              "is_active": True,
+          }
+      )
+      # We would also give it admin privileges for the sake of querying all users' attributes
+      sa_user.is_superuser = True
+      sa_user.save()
+
+      # 2. Create the OAuth2 Provider for M2M (Client Credentials Grant)
+      provider, p_created = OAuth2Provider.objects.get_or_create(
+          name="Tap Orchestrator Provider",
+          defaults={
+              "client_id": os.environ.get("TAP_CLIENT_ID"),
+              "client_secret": os.environ.get("TAP_CLIENT_SECRET"),
+              "authorization_flow": None, # M2M doesn't use standard auth flows usually in this context
+              "client_type": "confidential",
+          }
+      )
+
+      # If the provider already existed, we still want to ensure credentials match our generated ones
+      if not p_created:
+          provider.client_id = os.environ.get("TAP_CLIENT_ID")
+          provider.client_secret = os.environ.get("TAP_CLIENT_SECRET")
+          provider.save()
+
+      # 3. Create the Application linking the provider
+      app, a_created = Application.objects.get_or_create(
+          name="Tap Orchestrator App",
+          defaults={
+              "slug": "tap-orchestrator",
+              "provider": provider,
+          }
+      )
+  when: authentik_ready is success
+
+- name: Execute Authentik bootstrap script in Nomad container
+  ansible.builtin.command:
+    cmd: nomad alloc exec -task authentik-server -job authentik python /media/bootstrap_m2m.py
+  environment:
+    NOMAD_ADDR: "http://127.0.0.1:4646"
+    TAP_CLIENT_ID: "{{ authentik_m2m_client_id.stdout }}"
+    TAP_CLIENT_SECRET: "{{ authentik_m2m_client_secret.stdout }}"
+  when: authentik_ready is success
+  register: bootstrap_exec
+  ignore_errors: yes
+
+- name: Publish Authentik Client ID to Consul for Tap Orchestrator
+  ansible.builtin.uri:
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/authentik/tap-client-id"
+    method: PUT
+    client_cert: "/etc/consul.d/cert.pem"
+    client_key: "/etc/consul.d/key.pem"
+    ca_path: "/etc/consul.d/ca.pem"
+    headers:
+      X-Consul-Token: "{{ consul_bootstrap_token }}"
+    body: "{{ authentik_m2m_client_id.stdout }}"
+    status_code: 200
+  when: authentik_ready is success and bootstrap_exec.rc == 0
+
+- name: Publish Authentik Client Secret to Consul for Tap Orchestrator
+  ansible.builtin.uri:
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/authentik/tap-client-secret"
+    method: PUT
+    client_cert: "/etc/consul.d/cert.pem"
+    client_key: "/etc/consul.d/key.pem"
+    ca_path: "/etc/consul.d/ca.pem"
+    headers:
+      X-Consul-Token: "{{ consul_bootstrap_token }}"
+    body: "{{ authentik_m2m_client_secret.stdout }}"
+    status_code: 200
+  when: authentik_ready is success and bootstrap_exec.rc == 0

--- a/ansible/roles/authentik/tasks/main.yml
+++ b/ansible/roles/authentik/tasks/main.yml
@@ -174,3 +174,7 @@
     NOMAD_CLIENT_KEY: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.key.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
   register: authentik_deploy
   changed_when: "'modified' in authentik_deploy.stdout or 'created' in authentik_deploy.stdout"
+
+- include_tasks: bootstrap_m2m.yml
+  tags:
+    - authentik_bootstrap

--- a/ansible/roles/tap_orchestrator/tasks/main.yaml
+++ b/ansible/roles/tap_orchestrator/tasks/main.yaml
@@ -1,0 +1,38 @@
+---
+- name: Create Tap Orchestrator directory
+  ansible.builtin.file:
+    path: "/opt/tap_orchestrator"
+    state: directory
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: '0755'
+
+- name: Copy Tap Orchestrator python source files
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/services/tap_orchestrator/"
+    dest: "/opt/tap_orchestrator/"
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: '0644'
+
+- name: Copy config.yaml template
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/config.yaml"
+    dest: "/opt/tap_orchestrator/config.yaml"
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: '0644'
+
+- name: Template Tap Orchestrator Nomad job
+  ansible.builtin.template:
+    src: "tap_orchestrator.nomad.j2"
+    dest: "{{ nomad_jobs_dir }}/tap_orchestrator.nomad"
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: '0644'
+
+- name: Start Tap Orchestrator Nomad job
+  ansible.builtin.command:
+    cmd: nomad job run {{ nomad_jobs_dir }}/tap_orchestrator.nomad
+  environment:
+    NOMAD_ADDR: "http://127.0.0.1:4646"

--- a/ansible/roles/tap_orchestrator/tasks/main.yaml
+++ b/ansible/roles/tap_orchestrator/tasks/main.yaml
@@ -1,4 +1,35 @@
 ---
+- name: Fetch Authentik Tap Client ID from Consul
+  ansible.builtin.uri:
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/authentik/tap-client-id"
+    client_cert: "/etc/consul.d/cert.pem"
+    client_key: "/etc/consul.d/key.pem"
+    ca_path: "/etc/consul.d/ca.pem"
+    method: GET
+    headers:
+      X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
+    status_code: [200, 404]
+  register: authentik_tap_client_id_res
+  ignore_errors: yes
+
+- name: Fetch Authentik Tap Client Secret from Consul
+  ansible.builtin.uri:
+    url: "https://{{ cluster_ip | default('127.0.0.1') }}:{{ consul_https_port | default(8501) }}/v1/kv/authentik/tap-client-secret"
+    client_cert: "/etc/consul.d/cert.pem"
+    client_key: "/etc/consul.d/key.pem"
+    ca_path: "/etc/consul.d/ca.pem"
+    method: GET
+    headers:
+      X-Consul-Token: "{{ consul_bootstrap_token | default(omit) }}"
+    status_code: [200, 404]
+  register: authentik_tap_client_secret_res
+  ignore_errors: yes
+
+- name: Set Authentik credentials facts
+  ansible.builtin.set_fact:
+    tap_client_id: "{{ authentik_tap_client_id_res.json[0].Value | b64decode if (authentik_tap_client_id_res.status == 200) else '' }}"
+    tap_client_secret: "{{ authentik_tap_client_secret_res.json[0].Value | b64decode if (authentik_tap_client_secret_res.status == 200) else '' }}"
+
 - name: Create Tap Orchestrator directory
   ansible.builtin.file:
     path: "/opt/tap_orchestrator"

--- a/ansible/roles/tap_orchestrator/templates/tap_orchestrator.nomad.j2
+++ b/ansible/roles/tap_orchestrator/templates/tap_orchestrator.nomad.j2
@@ -23,6 +23,8 @@ job "tap-orchestrator" {
         TAP_ORCHESTRATOR_PORT   = "{{ tap_orchestrator_port }}"
         TAP_ORCHESTRATOR_SECRET = "change_me_secret"
         AUTHENTIK_API_URL       = "http://127.0.0.1:{{ authentik_http_port }}"
+        AUTHENTIK_CLIENT_ID     = "{{ tap_client_id }}"
+        AUTHENTIK_CLIENT_SECRET = "{{ tap_client_secret }}"
         NOMAD_API_URL           = "http://127.0.0.1:{{ nomad_http_port }}"
         VAULT_API_URL           = "http://127.0.0.1:8200"
         CLUSTER_RESOURCE_MAP_FILE = "/opt/tap_orchestrator/config.yaml"

--- a/ansible/roles/tap_orchestrator/templates/tap_orchestrator.nomad.j2
+++ b/ansible/roles/tap_orchestrator/templates/tap_orchestrator.nomad.j2
@@ -1,0 +1,66 @@
+job "tap-orchestrator" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "tap-orchestrator-group" {
+    count = 1
+
+    network {
+      mode = "host"
+      port "http" {
+        static = {{ tap_orchestrator_port }}
+      }
+    }
+
+    task "tap-orchestrator-task" {
+      driver = "raw_exec"
+
+      env {
+        MQTT_BROKER_HOST        = "127.0.0.1"
+        MQTT_BROKER_PORT        = "{{ mqtt_port }}"
+        MQTT_TOPIC_SUCCESS      = "tagreader/auth/success"
+        MQTT_TOPIC_FAILURE      = "tagreader/auth/failure"
+        TAP_ORCHESTRATOR_PORT   = "{{ tap_orchestrator_port }}"
+        TAP_ORCHESTRATOR_SECRET = "change_me_secret"
+        AUTHENTIK_API_URL       = "http://127.0.0.1:{{ authentik_http_port }}"
+        NOMAD_API_URL           = "http://127.0.0.1:{{ nomad_http_port }}"
+        VAULT_API_URL           = "http://127.0.0.1:8200"
+        CLUSTER_RESOURCE_MAP_FILE = "/opt/tap_orchestrator/config.yaml"
+      }
+
+      config {
+        command = "/bin/bash"
+        args    = ["-c", <<EOT
+          cd /opt/tap_orchestrator
+
+          # Initialize environment if needed
+          if [ ! -d ".venv" ]; then
+            uv venv
+          fi
+
+          source .venv/bin/activate
+
+          # Install dependencies
+          uv pip install -r requirements.txt
+
+          # Start the service
+          exec python3 main.py
+        EOT
+        ]
+      }
+
+      service {
+        name = "tap-orchestrator"
+        port = "http"
+        tags = ["tap-orchestrator"]
+
+        check {
+          type     = "http"
+          path     = "/docs" # FastAPI auto-generated docs endpoint
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -14,6 +14,7 @@
 - import_playbook: playbooks/services/app_services.yaml
 - import_playbook: playbooks/services/monitoring.yaml
 - import_playbook: playbooks/services/security.yaml
+- import_playbook: playbooks/services/tap_orchestrator.yaml
 - import_playbook: playbooks/services/seed_models_to_ipfs.yaml
 - import_playbook: playbooks/services/model_services.yaml
 - import_playbook: playbooks/services/core_ai_services.yaml

--- a/playbooks/services/tap_orchestrator.yaml
+++ b/playbooks/services/tap_orchestrator.yaml
@@ -1,0 +1,5 @@
+- hosts: controller_nodes
+  gather_facts: yes
+  become: yes
+  roles:
+    - tap_orchestrator

--- a/tests/test_tap_orchestrator.py
+++ b/tests/test_tap_orchestrator.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 
 import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../services/tap_orchestrator')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../services/tap_orchestrator')))
 
 from main import app, process_tap_event
 from models import DesfireEvent, AuthentikUser


### PR DESCRIPTION
* Added `tap_orchestrator` Python service logic with Authentik and Nomad stubs
* Implemented corresponding Ansible role for cluster deployment using `uv`
* Updated root `playbook.yaml` to include the `tap_orchestrator` playbook
* Updated `group_vars/all.yaml` with required ports
* Completed unit tests with fix for correct import paths based on code review