### PR TITLE
Fix Hermes Agent Ansible task failure due to stale git lock file

### DIFF
--- a/ansible/roles/hermes_agent/tasks/main.yaml
+++ b/ansible/roles/hermes_agent/tasks/main.yaml
@@ -4,6 +4,16 @@
   ignore_errors: yes
   changed_when: false
 
+- name: Remove stale git lock files in hermes-agent to prevent git update failures
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "/home/{{ target_user | default('pipecatapp') }}/.hermes/hermes-agent/.git/HEAD.lock"
+    - "/home/{{ target_user | default('pipecatapp') }}/.hermes/hermes-agent/.git/index.lock"
+  become: yes
+  become_user: "{{ target_user | default('pipecatapp') }}"
+
 - name: Install Hermes Agent
   ansible.builtin.shell:
     cmd: "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --non-interactive --skip-setup"


### PR DESCRIPTION
The issue describes a failure when running the `Install Hermes Agent` task in the `developer_tools.yaml` ansible playbook. The failure is caused by an existing `HEAD.lock` file preventing git from updating the repository (as run by the external install script), thus causing the overall ansible task to fail. 

This PR adds an idempotent task in `ansible/roles/hermes_agent/tasks/main.yaml` to ensure `.git/HEAD.lock` and `.git/index.lock` are absent in the Hermes installation directory prior to executing the installation script. This defensively protects the playbook from failures when these artifacts exist from previously killed or crashed jobs.

---
*PR created automatically by Jules for task [18238308974491646781](https://jules.google.com/task/18238308974491646781) started by @LokiMetaSmith*