### PR TITLE
Fix llxprt bundle bun resolution error in ansible tasks

### DIFF
--- a/ansible/roles/llxprt_code/tasks/main.yaml
+++ b/ansible/roles/llxprt_code/tasks/main.yaml
@@ -63,7 +63,7 @@
     dest: "{{ llxprt_code_dir }}/.env"
 
 - name: Remove existing MCP server from llxprt-code
-  ansible.builtin.command: npx llxprt mcp remove tool-server
+  ansible.builtin.command: sh ./packages/cli/bin/llxprt mcp remove tool-server
   args:
     chdir: "{{ llxprt_code_dir }}"
   ignore_errors: true
@@ -72,8 +72,8 @@
 - name: Add MCP server to llxprt-code
   ansible.builtin.command:
     argv:
-      - npx
-      - llxprt
+      - sh
+      - ./packages/cli/bin/llxprt
       - mcp
       - add
       - tool-server


### PR DESCRIPTION
Fixes an issue during Ansible provisioning where `npx llxprt mcp remove tool-server` fails with a 'bundled Bun runtime was not found' error. This was caused by the wrapper script failing to locate the bundled `bun` dependency when executed via `npx` in a globally installed context. The fix changes the command to invoke the local wrapper script explicitly using `sh ./packages/cli/bin/llxprt`, allowing it to resolve the bundled bun executable correctly.

---
*PR created automatically by Jules for task [14163318528702181383](https://jules.google.com/task/14163318528702181383) started by @LokiMetaSmith*