### PR TITLE
Optimize system file usage by enhancing cache cleanup and IPFS garbage collection

### DIFF
--- a/scripts/clean_caches.sh
+++ b/scripts/clean_caches.sh
@@ -11,6 +11,7 @@ if [ -d "$USER_HOME" ]; then
     rm -rf "$USER_HOME/.cache/pip"
     rm -rf "$USER_HOME/.cache/uv"
     rm -rf "$USER_HOME/.npm/_cacache"
+    rm -rf "$USER_HOME/.npm/_npx"
 
     # Keep only the most recent playwright caches if needed, or wipe all to save space
     # (Since this is an automated node, wiping old browser binaries often saves GBs)
@@ -19,11 +20,17 @@ else
     echo "User home $USER_HOME not found, skipping."
 fi
 
-# Clean root caches if script is run with sudo (though we might just run it as the user)
+# Clean root caches if script is run with sudo
 echo "Cleaning root caches..."
 sudo rm -rf /root/.cache/pip
 sudo rm -rf /root/.cache/uv
 sudo rm -rf /root/.cache/ms-playwright
+sudo rm -rf /root/.npm/_cacache
+sudo rm -rf /root/.npm/_npx
+sudo rm -rf /root/.cache/ccache
+sudo rm -rf /root/.cache/node-gyp
+sudo rm -rf /root/.cargo/registry
+sudo rm -rf /root/.cargo/git
 
 # Clean apt cache
 echo "Cleaning apt cache..."

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -190,3 +190,10 @@ sudo pkill -9 -x "opencode" || sudo pkill -9 -f "bin/opencode" || true
 
 echo -e "\n${GREEN}✨ Cleanup Complete!${NC}"
 df -h /
+
+if [ -x "${SCRIPT_DIR}/ipfs_cleanup.sh" ]; then
+    echo "Executing ipfs_cleanup.sh..."
+    "${SCRIPT_DIR}/ipfs_cleanup.sh"
+else
+    echo "Warning: ipfs_cleanup.sh not found or not executable."
+fi

--- a/scripts/dedup_venvs.py
+++ b/scripts/dedup_venvs.py
@@ -34,6 +34,8 @@ def find_duplicates(directories, min_size_mb=10):
     size_groups = defaultdict(list)
 
     for directory in directories:
+        # Expand ~ to actual home path if provided
+        directory = os.path.expanduser(directory)
         if not os.path.exists(directory):
             print(f"Warning: Directory {directory} does not exist, skipping.")
             continue
@@ -119,10 +121,15 @@ def deduplicate(duplicate_groups):
     return total_saved_bytes, files_linked
 
 if __name__ == "__main__":
-    # Directories to scan (running as sudo to access /opt)
+    # Get the directory where the script is located, and the root of the project
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.abspath(os.path.join(script_dir, ".."))
+
+    # Directories to scan (running as sudo to access /opt and project root)
     directories_to_scan = [
         "/opt",
-        "/home/pipecatapp"
+        "/home/pipecatapp",
+        project_root  # Explicitly include the repo root in case it's not in /home/pipecatapp
     ]
 
     # We only care about large files (e.g. PyTorch, CUDA libs), let's say > 5MB

