### PR TITLE
Fix IPFS_PATH in Ansible

### DIFF
--- a/ansible/roles/download_models/tasks/main.yaml
+++ b/ansible/roles/download_models/tasks/main.yaml
@@ -68,7 +68,7 @@
       ansible.builtin.command:
         cmd: "ipfs get {{ item.content }} -o {{ nomad_models_dir }}/{{ item.item | replace('models/ipfs/', '') }}"
       environment:
-        IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+        IPFS_PATH: "{{ ipfs_path }}"
       args:
         creates: "{{ nomad_models_dir }}/{{ item.item | replace('models/ipfs/', '') }}"
       loop: "{{ cid_values.results }}"

--- a/ansible/roles/exo/tasks/main.yaml
+++ b/ansible/roles/exo/tasks/main.yaml
@@ -59,7 +59,7 @@
   become: yes
   register: ipfs_add_result_exo
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   when: exo_enable
 
 - name: Clean up temporary Exo tarball

--- a/ansible/roles/last30days_service/tasks/main.yaml
+++ b/ansible/roles/last30days_service/tasks/main.yaml
@@ -32,7 +32,7 @@
   become: yes
   register: ipfs_add_result
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
 
 - name: Clean up temporary last30days_service tarball
   ansible.builtin.file:

--- a/ansible/roles/memory_graph/tasks/main.yaml
+++ b/ansible/roles/memory_graph/tasks/main.yaml
@@ -33,7 +33,7 @@
   become: yes
   register: ipfs_add_result_memory_graph
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
 - name: Clean up temporary memory-graph-service tarball
   ansible.builtin.file:
     path: /opt/memory-graph-service.tar

--- a/ansible/roles/memory_service/tasks/main.yaml
+++ b/ansible/roles/memory_service/tasks/main.yaml
@@ -38,7 +38,7 @@
   become: yes
   register: ipfs_add_result_memory
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
 
 - name: Clean up temporary memory_service tarball
   ansible.builtin.file:

--- a/ansible/roles/mqtt/tasks/main.yaml
+++ b/ansible/roles/mqtt/tasks/main.yaml
@@ -220,7 +220,7 @@
   become: yes
   register: ipfs_add_result_mosquitto
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   changed_when: false
   delegate_to: "{{ controller_host }}"
   run_once: true

--- a/ansible/roles/openclaw/tasks/main.yaml
+++ b/ansible/roles/openclaw/tasks/main.yaml
@@ -44,7 +44,7 @@
   become: yes
   register: ipfs_add_result_openclaw
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
 - name: Clean up temporary openclaw tarball
   ansible.builtin.file:
     path: /opt/openclaw.tar

--- a/ansible/roles/opengravity/tasks/main.yaml
+++ b/ansible/roles/opengravity/tasks/main.yaml
@@ -56,7 +56,7 @@
   become: yes
   register: ipfs_add_result_opengravity
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
 - name: Clean up temporary opengravity tarball
   ansible.builtin.file:
     path: /opt/opengravity.tar

--- a/ansible/roles/seed_models/tasks/main.yaml
+++ b/ansible/roles/seed_models/tasks/main.yaml
@@ -91,7 +91,7 @@
   ansible.builtin.command:
     cmd: ipfs add --nocopy -Q "{{ nomad_models_dir }}/llm/{{ item.filename }}"
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   register: llm_ipfs_cids
   loop: "{{ llm_models_to_download | selectattr('filename', 'defined') | list | unique(attribute='filename') }}"
   become: yes
@@ -147,7 +147,7 @@
   ansible.builtin.command:
     cmd: ipfs add --nocopy -Q -r "{{ nomad_models_dir }}/vllm/{{ item.repo_id.split('/')[-1] }}"
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   register: vllm_ipfs_cids
   loop: "{{ vllm_expert_models | selectattr('repo_id', 'defined') | list }}"
   become: yes
@@ -222,7 +222,7 @@
   ansible.builtin.command:
     cmd: ipfs add --nocopy -Q "{{ nomad_models_dir }}/stt/{{ item[0].key }}/{{ item[1].filename }}"
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   register: stt_url_ipfs_cids
   loop: "{{ stt_models | dict2items | subelements('value') | selectattr(1, 'match', 'url') | list }}"
   become: yes
@@ -248,7 +248,7 @@
   ansible.builtin.command:
     cmd: ipfs add --nocopy -Q -r "{{ nomad_models_dir }}/stt/{{ item[0].key }}/{{ item[1].name }}"
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   register: stt_hub_ipfs_cids
   loop: "{{ stt_models | dict2items | subelements('value') | selectattr(1, 'match', 'repo_id') | list }}"
   become: yes
@@ -300,7 +300,7 @@
   ansible.builtin.command:
     cmd: ipfs add --nocopy -Q "{{ nomad_models_dir }}/tts/{{ item.filename }}"
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   register: tts_ipfs_cids
   loop: "{{ piper_voice_files }}"
   become: yes
@@ -374,7 +374,7 @@
   ansible.builtin.command:
     cmd: ipfs add --nocopy -Q "{{ nomad_models_dir }}/vision/{{ item.filename }}"
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   register: vision_url_ipfs_cids
   loop: "{{ vision_models | selectattr('filename', 'defined') | list }}"
   become: yes
@@ -400,7 +400,7 @@
   ansible.builtin.command:
     cmd: ipfs add --nocopy -Q -r "{{ nomad_models_dir }}/vision/{{ item.name }}"
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   register: vision_hub_ipfs_cids
   loop: "{{ vision_models | selectattr('repo_id', 'defined') | list }}"
   become: yes
@@ -456,7 +456,7 @@
   ansible.builtin.command:
     cmd: ipfs add --nocopy -Q -r "{{ nomad_models_dir }}/embedding/{{ item.name }}"
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   register: embedding_ipfs_cids
   loop: "{{ embedding_models | selectattr('repo_id', 'defined') | list }}"
   become: yes
@@ -483,7 +483,7 @@
   ansible.builtin.command:
     cmd: ipfs add -Q -r "{{ role_path }}/files/reference_data"
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   register: reference_data_ipfs_cid
   become: yes
 

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -113,7 +113,7 @@
   become: yes
   register: ipfs_add_result_tool
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
 - name: Clean up temporary tool-server tarball
   ansible.builtin.file:
     path: /opt/tool-server.tar

--- a/ansible/tasks/build_pipecatapp_image.yaml
+++ b/ansible/tasks/build_pipecatapp_image.yaml
@@ -86,7 +86,7 @@
   become: yes
   register: ipfs_add_result
   environment:
-    IPFS_PATH: "{{ unified_fs_mount_point | default('/opt/unified_fs') }}/ipfs"
+    IPFS_PATH: "{{ ipfs_path }}"
   when: pipecat_deployment_style == 'docker'
 
 - name: Clean up temporary tarball


### PR DESCRIPTION
This replaces instances of IPFS_PATH resolving from unified_fs_mount_point to ipfs_path. That path was incorrect as the initialization logic for IPFS repository actually uses ipfs_path.

---
*PR created automatically by Jules for task [1407113786831636753](https://jules.google.com/task/1407113786831636753) started by @LokiMetaSmith*