### PR TITLE
Implement ATProto PdsSyncBuffer for eventual consistency

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -159,6 +159,32 @@
   tags:
     - deploy_app
 
+- name: Deploy ATProto sync buffer module directory
+  ansible.builtin.file:
+    path: "{{ pipecat_app_dir }}/tools/atproto_sync"
+    state: directory
+    mode: '0755'
+    owner: "{{ target_user | default('pipecatapp') }}"
+    group: "{{ target_user | default('pipecatapp') }}"
+  become: yes
+  tags:
+    - deploy_app
+
+- name: Deploy ATProto sync buffer module files
+  ansible.builtin.copy:
+    src: "{{ inventory_dir }}/pipecatapp/tools/atproto_sync/{{ item }}"
+    dest: "{{ pipecat_app_dir }}/tools/atproto_sync/{{ item }}"
+    mode: '0644'
+    owner: "{{ target_user | default('pipecatapp') }}"
+    group: "{{ target_user | default('pipecatapp') }}"
+  with_items:
+    - __init__.py
+    - sync_buffer.py
+    - sync_worker.py
+  become: yes
+  tags:
+    - deploy_app
+
 - name: Copy gossip_discovery module
   ansible.builtin.copy:
     mode: '0644'

--- a/pipecatapp/prompts/router.txt
+++ b/pipecatapp/prompts/router.txt
@@ -23,3 +23,9 @@ After you use a code-generating tool, the system will run a quality analysis. Th
 -   When using a tool or routing to an expert, **always** respond with a single JSON object containing the `tool` and `args` keys.
 -   When responding directly, provide a clear and concise answer in plain text.
 -   When the user's request has been fully satisfied, you **must** use the `final_answer.submit_task` tool to formally complete the interaction.
+
+# AT Protocol Identity
+When communicating externally using the AT Protocol tool (`atproto`), remember that you are broadcasting publicly to the decentralized AT Protocol network.
+1. Maintain a strict boundary: Internal scratchpad data, reasoning, and sensitive state must NEVER be pushed to ATProto.
+2. Only explicitly designated public responses should be broadcast via `atproto`.
+3. Actions submitted to `atproto` are queued locally to ensure offline eventual consistency.

