### PR TITLE
Fix IPFS Gateway configuration formatting and Ansible dictionary key error

### DIFF
--- a/ansible/roles/ipfs/tasks/main.yaml
+++ b/ansible/roles/ipfs/tasks/main.yaml
@@ -61,7 +61,7 @@
     group: root
   loop: "{{ groups['all'] | default([inventory_hostname]) }}"
   become: yes
-  when: inventory_hostname in groups['controller_nodes']
+  when: inventory_hostname in groups.get('controller_nodes', [])
 
 - name: Ensure local IPFS data directory exists
   ansible.builtin.file:

--- a/ansible/roles/ipfs/templates/ipfs.nomad.j2
+++ b/ansible/roles/ipfs/templates/ipfs.nomad.j2
@@ -33,8 +33,8 @@ job "ipfs" {
         IPFS_CONFIG_Datastore_StorageMax = "100GB"
         IPFS_CONFIG_Experimental_FilestoreEnabled = "true"
         # Bind to 0.0.0.0 so that Nomad prestart tasks using cluster_ip or 127.0.0.1 can reach it
-        IPFS_CONFIG_Addresses_Gateway = "/ip4/0.0.0.0/tcp/{{ ipfs_gateway_port | default(8080) }}"
-        IPFS_CONFIG_Addresses_API = "/ip4/0.0.0.0/tcp/{{ ipfs_api_port | default(5001) }}"
+        IPFS_CONFIG_Addresses_Gateway = "[\"/ip4/0.0.0.0/tcp/{{ ipfs_gateway_port | default(8080) }}\"]"
+        IPFS_CONFIG_Addresses_API = "[\"/ip4/0.0.0.0/tcp/{{ ipfs_api_port | default(5001) }}\"]"
       }
 
       resources {


### PR DESCRIPTION
This commit addresses the issue where `ansible/roles/mqtt/tasks/main.yaml` failed to reach the IPFS Gateway (`Connection refused`) while warming up the cache for the Mosquitto tarball. This was caused by an invalid environment variable configuration in the IPFS Nomad job (`ipfs.nomad.j2`). IPFS requires `Addresses.Gateway` to be an array of strings in its configuration, so the environment variable string override must also be a JSON array. This is now fixed. A secondary playbook task error related to an undefined dictionary key `controller_nodes` when running `app_services` against localhost is also fixed using `.get()` with an empty list fallback.

---
*PR created automatically by Jules for task [5396711325715269924](https://jules.google.com/task/5396711325715269924) started by @LokiMetaSmith*