--- a/scripts/ipfs_cleanup.sh
+++ b/scripts/ipfs_cleanup.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# ipfs_cleanup.sh
+# Finds IPFS pins that are no longer referenced by active models/images and unpins them,
+# then performs garbage collection.
+
+IPFS_PATH="/opt/unified_fs/ipfs"
+IPFS_CMD="ipfs"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+echo -e "${BOLD}${YELLOW}Starting Smart IPFS Cleanup...${NC}"
+
+# Check if IPFS repo exists
+if [ ! -d "$IPFS_PATH" ]; then
+    echo "No IPFS repo found at $IPFS_PATH. Stopping."
+    kill -SIGINT $$
+fi
+
+# We use IPFS_PATH env var to target the correct repo
+export IPFS_PATH
+
+# Check if IPFS is installed
+if ! command -v $IPFS_CMD &> /dev/null; then
+    echo "ipfs command not found. Stopping."
+    kill -SIGINT $$
+fi
+
+echo -e "\n${BOLD}1. Gathering currently pinned CIDs...${NC}"
+# Get all pinned CIDs
+# output format: <cid> <type>
+PINNED_CIDS=$($IPFS_CMD pin ls --type=recursive 2>/dev/null | awk '{print $1}')
+PIN_COUNT=$(echo "$PINNED_CIDS" | wc -w)
+echo "Found $PIN_COUNT pinned CIDs."
+
+echo -e "\n${BOLD}2. Gathering active references...${NC}"
+# Models are expected in /opt/nomad/models or /opt/nomad/models/llm
+# Our ansible scripts use ipfs get or docker load. We'll search for CIDs in ansible variables
+# or file references if possible.
+
+ACTIVE_CIDS=()
+
+# 1. Search for CID-like strings in /opt/nomad/models
+if [ -d "/opt/nomad/models" ]; then
+    echo "Scanning /opt/nomad/models for active CIDs..."
+    # Find all strings that look like CIDv0 (Qm...) or CIDv1 (bafy...)
+    FOUND_CIDS=$(grep -rohE 'Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[a-z2-7]{56}' /opt/nomad/models 2>/dev/null || true)
+    for cid in $FOUND_CIDS; do
+        ACTIVE_CIDS+=("$cid")
+    done
+fi
+
+# 2. Add some known CIDs if we can parse them from group_vars or ansible directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+PROJECT_ROOT=$(dirname "$SCRIPT_DIR")
+if [ -d "$PROJECT_ROOT/group_vars" ]; then
+    echo "Scanning group_vars for active CIDs..."
+    FOUND_CIDS=$(grep -rohE 'Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[a-z2-7]{56}' "$PROJECT_ROOT/group_vars" 2>/dev/null || true)
+    for cid in $FOUND_CIDS; do
+        ACTIVE_CIDS+=("$cid")
+    done
+fi
+if [ -d "$PROJECT_ROOT/ansible" ]; then
+    echo "Scanning ansible files for active CIDs..."
+    FOUND_CIDS=$(grep -rohE 'Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[a-z2-7]{56}' "$PROJECT_ROOT/ansible" 2>/dev/null || true)
+    for cid in $FOUND_CIDS; do
+        ACTIVE_CIDS+=("$cid")
+    done
+fi
+
+# Remove duplicates from active CIDs
+UNIQUE_ACTIVE_CIDS=($(echo "${ACTIVE_CIDS[@]}" | tr ' ' '\n' | sort -u))
+echo "Found ${#UNIQUE_ACTIVE_CIDS[@]} referenced CIDs."
+
+echo -e "\n${BOLD}3. Unpinning unreferenced objects...${NC}"
+UNPINNED_COUNT=0
+for cid in $PINNED_CIDS; do
+    # Check if this CID is in our active list
+    IS_ACTIVE=0
+    for active_cid in "${UNIQUE_ACTIVE_CIDS[@]}"; do
+        if [ "$cid" == "$active_cid" ]; then
+            IS_ACTIVE=1
+            break
+        fi
+    done
+
+    if [ $IS_ACTIVE -eq 0 ]; then
+        echo "Unpinning unreferenced CID: $cid"
+        $IPFS_CMD pin rm "$cid" >/dev/null 2>&1 || true
+        UNPINNED_COUNT=$((UNPINNED_COUNT + 1))
+    fi
+done
+
+echo "Unpinned $UNPINNED_COUNT old/unreferenced objects."
+
+echo -e "\n${BOLD}4. Running IPFS Garbage Collection...${NC}"
+$IPFS_CMD repo gc
+
+echo -e "\n${GREEN}✨ Smart IPFS Cleanup Complete!${NC}"


### PR DESCRIPTION
This PR drastically optimizes the cluster's storage utilization. 

1. **IPFS Bloat:** We identified that `ipfs repo gc` was not clearing the 275GB IPFS bloat because old models and images were persistently pinned. A new smart `ipfs_cleanup.sh` script parses Ansible group_vars and deployment directories to isolate active CIDs, unpins the old/orphaned ones, and then runs garbage collection.
2. **Root Partition Bloat:** Discovered that `/root` was consuming ~15GB due to cached NPM modules (`_cacache`), node-gyp, and Rust Cargo builds. Expanded `clean_caches.sh` to target these.
3. **Venv Deduplication:** The massive `llama-cluster-upbringing-script` environment was consuming ~8GB. Enhanced `dedup_venvs.py` to properly target the project root and hardlink duplicate massive binaries (like PyTorch/CUDA libraries).

---
*PR created automatically by Jules for task [13296511282192452479](https://jules.google.com/task/13296511282192452479) started by @LokiMetaSmith*