--- a/pipecatapp/tools/atproto_sync/sync_buffer.py
+++ b/pipecatapp/tools/atproto_sync/sync_buffer.py
@@ -1,0 +1,147 @@
+import sqlite3
+import json
+import logging
+from typing import List, Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+class PdsSyncBuffer:
+    """
+    A local, persistent queue (SQLite-backed) for caching ATProto actions.
+    Ensures that agents can publish states/posts even when offline, providing
+    eventual consistency to the remote PDS once network connectivity is restored.
+    """
+    def __init__(self, db_path: str = "atproto_sync_buffer.sqlite"):
+        self.db_path = db_path
+        self._init_db()
+
+    def _get_connection(self):
+        """Returns a connection tailored to the DB path, handling :memory: correctly."""
+        # For :memory: databases, check_same_thread must be False for tests if shared across threads,
+        # but :memory: creates a new DB per connection unless using URI.
+        # Actually, if db_path is :memory:, we should store the connection in self
+        # so it's not destroyed when the connection is closed.
+
+        # We will use file-based databases in production, but support memory for testing
+        if self.db_path == ':memory:':
+            if not hasattr(self, '_mem_conn'):
+                self._mem_conn = sqlite3.connect(':memory:', check_same_thread=False)
+            return self._mem_conn
+        else:
+            return sqlite3.connect(self.db_path, check_same_thread=False)
+
+    def _init_db(self):
+        """Initializes the SQLite database and creates the queue table."""
+        try:
+            conn = self._get_connection()
+            cursor = conn.cursor()
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS atproto_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    action TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    status TEXT DEFAULT 'pending',
+                    error_msg TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            ''')
+            conn.commit()
+            if self.db_path != ':memory:':
+                conn.close()
+        except sqlite3.Error as e:
+            logger.error(f"Failed to initialize PdsSyncBuffer DB: {e}")
+
+    def add_event(self, action: str, payload: Dict[str, Any]) -> int:
+        """
+        Adds an ATProto action to the sync buffer queue.
+
+        Args:
+            action (str): The action to perform (e.g., 'send_post').
+            payload (dict): The arguments/data for the action.
+
+        Returns:
+            int: The ID of the inserted event, or -1 if failed.
+        """
+        try:
+            conn = self._get_connection()
+            cursor = conn.cursor()
+            cursor.execute(
+                "INSERT INTO atproto_events (action, payload, status) VALUES (?, ?, ?)",
+                (action, json.dumps(payload), 'pending')
+            )
+            conn.commit()
+            last_id = cursor.lastrowid
+            if self.db_path != ':memory:':
+                conn.close()
+            return last_id
+        except sqlite3.Error as e:
+            logger.error(f"Failed to add event to PdsSyncBuffer: {e}")
+            return -1
+
+    def get_pending_events(self, limit: int = 50) -> List[Dict[str, Any]]:
+        """
+        Retrieves a list of pending events from the queue.
+
+        Args:
+            limit (int): The maximum number of events to retrieve.
+
+        Returns:
+            List[dict]: A list of event dictionaries.
+        """
+        events = []
+        try:
+            conn = self._get_connection()
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM atproto_events WHERE status = 'pending' ORDER BY created_at ASC LIMIT ?",
+                (limit,)
+            )
+            rows = cursor.fetchall()
+            for row in rows:
+                events.append({
+                    "id": row["id"],
+                    "action": row["action"],
+                    "payload": json.loads(row["payload"]),
+                    "status": row["status"],
+                    "created_at": row["created_at"]
+                })
+            if self.db_path != ':memory:':
+                conn.close()
+        except sqlite3.Error as e:
+            logger.error(f"Failed to get pending events from PdsSyncBuffer: {e}")
+        return events
+
+    def mark_event_completed(self, event_id: int):
+        """Marks an event as successfully completed."""
+        self._update_event_status(event_id, 'completed')
+
+    def mark_event_failed(self, event_id: int, error_msg: str):
+        """Marks an event as failed (it will not be retried automatically)."""
+        try:
+            conn = self._get_connection()
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE atproto_events SET status = ?, error_msg = ? WHERE id = ?",
+                ('failed', error_msg, event_id)
+            )
+            conn.commit()
+            if self.db_path != ':memory:':
+                conn.close()
+        except sqlite3.Error as e:
+            logger.error(f"Failed to mark event {event_id} as failed: {e}")
+
+    def _update_event_status(self, event_id: int, status: str):
+        """Internal helper to update the status of an event."""
+        try:
+            conn = self._get_connection()
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE atproto_events SET status = ? WHERE id = ?",
+                (status, event_id)
+            )
+            conn.commit()
+            if self.db_path != ':memory:':
+                conn.close()
+        except sqlite3.Error as e:
+            logger.error(f"Failed to update event {event_id} status to {status}: {e}")

--- a/pipecatapp/tools/atproto_sync/sync_worker.py
+++ b/pipecatapp/tools/atproto_sync/sync_worker.py
@@ -1,0 +1,85 @@
+import asyncio
+import logging
+from typing import Any, Optional
+
+from pipecatapp.tools.atproto_sync.sync_buffer import PdsSyncBuffer
+
+logger = logging.getLogger(__name__)
+
+
+class SyncWorker:
+    """
+    A background worker that periodically polls the PdsSyncBuffer for pending
+    ATProto actions (e.g., 'send_post') and attempts to execute them using the
+    provided client initialization function.
+    Provides eventual consistency for offline publishing.
+    """
+
+    def __init__(self, buffer: PdsSyncBuffer, get_client_func, interval_seconds: int = 15):
+        self.buffer = buffer
+        self.get_client_func = get_client_func
+        self.interval_seconds = interval_seconds
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+    def start(self):
+        """Starts the background synchronization loop."""
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._sync_loop())
+        logger.info("ATProto SyncWorker started.")
+
+    def stop(self):
+        """Stops the background synchronization loop."""
+        self._running = False
+        if self._task:
+            self._task.cancel()
+        logger.info("ATProto SyncWorker stopped.")
+
+    async def _sync_loop(self):
+        """Main loop that polls and processes pending events."""
+        while self._running:
+            try:
+                events = self.buffer.get_pending_events()
+                if events:
+                    logger.info(f"SyncWorker found {len(events)} pending ATProto events.")
+                    await self._process_events(events)
+            except Exception as e:
+                logger.error(f"Error in SyncWorker loop: {e}")
+
+            await asyncio.sleep(self.interval_seconds)
+
+    async def _process_events(self, events: list):
+        """Processes a list of pending events."""
+        # Try to initialize the client. If it fails (e.g., offline), we skip processing
+        # this batch and wait for the next loop.
+        try:
+            client = await asyncio.to_thread(self.get_client_func)
+        except Exception as e:
+            logger.warning(f"SyncWorker could not get ATProto client (offline/unreachable PDS). Retrying later. Error: {e}")
+            return
+
+        for event in events:
+            event_id = event['id']
+            action = event['action']
+            payload = event['payload']
+
+            try:
+                if action == 'send_post':
+                    text = payload.get('text', '')
+                    # Execute the client action in a separate thread to prevent blocking
+                    await asyncio.to_thread(client.send_post, text=text)
+                    self.buffer.mark_event_completed(event_id)
+                    logger.info(f"SyncWorker successfully completed event {event_id} ({action}).")
+                else:
+                    error_msg = f"Unknown action: {action}"
+                    logger.error(error_msg)
+                    self.buffer.mark_event_failed(event_id, error_msg)
+
+            except Exception as e:
+                # If an individual event fails, we check if it's a network error vs a hard format error.
+                # For simplicity, we can assume if the PDS is unreachable, it raises an Exception,
+                # and we might just leave it pending to retry next time, or we can use error matching.
+                # Here we will leave it pending if it fails (eventual consistency).
+                logger.warning(f"SyncWorker failed to process event {event_id} ({action}): {e}. Will retry.")

--- a/pipecatapp/tools/atproto_tool.py
+++ b/pipecatapp/tools/atproto_tool.py
@@ -2,19 +2,39 @@ import logging
 import asyncio
 from typing import Optional, List
 
+from pipecatapp.tools.atproto_sync.sync_buffer import PdsSyncBuffer
+from pipecatapp.tools.atproto_sync.sync_worker import SyncWorker
+
 logger = logging.getLogger(__name__)
 
 class ATProtoTool:
     """
     A tool for interacting with the AT Protocol (Bluesky/Colibri) using the atproto SDK.
+    Instead of broadcasting directly, actions like send_post are queued to a local sync buffer
+    for eventual consistency.
     """
-    def __init__(self, username: str, password: str, pds_url: str = "https://bsky.social"):
+    def __init__(self, username: str, password: str, pds_url: str = "https://bsky.social", buffer_db_path: str = "atproto_sync_buffer.sqlite"):
         self.username = username
         self.password = password
         self.pds_url = pds_url
-        self.description = "Read and send messages/posts via the AT Protocol (Bluesky/Colibri)."
+        self.description = "Queue public posts to the AT Protocol feed (broadcasts). Private agent thoughts must NOT be sent here."
         self.name = "atproto"
         self._client = None
+
+        # Initialize sync buffer and worker for local-first eventual consistency
+        self.buffer = PdsSyncBuffer(db_path=buffer_db_path)
+        self.worker = SyncWorker(self.buffer, self._get_client, interval_seconds=30)
+
+        # We start the worker immediately (or could delay until first action)
+        # Note: If ATProtoTool is re-instantiated often, you might want a singleton worker,
+        # but for this swarm integration, each agent/tool instance having a worker is acceptable.
+        try:
+            # We attempt to start it. It requires a running event loop.
+            # In cases where it's initialized before the loop, we catch RuntimeError.
+            loop = asyncio.get_running_loop()
+            self.worker.start()
+        except RuntimeError:
+            pass # We can start it lazily on the first async call
 
 
     def get_schema(self) -> dict:
@@ -41,6 +61,13 @@ class ATProtoTool:
         }
 
     def execute(self, action: str, **kwargs):
+        # Ensure worker is started if we missed it during init
+        if not self.worker._running:
+            try:
+                self.worker.start()
+            except RuntimeError:
+                pass
+
         if action == "send_post":
             return getattr(self, "send_post")(**kwargs.get("kwargs", kwargs))
         if action == "get_timeline":
@@ -61,7 +88,7 @@ class ATProtoTool:
 
     async def send_post(self, text: str) -> str:
         """
-        Sends a text post via the AT Protocol.
+        Queues a text post to the local sync buffer. It will be pushed to the PDS when online.
 
         Args:
             text (str): The content of the post.
@@ -69,18 +96,25 @@ class ATProtoTool:
         Returns:
             str: Result message indicating success or failure.
         """
+        # Start worker if not started
+        if not self.worker._running:
+            self.worker.start()
+
         try:
-            # We run the synchronous atproto Client in a thread to avoid blocking the event loop
-            client = await asyncio.to_thread(self._get_client)
-            result = await asyncio.to_thread(client.send_post, text=text)
-            return f"Post sent successfully. URI: {result.uri}"
+            # We no longer block waiting for the remote PDS. We use the local buffer.
+            event_id = self.buffer.add_event('send_post', {'text': text})
+            if event_id != -1:
+                return f"Post queued successfully for eventual broadcast (Local Event ID: {event_id})."
+            else:
+                return "Error: Failed to queue post locally."
         except Exception as e:
-            logger.error(f"Error sending post via AT Protocol: {e}")
-            return f"Error sending post: {str(e)}"
+            logger.error(f"Error queueing post via AT Protocol: {e}")
+            return f"Error queueing post: {str(e)}"
 
     async def get_timeline(self, limit: int = 10) -> str:
         """
-        Fetches the latest posts from the user's timeline.
+        Fetches the latest posts from the user's timeline. Since this is a read operation,
+        it still requires remote PDS connectivity.
 
         Args:
             limit (int): The maximum number of posts to fetch (default 10).
@@ -110,5 +144,5 @@ class ATProtoTool:
             return "\n".join(posts)
 
         except Exception as e:
-            logger.error(f"Error fetching timeline via AT Protocol: {e}")
-            return f"Error fetching timeline: {str(e)}"
+            logger.error(f"Error fetching timeline via AT Protocol (offline?): {e}")
+            return f"Could not fetch timeline. You might be offline or PDS is unreachable. Error: {str(e)}"

--- a/tests/unit/test_atproto_tool.py
+++ b/tests/unit/test_atproto_tool.py
@@ -4,23 +4,34 @@ from unittest.mock import MagicMock, patch
 from pipecatapp.tools.atproto_tool import ATProtoTool
 
 def test_atproto_tool_initialization():
-    tool = ATProtoTool("user", "pass")
+    tool = ATProtoTool("user", "pass", buffer_db_path=":memory:")
     assert tool.name == "atproto"
     assert tool.username == "user"
 
-def test_send_post():
-    tool = ATProtoTool("user", "pass")
+def test_send_post_queues_locally():
+    # Since we are using an async tool context, we don't start the worker loop explicitly for the sync test
+    tool = ATProtoTool("user", "pass", buffer_db_path=":memory:")
 
-    mock_client = MagicMock()
-    mock_client.send_post.return_value = MagicMock(uri="at://mock/uri")
+    res = asyncio.run(tool.send_post("Hello World offline"))
+    assert "Post queued successfully" in res
 
-    with patch("pipecatapp.tools.atproto_tool.ATProtoTool._get_client", return_value=mock_client):
-        res = asyncio.run(tool.send_post("Hello World"))
-        assert "Post sent successfully" in res
-        assert "at://mock/uri" in res
+    # Check that it is actually in the buffer
+    pending = tool.buffer.get_pending_events()
+    assert len(pending) == 1
+    assert pending[0]['action'] == 'send_post'
+    assert pending[0]['payload']['text'] == 'Hello World offline'
 
-def test_get_timeline():
-    tool = ATProtoTool("user", "pass")
+def test_get_timeline_offline():
+    tool = ATProtoTool("user", "pass", buffer_db_path=":memory:")
+
+    # Mock getting client to throw an exception to simulate offline
+    with patch("pipecatapp.tools.atproto_tool.ATProtoTool._get_client", side_effect=Exception("Network unreachable")):
+        res = asyncio.run(tool.get_timeline())
+        assert "Could not fetch timeline" in res
+        assert "Network unreachable" in res
+
+def test_get_timeline_online():
+    tool = ATProtoTool("user", "pass", buffer_db_path=":memory:")
 
     mock_client = MagicMock()
     mock_post1 = MagicMock()


### PR DESCRIPTION
Implemented the `PdsSyncBuffer` and `SyncWorker` as outlined in `docs/ATPROTO_IDENTITY_ARCHITECTURE.md`. This allows `ATProtoTool` to function correctly in offline or intermittent network states by queueing post events locally and synchronizing them when the Personal Data Server (PDS) becomes reachable. Prompts have been updated to emphasize the boundary between public broadcasts and internal memory. Tests pass and changes are fully ready.

---
*PR created automatically by Jules for task [4472286605348933868](https://jules.google.com/task/4472286605348933868) started by @LokiMetaSmith*