### PR TITLE
Fix out-of-bounds relative paths in Ansible files

### DIFF
--- a/ansible/roles/apt_proxy/tasks/main.yml
+++ b/ansible/roles/apt_proxy/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Copy APT Proxy source files to target
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../../pipecatapp/services/ipfs_apt_proxy/"
+    src: "{{ playbook_dir }}/../pipecatapp/services/ipfs_apt_proxy/"
     dest: "{{ apt_proxy_src_dir.path }}/"
     mode: '0644'
 

--- a/ansible/roles/apt_proxy/tasks/main.yml
+++ b/ansible/roles/apt_proxy/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Copy APT Proxy source files to target
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../pipecatapp/services/ipfs_apt_proxy/"
+    src: "{{ project_root }}/pipecatapp/services/ipfs_apt_proxy/"
     dest: "{{ apt_proxy_src_dir.path }}/"
     mode: '0644'
 

--- a/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
+++ b/ansible/roles/bootstrap_agent/tasks/deploy_llama_cpp_model.yaml
@@ -15,7 +15,7 @@
 
 - name: Render the Llama.cpp RPC Nomad job from template for bootstrap
   ansible.builtin.template:
-    src: "{{ inventory_dir }}/ansible/jobs/llamacpp-rpc.nomad.j2"
+    src: "{{ project_root }}/ansible/jobs/llamacpp-rpc.nomad.j2"
     dest: "{{ nomad_jobs_dir }}/llamacpp-rpc.nomad"
     mode: '0644'
   vars:

--- a/ansible/roles/btrfs_snapshot/tasks/main.yaml
+++ b/ansible/roles/btrfs_snapshot/tasks/main.yaml
@@ -232,7 +232,7 @@
 
 - name: Deploy OS Recovery tool to target host
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../scripts/recover_os.py"
+    src: "{{ project_root }}/scripts/recover_os.py"
     dest: "/opt/cluster-infra/scripts/recover_os.py"
     mode: '0755'
   become: yes

--- a/ansible/roles/btrfs_snapshot/tasks/main.yaml
+++ b/ansible/roles/btrfs_snapshot/tasks/main.yaml
@@ -232,7 +232,7 @@
 
 - name: Deploy OS Recovery tool to target host
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../../scripts/recover_os.py"
+    src: "{{ playbook_dir }}/../scripts/recover_os.py"
     dest: "/opt/cluster-infra/scripts/recover_os.py"
     mode: '0755'
   become: yes

--- a/ansible/roles/last30days_service/tasks/main.yaml
+++ b/ansible/roles/last30days_service/tasks/main.yaml
@@ -17,7 +17,7 @@
     name: last30days-service
     tag: local
     build:
-      path: "{{ role_path }}/../../../last30days_service"
+      path: "{{ role_path }}/../../last30days_service"
       nocache: true
     source: build
     force_source: true

--- a/ansible/roles/last30days_service/tasks/main.yaml
+++ b/ansible/roles/last30days_service/tasks/main.yaml
@@ -17,7 +17,7 @@
     name: last30days-service
     tag: local
     build:
-      path: "{{ role_path }}/../../last30days_service"
+      path: "{{ project_root }}/last30days_service"
       nocache: true
     source: build
     force_source: true

--- a/ansible/roles/llama_cpp/tasks/main.yaml
+++ b/ansible/roles/llama_cpp/tasks/main.yaml
@@ -244,7 +244,7 @@
         all_models_to_benchmark: "{{ expert_models.values() | sum(start=[]) | unique(attribute='filename') }}"
 
     - name: Benchmark each available model and record results
-      ansible.builtin.include_tasks: ../../../../playbooks/benchmark_single_model.yaml
+      ansible.builtin.include_tasks: ../../../playbooks/benchmark_single_model.yaml
       loop: "{{ all_models_to_benchmark }}"
       loop_control:
         loop_var: model_item

--- a/ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml
+++ b/ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml
@@ -17,7 +17,7 @@
 
 - name: Template rpc job for {{ model_item.filename }}
   ansible.builtin.template:
-    src: ../../jobs/llamacpp-rpc.nomad.j2
+    src: ../jobs/llamacpp-rpc.nomad.j2
     dest: "/tmp/rpc-{{ model_item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
     mode: '0644'
   vars:

--- a/ansible/roles/memory_graph/tasks/main.yaml
+++ b/ansible/roles/memory_graph/tasks/main.yaml
@@ -19,7 +19,7 @@
   community.docker.docker_image:
     name: "memory-graph-service:local"
     build:
-      path: "{{ inventory_dir }}/pipecatapp/memory_graph_service"
+      path: "{{ project_root }}/pipecatapp/memory_graph_service"
       pull: yes
     source: build
     force_source: true

--- a/ansible/roles/memory_service/tasks/main.yaml
+++ b/ansible/roles/memory_service/tasks/main.yaml
@@ -15,7 +15,7 @@
 
 - name: Copy Dockerfile to build directory
   ansible.builtin.copy:
-    src: "{{ role_path }}/../../../docker/memory_service/Dockerfile"
+    src: "{{ role_path }}/../../docker/memory_service/Dockerfile"
     dest: "/opt/memory_service/build/Dockerfile"
     mode: '0644'
 

--- a/ansible/roles/memory_service/tasks/main.yaml
+++ b/ansible/roles/memory_service/tasks/main.yaml
@@ -15,7 +15,7 @@
 
 - name: Copy Dockerfile to build directory
   ansible.builtin.copy:
-    src: "{{ role_path }}/../../docker/memory_service/Dockerfile"
+    src: "{{ project_root }}/docker/memory_service/Dockerfile"
     dest: "/opt/memory_service/build/Dockerfile"
     mode: '0644'
 

--- a/ansible/roles/opengravity/tasks/main.yaml
+++ b/ansible/roles/opengravity/tasks/main.yaml
@@ -22,7 +22,7 @@
 
 - name: Sync OpenGravity files to build context
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../../pipecatapp/ui/opengravity/"
+    src: "{{ playbook_dir }}/../pipecatapp/ui/opengravity/"
     dest: "/opt/opengravity-build/"
     mode: '0644'
     directory_mode: '0755'
@@ -45,7 +45,7 @@
     image_tag: "local"
     build_dir: "/opt/opengravity-build"
   ansible.builtin.include_tasks:
-    file: "../../tasks/build_cached_image.yaml"
+    file: "../tasks/build_cached_image.yaml"
 
 - name: Export opengravity image to tarball
   ansible.builtin.command: docker save -o /opt/opengravity.tar opengravity:local

--- a/ansible/roles/opengravity/tasks/main.yaml
+++ b/ansible/roles/opengravity/tasks/main.yaml
@@ -22,7 +22,7 @@
 
 - name: Sync OpenGravity files to build context
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../pipecatapp/ui/opengravity/"
+    src: "{{ project_root }}/pipecatapp/ui/opengravity/"
     dest: "/opt/opengravity-build/"
     mode: '0644'
     directory_mode: '0755'

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -73,7 +73,7 @@
 
     - name: Run benchmark script if log file does not exist
       ansible.builtin.command:
-        cmd: "/home/{{ target_user | default('pipecatapp') }}/llama-cluster-upbringing-script/.venv/bin/python3 {{ playbook_dir }}/../scripts/benchmark_resources.py"
+        cmd: "/home/{{ target_user | default('pipecatapp') }}/llama-cluster-upbringing-script/.venv/bin/python3 {{ project_root }}/scripts/benchmark_resources.py"
       become: yes
       when: not benchmark_log_stat.stat.exists
 
@@ -153,7 +153,7 @@
 - name: Copy requirements.txt
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/requirements.txt"
+    src: "{{ project_root }}/pipecatapp/requirements.txt"
     dest: "{{ pipecat_app_dir }}/requirements.txt"
   become: yes
   tags:
@@ -172,7 +172,7 @@
 
 - name: Deploy ATProto sync buffer module files
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/tools/atproto_sync/{{ item }}"
+    src: "{{ project_root }}/pipecatapp/tools/atproto_sync/{{ item }}"
     dest: "{{ pipecat_app_dir }}/tools/atproto_sync/{{ item }}"
     mode: '0644'
     owner: "{{ target_user | default('pipecatapp') }}"
@@ -188,7 +188,7 @@
 - name: Copy gossip_discovery module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/gossip_discovery.py"
+    src: "{{ project_root }}/pipecatapp/gossip_discovery.py"
     dest: "{{ pipecat_app_dir }}/gossip_discovery.py"
   become: yes
   tags:
@@ -219,7 +219,7 @@
 - name: Copy pipecat app
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/app.py"
+    src: "{{ project_root }}/pipecatapp/app.py"
     dest: "{{ pipecat_app_dir }}/app.py"
   become: yes
   tags:
@@ -228,7 +228,7 @@
 - name: Copy task supervisor
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/task_supervisor.py"
+    src: "{{ project_root }}/pipecatapp/task_supervisor.py"
     dest: "{{ pipecat_app_dir }}/task_supervisor.py"
   become: yes
   tags:
@@ -237,7 +237,7 @@
 - name: Copy agent factory
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/agent_factory.py"
+    src: "{{ project_root }}/pipecatapp/agent_factory.py"
     dest: "{{ pipecat_app_dir }}/agent_factory.py"
   become: yes
   tags:
@@ -246,7 +246,7 @@
 - name: Copy worker agent
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/worker_agent.py"
+    src: "{{ project_root }}/pipecatapp/worker_agent.py"
     dest: "{{ pipecat_app_dir }}/worker_agent.py"
   become: yes
   tags:
@@ -255,7 +255,7 @@
 - name: Copy pmm memory client
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/pmm_memory_client.py"
+    src: "{{ project_root }}/pipecatapp/pmm_memory_client.py"
     dest: "{{ pipecat_app_dir }}/pmm_memory_client.py"
   become: yes
   tags:
@@ -264,7 +264,7 @@
 - name: Copy pmm memory module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/pmm_memory.py"
+    src: "{{ project_root }}/pipecatapp/pmm_memory.py"
     dest: "{{ pipecat_app_dir }}/pmm_memory.py"
   become: yes
   tags:
@@ -273,7 +273,7 @@
 - name: Copy quality_control module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/quality_control.py"
+    src: "{{ project_root }}/pipecatapp/quality_control.py"
     dest: "{{ pipecat_app_dir }}/quality_control.py"
   become: yes
   tags:
@@ -282,7 +282,7 @@
 - name: Copy durable_execution module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/durable_execution.py"
+    src: "{{ project_root }}/pipecatapp/durable_execution.py"
     dest: "{{ pipecat_app_dir }}/durable_execution.py"
   become: yes
   tags:
@@ -291,7 +291,7 @@
 - name: Copy workflow directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/workflow"
+    src: "{{ project_root }}/pipecatapp/workflow"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -345,7 +345,7 @@
 - name: Copy memory module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/memory.py"
+    src: "{{ project_root }}/pipecatapp/memory.py"
     dest: "{{ pipecat_app_dir }}/memory.py"
   become: yes
   tags:
@@ -354,7 +354,7 @@
 - name: Copy net_utils module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/net_utils.py"
+    src: "{{ project_root }}/pipecatapp/net_utils.py"
     dest: "{{ pipecat_app_dir }}/net_utils.py"
   become: yes
   tags:
@@ -363,7 +363,7 @@
 - name: Copy models module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/models.py"
+    src: "{{ project_root }}/pipecatapp/models.py"
     dest: "{{ pipecat_app_dir }}/models.py"
   become: yes
   tags:
@@ -372,7 +372,7 @@
 - name: Copy rate_limiter module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/rate_limiter.py"
+    src: "{{ project_root }}/pipecatapp/rate_limiter.py"
     dest: "{{ pipecat_app_dir }}/rate_limiter.py"
   become: yes
   tags:
@@ -381,7 +381,7 @@
 - name: Copy security module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/security.py"
+    src: "{{ project_root }}/pipecatapp/security.py"
     dest: "{{ pipecat_app_dir }}/security.py"
   become: yes
   tags:
@@ -390,7 +390,7 @@
 - name: Copy api_keys module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/api_keys.py"
+    src: "{{ project_root }}/pipecatapp/api_keys.py"
     dest: "{{ pipecat_app_dir }}/api_keys.py"
   become: yes
   tags:
@@ -399,7 +399,7 @@
 - name: Copy llm_clients module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/llm_clients.py"
+    src: "{{ project_root }}/pipecatapp/llm_clients.py"
     dest: "{{ pipecat_app_dir }}/llm_clients.py"
   become: yes
   tags:
@@ -408,7 +408,7 @@
 - name: Copy archivist service
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/archivist_service.py"
+    src: "{{ project_root }}/pipecatapp/archivist_service.py"
     dest: "{{ pipecat_app_dir }}/archivist_service.py"
   become: yes
   tags:
@@ -416,7 +416,7 @@
 
 - name: Copy archivist startup script
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/start_archivist.sh"
+    src: "{{ project_root }}/pipecatapp/start_archivist.sh"
     dest: "{{ pipecat_app_dir }}/start_archivist.sh"
     mode: '0755'
   become: yes
@@ -426,7 +426,7 @@
 - name: Copy web_server module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/web_server.py"
+    src: "{{ project_root }}/pipecatapp/web_server.py"
     dest: "{{ pipecat_app_dir }}/web_server.py"
   become: yes
   tags:
@@ -435,7 +435,7 @@
 - name: Copy static assets
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/static"
+    src: "{{ project_root }}/pipecatapp/static"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -444,7 +444,7 @@
 - name: Copy tools directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/tools"
+    src: "{{ project_root }}/pipecatapp/tools"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -453,7 +453,7 @@
 - name: Copy integrations directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/integrations"
+    src: "{{ project_root }}/pipecatapp/integrations"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -461,7 +461,7 @@
 
 - name: Copy gossip_discovery module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/gossip_discovery.py"
+    src: "{{ project_root }}/pipecatapp/gossip_discovery.py"
     dest: "{{ pipecat_app_dir }}/gossip_discovery.py"
   become: yes
   tags:
@@ -469,7 +469,7 @@
 
 - name: Copy __init__ module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/__init__.py"
+    src: "{{ project_root }}/pipecatapp/__init__.py"
     dest: "{{ pipecat_app_dir }}/__init__.py"
   become: yes
   tags:
@@ -477,7 +477,7 @@
 
 - name: Copy expert_tracker module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/expert_tracker.py"
+    src: "{{ project_root }}/pipecatapp/expert_tracker.py"
     dest: "{{ pipecat_app_dir }}/expert_tracker.py"
   become: yes
   tags:
@@ -485,7 +485,7 @@
 
 - name: Copy file_ingestion module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/file_ingestion.py"
+    src: "{{ project_root }}/pipecatapp/file_ingestion.py"
     dest: "{{ pipecat_app_dir }}/file_ingestion.py"
   become: yes
   tags:
@@ -493,7 +493,7 @@
 
 - name: Copy generate_real_embeddings module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/generate_real_embeddings.py"
+    src: "{{ project_root }}/pipecatapp/generate_real_embeddings.py"
     dest: "{{ pipecat_app_dir }}/generate_real_embeddings.py"
   become: yes
   tags:
@@ -501,7 +501,7 @@
 
 - name: Copy janitor_agent module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/janitor_agent.py"
+    src: "{{ project_root }}/pipecatapp/janitor_agent.py"
     dest: "{{ pipecat_app_dir }}/janitor_agent.py"
   become: yes
   tags:
@@ -509,7 +509,7 @@
 
 - name: Copy judge_agent module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/judge_agent.py"
+    src: "{{ project_root }}/pipecatapp/judge_agent.py"
     dest: "{{ pipecat_app_dir }}/judge_agent.py"
   become: yes
   tags:
@@ -517,7 +517,7 @@
 
 - name: Copy langchain_memory_wrappers module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/langchain_memory_wrappers.py"
+    src: "{{ project_root }}/pipecatapp/langchain_memory_wrappers.py"
     dest: "{{ pipecat_app_dir }}/langchain_memory_wrappers.py"
   become: yes
   tags:
@@ -525,7 +525,7 @@
 
 - name: Copy local_llm module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/local_llm.py"
+    src: "{{ project_root }}/pipecatapp/local_llm.py"
     dest: "{{ pipecat_app_dir }}/local_llm.py"
   become: yes
   tags:
@@ -533,7 +533,7 @@
 
 - name: Copy local_world_model module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/local_world_model.py"
+    src: "{{ project_root }}/pipecatapp/local_world_model.py"
     dest: "{{ pipecat_app_dir }}/local_world_model.py"
   become: yes
   tags:
@@ -541,7 +541,7 @@
 
 - name: Copy manager_agent module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/manager_agent.py"
+    src: "{{ project_root }}/pipecatapp/manager_agent.py"
     dest: "{{ pipecat_app_dir }}/manager_agent.py"
   become: yes
   tags:
@@ -549,7 +549,7 @@
 
 - name: Copy memory_backends module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/memory_backends.py"
+    src: "{{ project_root }}/pipecatapp/memory_backends.py"
     dest: "{{ pipecat_app_dir }}/memory_backends.py"
   become: yes
   tags:
@@ -557,7 +557,7 @@
 
 - name: Copy memory_legacy module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/memory_legacy.py"
+    src: "{{ project_root }}/pipecatapp/memory_legacy.py"
     dest: "{{ pipecat_app_dir }}/memory_legacy.py"
   become: yes
   tags:
@@ -565,7 +565,7 @@
 
 - name: Copy mqtt_world_model_client module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/mqtt_world_model_client.py"
+    src: "{{ project_root }}/pipecatapp/mqtt_world_model_client.py"
     dest: "{{ pipecat_app_dir }}/mqtt_world_model_client.py"
   become: yes
   tags:
@@ -573,7 +573,7 @@
 
 - name: Copy secret_manager module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/secret_manager.py"
+    src: "{{ project_root }}/pipecatapp/secret_manager.py"
     dest: "{{ pipecat_app_dir }}/secret_manager.py"
   become: yes
   tags:
@@ -581,7 +581,7 @@
 
 - name: Copy skill_library module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/skill_library.py"
+    src: "{{ project_root }}/pipecatapp/skill_library.py"
     dest: "{{ pipecat_app_dir }}/skill_library.py"
   become: yes
   tags:
@@ -589,7 +589,7 @@
 
 - name: Copy technician_agent module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/technician_agent.py"
+    src: "{{ project_root }}/pipecatapp/technician_agent.py"
     dest: "{{ pipecat_app_dir }}/technician_agent.py"
   become: yes
   tags:
@@ -597,7 +597,7 @@
 
 - name: Copy tool_server module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/tool_server.py"
+    src: "{{ project_root }}/pipecatapp/tool_server.py"
     dest: "{{ pipecat_app_dir }}/tool_server.py"
   become: yes
   tags:
@@ -605,7 +605,7 @@
 
 - name: Copy train_router module
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/pipecatapp/train_router.py"
+    src: "{{ project_root }}/pipecatapp/train_router.py"
     dest: "{{ pipecat_app_dir }}/train_router.py"
   become: yes
   tags:
@@ -614,7 +614,7 @@
 - name: Copy network_scanner module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/network_scanner.py"
+    src: "{{ project_root }}/pipecatapp/network_scanner.py"
     dest: "{{ pipecat_app_dir }}/network_scanner.py"
   become: yes
   tags:
@@ -623,7 +623,7 @@
 - name: Copy moondream_detector module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/moondream_detector.py"
+    src: "{{ project_root }}/pipecatapp/moondream_detector.py"
     dest: "{{ pipecat_app_dir }}/moondream_detector.py"
   become: yes
   tags:
@@ -633,7 +633,7 @@
 - name: Copy __init__ module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/__init__.py"
+    src: "{{ project_root }}/pipecatapp/__init__.py"
     dest: "{{ pipecat_app_dir }}/__init__.py"
   become: yes
   tags:
@@ -642,7 +642,7 @@
 - name: Copy expert_tracker module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/expert_tracker.py"
+    src: "{{ project_root }}/pipecatapp/expert_tracker.py"
     dest: "{{ pipecat_app_dir }}/expert_tracker.py"
   become: yes
   tags:
@@ -651,7 +651,7 @@
 - name: Copy file_ingestion module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/file_ingestion.py"
+    src: "{{ project_root }}/pipecatapp/file_ingestion.py"
     dest: "{{ pipecat_app_dir }}/file_ingestion.py"
   become: yes
   tags:
@@ -660,7 +660,7 @@
 - name: Copy generate_real_embeddings module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/generate_real_embeddings.py"
+    src: "{{ project_root }}/pipecatapp/generate_real_embeddings.py"
     dest: "{{ pipecat_app_dir }}/generate_real_embeddings.py"
   become: yes
   tags:
@@ -669,7 +669,7 @@
 - name: Copy janitor_agent module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/janitor_agent.py"
+    src: "{{ project_root }}/pipecatapp/janitor_agent.py"
     dest: "{{ pipecat_app_dir }}/janitor_agent.py"
   become: yes
   tags:
@@ -678,7 +678,7 @@
 - name: Copy judge_agent module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/judge_agent.py"
+    src: "{{ project_root }}/pipecatapp/judge_agent.py"
     dest: "{{ pipecat_app_dir }}/judge_agent.py"
   become: yes
   tags:
@@ -687,7 +687,7 @@
 - name: Copy langchain_memory_wrappers module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/langchain_memory_wrappers.py"
+    src: "{{ project_root }}/pipecatapp/langchain_memory_wrappers.py"
     dest: "{{ pipecat_app_dir }}/langchain_memory_wrappers.py"
   become: yes
   tags:
@@ -696,7 +696,7 @@
 - name: Copy local_llm module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/local_llm.py"
+    src: "{{ project_root }}/pipecatapp/local_llm.py"
     dest: "{{ pipecat_app_dir }}/local_llm.py"
   become: yes
   tags:
@@ -705,7 +705,7 @@
 - name: Copy local_world_model module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/local_world_model.py"
+    src: "{{ project_root }}/pipecatapp/local_world_model.py"
     dest: "{{ pipecat_app_dir }}/local_world_model.py"
   become: yes
   tags:
@@ -714,7 +714,7 @@
 - name: Copy manager_agent module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/manager_agent.py"
+    src: "{{ project_root }}/pipecatapp/manager_agent.py"
     dest: "{{ pipecat_app_dir }}/manager_agent.py"
   become: yes
   tags:
@@ -723,7 +723,7 @@
 - name: Copy memory_backends module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/memory_backends.py"
+    src: "{{ project_root }}/pipecatapp/memory_backends.py"
     dest: "{{ pipecat_app_dir }}/memory_backends.py"
   become: yes
   tags:
@@ -732,7 +732,7 @@
 - name: Copy memory_legacy module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/memory_legacy.py"
+    src: "{{ project_root }}/pipecatapp/memory_legacy.py"
     dest: "{{ pipecat_app_dir }}/memory_legacy.py"
   become: yes
   tags:
@@ -741,7 +741,7 @@
 - name: Copy mqtt_world_model_client module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/mqtt_world_model_client.py"
+    src: "{{ project_root }}/pipecatapp/mqtt_world_model_client.py"
     dest: "{{ pipecat_app_dir }}/mqtt_world_model_client.py"
   become: yes
   tags:
@@ -750,7 +750,7 @@
 - name: Copy secret_manager module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/secret_manager.py"
+    src: "{{ project_root }}/pipecatapp/secret_manager.py"
     dest: "{{ pipecat_app_dir }}/secret_manager.py"
   become: yes
   tags:
@@ -759,7 +759,7 @@
 - name: Copy skill_library module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/skill_library.py"
+    src: "{{ project_root }}/pipecatapp/skill_library.py"
     dest: "{{ pipecat_app_dir }}/skill_library.py"
   become: yes
   tags:
@@ -768,7 +768,7 @@
 - name: Copy technician_agent module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/technician_agent.py"
+    src: "{{ project_root }}/pipecatapp/technician_agent.py"
     dest: "{{ pipecat_app_dir }}/technician_agent.py"
   become: yes
   tags:
@@ -777,7 +777,7 @@
 - name: Copy tool_server module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/tool_server.py"
+    src: "{{ project_root }}/pipecatapp/tool_server.py"
     dest: "{{ pipecat_app_dir }}/tool_server.py"
   become: yes
   tags:
@@ -786,7 +786,7 @@
 - name: Copy train_router module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/train_router.py"
+    src: "{{ project_root }}/pipecatapp/train_router.py"
     dest: "{{ pipecat_app_dir }}/train_router.py"
   become: yes
   tags:
@@ -795,7 +795,7 @@
 - name: Copy ontology module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/ontology.py"
+    src: "{{ project_root }}/pipecatapp/ontology.py"
     dest: "{{ pipecat_app_dir }}/ontology.py"
   become: yes
   tags:
@@ -804,7 +804,7 @@
 - name: Copy context_handoff module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/context_handoff.py"
+    src: "{{ project_root }}/pipecatapp/context_handoff.py"
     dest: "{{ pipecat_app_dir }}/context_handoff.py"
   become: yes
   tags:
@@ -813,7 +813,7 @@
 - name: Copy sharded_pmm_memory module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/sharded_pmm_memory.py"
+    src: "{{ project_root }}/pipecatapp/sharded_pmm_memory.py"
     dest: "{{ pipecat_app_dir }}/sharded_pmm_memory.py"
   become: yes
   tags:
@@ -822,7 +822,7 @@
 - name: Copy sharded_router module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/sharded_router.py"
+    src: "{{ project_root }}/pipecatapp/sharded_router.py"
     dest: "{{ pipecat_app_dir }}/sharded_router.py"
   become: yes
   tags:
@@ -831,7 +831,7 @@
 - name: Copy atproto_crypto module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/atproto_crypto.py"
+    src: "{{ project_root }}/pipecatapp/atproto_crypto.py"
     dest: "{{ pipecat_app_dir }}/atproto_crypto.py"
   become: yes
   tags:
@@ -840,7 +840,7 @@
 - name: Copy onecli_proxy module
   ansible.builtin.copy:
     mode: '0644'
-    src: "{{ inventory_dir }}/pipecatapp/onecli_proxy.py"
+    src: "{{ project_root }}/pipecatapp/onecli_proxy.py"
     dest: "{{ pipecat_app_dir }}/onecli_proxy.py"
   become: yes
   tags:
@@ -849,7 +849,7 @@
 - name: Copy concurrency directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/concurrency"
+    src: "{{ project_root }}/pipecatapp/concurrency"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -858,7 +858,7 @@
 - name: Copy workflows directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/workflows"
+    src: "{{ project_root }}/pipecatapp/workflows"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -867,7 +867,7 @@
 - name: Copy persona_plex directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/persona_plex"
+    src: "{{ project_root }}/pipecatapp/persona_plex"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -876,7 +876,7 @@
 
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/datasets"
+    src: "{{ project_root }}/pipecatapp/datasets"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -885,7 +885,7 @@
 - name: Copy resources directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/resources"
+    src: "{{ project_root }}/pipecatapp/resources"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -894,7 +894,7 @@
 - name: Copy mtac pipeline directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/mtac"
+    src: "{{ project_root }}/pipecatapp/mtac"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -903,7 +903,7 @@
 - name: Copy mtac pipeline module
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/mtac_pipeline.py"
+    src: "{{ project_root }}/pipecatapp/mtac_pipeline.py"
     dest: "{{ pipecat_app_dir }}/mtac_pipeline.py"
   become: yes
   tags:
@@ -912,7 +912,7 @@
 - name: Copy memory_backends_impl directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/memory_backends_impl"
+    src: "{{ project_root }}/pipecatapp/memory_backends_impl"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -921,7 +921,7 @@
 - name: Copy memory_graph_service directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/memory_graph_service"
+    src: "{{ project_root }}/pipecatapp/memory_graph_service"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -930,7 +930,7 @@
 - name: Copy miniray directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/miniray"
+    src: "{{ project_root }}/pipecatapp/miniray"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -939,7 +939,7 @@
 - name: Copy servers directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/servers"
+    src: "{{ project_root }}/pipecatapp/servers"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -948,7 +948,7 @@
 - name: Copy services directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/services"
+    src: "{{ project_root }}/pipecatapp/services"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -957,7 +957,7 @@
 - name: Copy ui directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/ui"
+    src: "{{ project_root }}/pipecatapp/ui"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -966,7 +966,7 @@
 - name: Copy utils directory
   ansible.builtin.copy:
     mode: '0755'
-    src: "{{ inventory_dir }}/pipecatapp/utils"
+    src: "{{ project_root }}/pipecatapp/utils"
     dest: "{{ pipecat_app_dir }}/"
   become: yes
   tags:
@@ -1050,7 +1050,7 @@
 
 - name: Build pipecatapp Docker image
   ansible.builtin.include_tasks:
-    file: "{{ inventory_dir }}/ansible/tasks/build_pipecatapp_image.yaml"
+    file: "{{ project_root }}/ansible/tasks/build_pipecatapp_image.yaml"
 
 - name: Handle docker specific tasks for pipecatapp
   block:

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -73,7 +73,7 @@
 
     - name: Run benchmark script if log file does not exist
       ansible.builtin.command:
-        cmd: "/home/{{ target_user | default('pipecatapp') }}/llama-cluster-upbringing-script/.venv/bin/python3 {{ playbook_dir }}/../../scripts/benchmark_resources.py"
+        cmd: "/home/{{ target_user | default('pipecatapp') }}/llama-cluster-upbringing-script/.venv/bin/python3 {{ playbook_dir }}/../scripts/benchmark_resources.py"
       become: yes
       when: not benchmark_log_stat.stat.exists
 
@@ -1098,7 +1098,7 @@
 - name: Template prompt evolution Nomad job file
   ansible.builtin.template:
     mode: '0644'
-    src: ../../jobs/evolve-prompt.nomad.j2
+    src: ../jobs/evolve-prompt.nomad.j2
     dest: "{{ nomad_jobs_dir }}/evolve-prompt.nomad"
   become: yes
 
@@ -1128,14 +1128,14 @@
 - name: Create router job file from template
   ansible.builtin.template:
     mode: '0644'
-    src: ../../jobs/router.nomad.j2
+    src: ../jobs/router.nomad.j2
     dest: "{{ nomad_jobs_dir }}/router.nomad"
   become: yes
 
 - name: Create ds4 expert job files from template
   ansible.builtin.template:
     mode: '0644'
-    src: ../../jobs/ds4-server.nomad.j2
+    src: ../jobs/ds4-server.nomad.j2
     dest: "{{ nomad_jobs_dir }}/ds4-server-{{ item.name | lower | replace(' ', '-') }}.nomad"
   loop: "{{ expert_models.ds4 | default([]) }}"
   when: >
@@ -1148,7 +1148,7 @@
 - name: Create expert job files from template for verified models
   ansible.builtin.template:
     mode: '0644'
-    src: ../../jobs/expert.nomad.j2
+    src: ../jobs/expert.nomad.j2
     dest: "{{ nomad_jobs_dir }}/expert-{{ current_expert }}.nomad"
   loop: "{{ verified_experts | default([]) }}"
   loop_control:
@@ -1187,7 +1187,7 @@
 - name: Copy test runner Nomad job template
   ansible.builtin.copy:
     mode: '0644'
-    src: ../../jobs/test-runner.nomad.j2
+    src: ../jobs/test-runner.nomad.j2
     dest: "{{ nomad_jobs_dir }}/test-runner.nomad.j2"
   become: yes
 

--- a/ansible/roles/pypi_proxy/tasks/main.yml
+++ b/ansible/roles/pypi_proxy/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Copy PyPI Proxy source files to target
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../../pipecatapp/services/ipfs_pypi_proxy/"
+    src: "{{ playbook_dir }}/../pipecatapp/services/ipfs_pypi_proxy/"
     dest: "{{ pypi_proxy_src_dir.path }}/"
     mode: '0644'
 

--- a/ansible/roles/pypi_proxy/tasks/main.yml
+++ b/ansible/roles/pypi_proxy/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Copy PyPI Proxy source files to target
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../pipecatapp/services/ipfs_pypi_proxy/"
+    src: "{{ project_root }}/pipecatapp/services/ipfs_pypi_proxy/"
     dest: "{{ pypi_proxy_src_dir.path }}/"
     mode: '0644'
 

--- a/ansible/roles/semantic_router/tasks/main.yaml
+++ b/ansible/roles/semantic_router/tasks/main.yaml
@@ -41,7 +41,7 @@
 
 - name: Build Semantic Router Docker Image (cached)
   ansible.builtin.include_tasks:
-    file: "../../tasks/build_cached_image.yaml"
+    file: "../tasks/build_cached_image.yaml"
   vars:
     build_dir: "{{ semantic_router_build_dir }}"
     image_name: "{{ _semantic_router_base_image }}"

--- a/ansible/roles/smol_agent_server/tasks/main.yaml
+++ b/ansible/roles/smol_agent_server/tasks/main.yaml
@@ -9,7 +9,7 @@
 
 - name: Template smol-agent-server job
   ansible.builtin.template:
-    src: ../../jobs/smol-agent-server.nomad.j2
+    src: ../jobs/smol-agent-server.nomad.j2
     dest: /tmp/smol-agent-server.nomad
     mode: '0644'
 

--- a/ansible/roles/tap_orchestrator/tasks/main.yaml
+++ b/ansible/roles/tap_orchestrator/tasks/main.yaml
@@ -40,7 +40,7 @@
 
 - name: Copy Tap Orchestrator python source files
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/services/tap_orchestrator/"
+    src: "{{ project_root }}/services/tap_orchestrator/"
     dest: "/opt/tap_orchestrator/"
     owner: "{{ target_user }}"
     group: "{{ target_user }}"

--- a/ansible/roles/tap_orchestrator/tasks/main.yaml
+++ b/ansible/roles/tap_orchestrator/tasks/main.yaml
@@ -40,7 +40,7 @@
 
 - name: Copy Tap Orchestrator python source files
   ansible.builtin.copy:
-    src: "{{ inventory_dir }}/../services/tap_orchestrator/"
+    src: "{{ inventory_dir }}/services/tap_orchestrator/"
     dest: "/opt/tap_orchestrator/"
     owner: "{{ target_user }}"
     group: "{{ target_user }}"

--- a/ansible/roles/tml_interaction/tasks/main.yaml
+++ b/ansible/roles/tml_interaction/tasks/main.yaml
@@ -26,7 +26,7 @@
     NOMAD_CLIENT_KEY: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.key.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
 - name: Template tml-interaction nomad job for each model
   ansible.builtin.template:
-    src: ../../jobs/tml-interaction.nomad.j2
+    src: ../jobs/tml-interaction.nomad.j2
     dest: "/tmp/tml-interaction-{{ item.name | regex_replace('[^a-zA-Z0-9-]', '-') | lower }}.nomad"
     mode: '0644'
   loop: "{{ tml_models }}"

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -53,7 +53,7 @@
 
 - name: "Tool Server : Copy pmm_memory.py"
   ansible.builtin.copy:
-    src: "{{ role_path }}/../../pipecatapp/pmm_memory.py"
+    src: "{{ project_root }}/pipecatapp/pmm_memory.py"
     dest: "/opt/tool_server/pmm_memory.py"
     owner: "{{ target_user }}"
     group: "{{ target_user }}"
@@ -62,7 +62,7 @@
 
 - name: "Tool Server : Copy secret_manager.py"
   ansible.builtin.copy:
-    src: "{{ role_path }}/../../pipecatapp/secret_manager.py"
+    src: "{{ project_root }}/pipecatapp/secret_manager.py"
     dest: "/opt/tool_server/secret_manager.py"
     owner: "{{ target_user }}"
     group: "{{ target_user }}"
@@ -71,7 +71,7 @@
 
 - name: "Tool Server : Copy net_utils.py"
   ansible.builtin.copy:
-    src: "{{ role_path }}/../../pipecatapp/net_utils.py"
+    src: "{{ project_root }}/pipecatapp/net_utils.py"
     dest: "/opt/tool_server/net_utils.py"
     owner: "{{ target_user }}"
     group: "{{ target_user }}"
@@ -80,7 +80,7 @@
 
 - name: "Tool Server : Copy tools directory"
   ansible.builtin.copy:
-    src: "{{ role_path }}/../../pipecatapp/tools"
+    src: "{{ project_root }}/pipecatapp/tools"
     dest: "/opt/tool_server/"
     owner: "{{ target_user }}"
     group: "{{ target_user }}"

--- a/ansible/roles/tool_server/tasks/main.yaml
+++ b/ansible/roles/tool_server/tasks/main.yaml
@@ -53,7 +53,7 @@
 
 - name: "Tool Server : Copy pmm_memory.py"
   ansible.builtin.copy:
-    src: "{{ role_path }}/../../../pipecatapp/pmm_memory.py"
+    src: "{{ role_path }}/../../pipecatapp/pmm_memory.py"
     dest: "/opt/tool_server/pmm_memory.py"
     owner: "{{ target_user }}"
     group: "{{ target_user }}"
@@ -62,7 +62,7 @@
 
 - name: "Tool Server : Copy secret_manager.py"
   ansible.builtin.copy:
-    src: "{{ role_path }}/../../../pipecatapp/secret_manager.py"
+    src: "{{ role_path }}/../../pipecatapp/secret_manager.py"
     dest: "/opt/tool_server/secret_manager.py"
     owner: "{{ target_user }}"
     group: "{{ target_user }}"
@@ -71,7 +71,7 @@
 
 - name: "Tool Server : Copy net_utils.py"
   ansible.builtin.copy:
-    src: "{{ role_path }}/../../../pipecatapp/net_utils.py"
+    src: "{{ role_path }}/../../pipecatapp/net_utils.py"
     dest: "/opt/tool_server/net_utils.py"
     owner: "{{ target_user }}"
     group: "{{ target_user }}"
@@ -80,7 +80,7 @@
 
 - name: "Tool Server : Copy tools directory"
   ansible.builtin.copy:
-    src: "{{ role_path }}/../../../pipecatapp/tools"
+    src: "{{ role_path }}/../../pipecatapp/tools"
     dest: "/opt/tool_server/"
     owner: "{{ target_user }}"
     group: "{{ target_user }}"
@@ -93,7 +93,7 @@
 
 - name: "Tool Server : Build tool-server docker image (cached)"
   ansible.builtin.include_tasks:
-    file: "../../tasks/build_cached_image.yaml"
+    file: "../tasks/build_cached_image.yaml"
   vars:
     build_dir: "/opt/tool_server"
     image_name: "tool-server"

--- a/ansible/roles/world_model_service/tasks/main.yaml
+++ b/ansible/roles/world_model_service/tasks/main.yaml
@@ -41,7 +41,7 @@
   tags:
     - world_model_service
   ansible.builtin.include_tasks:
-    file: "../../tasks/build_cached_image.yaml"
+    file: "../tasks/build_cached_image.yaml"
   vars:
     build_dir: "/opt/world_model_service"
     image_name: "world-model-service"
@@ -246,7 +246,7 @@
   tags:
     - world_model_service
   ansible.builtin.template:
-    src: "../../jobs/llamacpp-batch.nomad.j2"
+    src: "../jobs/llamacpp-batch.nomad.j2"
     dest: "{{ nomad_jobs_dir }}/llamacpp-batch.nomad"
     owner: "root"
     group: "root"

--- a/ansible/tasks/deploy_expert_wrapper.yaml
+++ b/ansible/tasks/deploy_expert_wrapper.yaml
@@ -14,7 +14,7 @@
 
     - name: "Expert {{ expert_name }} : Synchronize pipecatapp source"
       ansible.posix.synchronize:
-        src: "{{ inventory_dir }}/pipecatapp/"
+        src: "{{ project_root }}/pipecatapp/"
         dest: "{{ pipecat_app_mount_source }}/"
         rsync_opts:
           - "--exclude=.git"
@@ -32,7 +32,7 @@
       block:
         - name: "Expert {{ expert_name }} : Build {{ pipecat_image_name }} Docker image"
           ansible.builtin.include_tasks:
-            file: "{{ inventory_dir }}/ansible/tasks/build_pipecatapp_image.yaml"
+            file: "{{ project_root }}/ansible/tasks/build_pipecatapp_image.yaml"
           vars:
             pipecat_build_dir: "{{ pipecat_app_mount_source }}"
 
@@ -49,7 +49,7 @@
 
     - name: "Expert {{ expert_name }} : Ensure startup script exists (Dev Mode fallback)"
       ansible.builtin.template:
-        src: "{{ inventory_dir }}/ansible/roles/pipecatapp/templates/start_pipecatapp.sh.j2"
+        src: "{{ project_root }}/ansible/roles/pipecatapp/templates/start_pipecatapp.sh.j2"
         dest: "{{ pipecat_app_mount_source }}/start_pipecat.sh"
         mode: '0755'
 
@@ -161,7 +161,7 @@
 
     - name: "Expert {{ expert_name }} : Analyze allocations"
       ansible.builtin.command:
-        cmd: "python3 {{ playbook_dir }}/../scripts/analyze_nomad_allocs.py /tmp/expert_{{ expert_name }}_allocs.json"
+        cmd: "python3 {{ project_root }}/scripts/analyze_nomad_allocs.py /tmp/expert_{{ expert_name }}_allocs.json"
       register: expert_allocs_analysis
       changed_when: false
       failed_when: false

--- a/ansible/tasks/deploy_expert_wrapper.yaml
+++ b/ansible/tasks/deploy_expert_wrapper.yaml
@@ -161,7 +161,7 @@
 
     - name: "Expert {{ expert_name }} : Analyze allocations"
       ansible.builtin.command:
-        cmd: "python3 {{ playbook_dir }}/../../scripts/analyze_nomad_allocs.py /tmp/expert_{{ expert_name }}_allocs.json"
+        cmd: "python3 {{ playbook_dir }}/../scripts/analyze_nomad_allocs.py /tmp/expert_{{ expert_name }}_allocs.json"
       register: expert_allocs_analysis
       changed_when: false
       failed_when: false

--- a/ansible/tasks/deploy_model_gpu_provider.yaml
+++ b/ansible/tasks/deploy_model_gpu_provider.yaml
@@ -33,7 +33,7 @@
 
 - name: "Render the GPU Provider Pool job template for {{ model.name }}"
   ansible.builtin.template:
-    src: "{{ playbook_dir }}/../../ansible/jobs/llamacpp-rpc.nomad.j2"
+    src: "{{ playbook_dir }}/../ansible/jobs/llamacpp-rpc.nomad.j2"
     dest: "/tmp/{{ rpc_job_name }}.nomad"
     mode: '0644'
   vars:

--- a/ansible/tasks/deploy_model_gpu_provider.yaml
+++ b/ansible/tasks/deploy_model_gpu_provider.yaml
@@ -33,7 +33,7 @@
 
 - name: "Render the GPU Provider Pool job template for {{ model.name }}"
   ansible.builtin.template:
-    src: "{{ playbook_dir }}/../ansible/jobs/llamacpp-rpc.nomad.j2"
+    src: "{{ project_root }}/ansible/jobs/llamacpp-rpc.nomad.j2"
     dest: "/tmp/{{ rpc_job_name }}.nomad"
     mode: '0644'
   vars:

--- a/ansible/tests/verify_grafana.yaml
+++ b/ansible/tests/verify_grafana.yaml
@@ -6,7 +6,7 @@
   tasks:
     - name: Load global variables
       ansible.builtin.include_vars:
-        file: "{{ inventory_dir | default(playbook_dir + '/../') }}/group_vars/all.yaml"
+        file: "{{ project_root }}/group_vars/all.yaml"
 
     - name: Set facts for Grafana access
       ansible.builtin.set_fact:

--- a/ansible/tests/verify_grafana.yaml
+++ b/ansible/tests/verify_grafana.yaml
@@ -6,7 +6,7 @@
   tasks:
     - name: Load global variables
       ansible.builtin.include_vars:
-        file: "{{ inventory_dir | default(playbook_dir + '/../../') }}/group_vars/all.yaml"
+        file: "{{ inventory_dir | default(playbook_dir + '/../') }}/group_vars/all.yaml"
 
     - name: Set facts for Grafana access
       ansible.builtin.set_fact:

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -284,3 +284,4 @@ celld_enabled: true
 celld_bucket: "celld-cells"
 minio_root_user: "minioadmin"
 minio_root_password: "change_me_in_prod_minio"
+project_root: "{{ inventory_dir }}"

--- a/playbooks/deploy_expert.yaml
+++ b/playbooks/deploy_expert.yaml
@@ -59,8 +59,8 @@
     - name: Render the Llama Expert job template with custom variables
       ansible.builtin.shell:
         cmd: |
-          /tmp/jinja2_venv/bin/python {{ playbook_dir }}/../render_template.py \
-          {{ playbook_dir }}/../ansible/jobs/expert.nomad.j2 \
+          /tmp/jinja2_venv/bin/python {{ project_root }}/render_template.py \
+          {{ project_root }}/ansible/jobs/expert.nomad.j2 \
           {{ playbook_dir }}/tmp/expert-{{ current_expert }}-vars.json \
           > {{ playbook_dir }}/tmp/expert-{{ current_expert }}.nomad
 

--- a/playbooks/heal_cluster.yaml
+++ b/playbooks/heal_cluster.yaml
@@ -5,9 +5,9 @@
   gather_facts: yes
 
   vars_files:
-    - "{{ playbook_dir }}/../group_vars/all.yaml"
-    - "{{ playbook_dir }}/../group_vars/models.yaml"
-    - "{{ playbook_dir }}/../group_vars/external_experts.yaml"
+    - "{{ project_root }}/group_vars/all.yaml"
+    - "{{ project_root }}/group_vars/models.yaml"
+    - "{{ project_root }}/group_vars/external_experts.yaml"
 
   vars:
     target_user: "pipecatapp"

--- a/playbooks/heal_job.yaml
+++ b/playbooks/heal_job.yaml
@@ -58,7 +58,7 @@
 
         - name: Validate the fix with a unit test
           ansible.builtin.script:
-            cmd: "python {{ playbook_dir }}/../tests/integration/test_pipecat_app.py {{ pipecat_ip }}"
+            cmd: "python {{ project_root }}/tests/integration/test_pipecat_app.py {{ pipecat_ip }}"
           register: test_result
           changed_when: false
           when: pipecat_ip is defined
@@ -128,7 +128,7 @@
 
         - name: Validate the fix with a unit test
           ansible.builtin.script:
-            cmd: "python {{ playbook_dir }}/../tests/integration/test_pipecat_app.py {{ pipecat_ip }}"
+            cmd: "python {{ project_root }}/tests/integration/test_pipecat_app.py {{ pipecat_ip }}"
           register: test_result
           changed_when: false
           when: pipecat_ip is defined

--- a/playbooks/network/verify.yaml
+++ b/playbooks/network/verify.yaml
@@ -52,7 +52,7 @@
       rescue:
         - name: "DEBUG: Run Mesh Debug Script on Failure"
           script:
-            cmd: "{{ playbook_dir }}/../scripts/debug_mesh.sh"
+            cmd: "{{ project_root }}/scripts/debug_mesh.sh"
           register: debug_output
           ignore_errors: yes
 

--- a/playbooks/network/verify.yaml
+++ b/playbooks/network/verify.yaml
@@ -52,7 +52,7 @@
       rescue:
         - name: "DEBUG: Run Mesh Debug Script on Failure"
           script:
-            cmd: "{{ playbook_dir }}/../../scripts/debug_mesh.sh"
+            cmd: "{{ playbook_dir }}/../scripts/debug_mesh.sh"
           register: debug_output
           ignore_errors: yes
 

--- a/playbooks/run_config_manager.yaml
+++ b/playbooks/run_config_manager.yaml
@@ -1,8 +1,8 @@
 - hosts: localhost
   gather_facts: yes
   vars_files:
-    - "{{ playbook_dir }}/../group_vars/all.yaml"
-    - "{{ playbook_dir }}/../group_vars/models.yaml"
-    - "{{ playbook_dir }}/../group_vars/external_experts.yaml"
+    - "{{ project_root }}/group_vars/all.yaml"
+    - "{{ project_root }}/group_vars/models.yaml"
+    - "{{ project_root }}/group_vars/external_experts.yaml"
   roles:
     - config_manager

--- a/playbooks/run_consul.yaml
+++ b/playbooks/run_consul.yaml
@@ -1,8 +1,8 @@
 - hosts: localhost
   gather_facts: yes
   vars_files:
-    - "{{ playbook_dir }}/../group_vars/all.yaml"
-    - "{{ playbook_dir }}/../group_vars/models.yaml"
-    - "{{ playbook_dir }}/../group_vars/external_experts.yaml"
+    - "{{ project_root }}/group_vars/all.yaml"
+    - "{{ project_root }}/group_vars/models.yaml"
+    - "{{ project_root }}/group_vars/external_experts.yaml"
   roles:
     - consul

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -87,7 +87,7 @@
 
         - name: Synchronize pipecatapp source to controller
           ansible.posix.synchronize:
-            src: "{{ inventory_dir }}/pipecatapp/"
+            src: "{{ project_root }}/pipecatapp/"
             dest: "{{ cluster_infra_dir }}/pipecatapp/"
             rsync_opts:
               - "--exclude=.git"
@@ -105,7 +105,7 @@
 
         - name: Ensure pipecatapp Docker image is built
           ansible.builtin.include_tasks:
-            file: "{{ inventory_dir }}/ansible/tasks/build_pipecatapp_image.yaml"
+            file: "{{ project_root }}/ansible/tasks/build_pipecatapp_image.yaml"
           vars:
             pipecat_build_dir: "{{ cluster_infra_dir }}/pipecatapp"
           tags:
@@ -150,7 +150,7 @@
 
         - name: Deploy and run the GPU Provider Pool job for verified models
           include_tasks:
-            file: "{{ playbook_dir }}/../ansible/tasks/deploy_model_gpu_provider.yaml"
+            file: "{{ project_root }}/ansible/tasks/deploy_model_gpu_provider.yaml"
           loop: "{{ deployment_candidates }}"
           loop_control:
             loop_var: model
@@ -259,7 +259,7 @@
 
         - name: Create Expert Orchestrator job files
           include_tasks:
-            file: "{{ playbook_dir }}/../ansible/tasks/create_expert_job.yaml"
+            file: "{{ project_root }}/ansible/tasks/create_expert_job.yaml"
           loop: "{{ verified_experts | default([]) }}"
           loop_control:
             loop_var: current_expert
@@ -269,7 +269,7 @@
 
         - name: Deploy the Expert Orchestrator services with debugging
           include_tasks:
-            file: "{{ playbook_dir }}/../ansible/tasks/deploy_expert_wrapper.yaml"
+            file: "{{ project_root }}/ansible/tasks/deploy_expert_wrapper.yaml"
           vars:
             registry_is_reachable: "{{ global_registry_check.state | default('stopped') == 'started' }}"
           loop: "{{ verified_experts | default([]) }}"

--- a/playbooks/services/ai_experts.yaml
+++ b/playbooks/services/ai_experts.yaml
@@ -150,7 +150,7 @@
 
         - name: Deploy and run the GPU Provider Pool job for verified models
           include_tasks:
-            file: "{{ playbook_dir }}/../../ansible/tasks/deploy_model_gpu_provider.yaml"
+            file: "{{ playbook_dir }}/../ansible/tasks/deploy_model_gpu_provider.yaml"
           loop: "{{ deployment_candidates }}"
           loop_control:
             loop_var: model
@@ -259,7 +259,7 @@
 
         - name: Create Expert Orchestrator job files
           include_tasks:
-            file: "{{ playbook_dir }}/../../ansible/tasks/create_expert_job.yaml"
+            file: "{{ playbook_dir }}/../ansible/tasks/create_expert_job.yaml"
           loop: "{{ verified_experts | default([]) }}"
           loop_control:
             loop_var: current_expert
@@ -269,7 +269,7 @@
 
         - name: Deploy the Expert Orchestrator services with debugging
           include_tasks:
-            file: "{{ playbook_dir }}/../../ansible/tasks/deploy_expert_wrapper.yaml"
+            file: "{{ playbook_dir }}/../ansible/tasks/deploy_expert_wrapper.yaml"
           vars:
             registry_is_reachable: "{{ global_registry_check.state | default('stopped') == 'started' }}"
           loop: "{{ verified_experts | default([]) }}"

--- a/playbooks/services/consul.yaml
+++ b/playbooks/services/consul.yaml
@@ -29,7 +29,7 @@
     - name: Run Consul Unit Tests
       ansible.builtin.command:
         cmd: "{{ ansible_playbook_python }} -m unittest tests.unit.test_infrastructure.TestInfrastructure.test_consul_running"
-        chdir: "{{ playbook_dir }}/../../"
+        chdir: "{{ playbook_dir }}/../"
       changed_when: false
       tags:
         - consul_test

--- a/playbooks/services/consul.yaml
+++ b/playbooks/services/consul.yaml
@@ -29,7 +29,7 @@
     - name: Run Consul Unit Tests
       ansible.builtin.command:
         cmd: "{{ ansible_playbook_python }} -m unittest tests.unit.test_infrastructure.TestInfrastructure.test_consul_running"
-        chdir: "{{ playbook_dir }}/../"
+        chdir: "{{ project_root }}/"
       changed_when: false
       tags:
         - consul_test

--- a/playbooks/services/core_infra.yaml
+++ b/playbooks/services/core_infra.yaml
@@ -23,7 +23,7 @@
       tags:
         - sync
       ansible.posix.synchronize:
-        src: "{{ playbook_dir }}/../../"
+        src: "{{ playbook_dir }}/../"
         dest: /opt/cluster-infra/
         rsync_opts:
           - "--exclude=.git"
@@ -37,7 +37,7 @@
       tags:
         - sync
       ansible.posix.synchronize:
-        src: "{{ playbook_dir }}/../../"
+        src: "{{ playbook_dir }}/../"
         dest: /opt/cluster-infra/
         rsync_opts:
           - "--exclude=.git"

--- a/playbooks/services/core_infra.yaml
+++ b/playbooks/services/core_infra.yaml
@@ -23,7 +23,7 @@
       tags:
         - sync
       ansible.posix.synchronize:
-        src: "{{ playbook_dir }}/../"
+        src: "{{ project_root }}/"
         dest: /opt/cluster-infra/
         rsync_opts:
           - "--exclude=.git"
@@ -37,7 +37,7 @@
       tags:
         - sync
       ansible.posix.synchronize:
-        src: "{{ playbook_dir }}/../"
+        src: "{{ project_root }}/"
         dest: /opt/cluster-infra/
         rsync_opts:
           - "--exclude=.git"

--- a/playbooks/services/nomad.yaml
+++ b/playbooks/services/nomad.yaml
@@ -15,7 +15,7 @@
     - name: Run Nomad Unit Tests
       ansible.builtin.command:
         cmd: "{{ ansible_playbook_python }} -m unittest tests.unit.test_infrastructure.TestInfrastructure.test_nomad_running"
-        chdir: "{{ playbook_dir }}/../"
+        chdir: "{{ project_root }}/"
       changed_when: false
       tags:
         - nomad_test

--- a/playbooks/services/nomad.yaml
+++ b/playbooks/services/nomad.yaml
@@ -15,7 +15,7 @@
     - name: Run Nomad Unit Tests
       ansible.builtin.command:
         cmd: "{{ ansible_playbook_python }} -m unittest tests.unit.test_infrastructure.TestInfrastructure.test_nomad_running"
-        chdir: "{{ playbook_dir }}/../../"
+        chdir: "{{ playbook_dir }}/../"
       changed_when: false
       tags:
         - nomad_test

--- a/playbooks/services/tap_orchestrator.yaml
+++ b/playbooks/services/tap_orchestrator.yaml
@@ -1,5 +1,7 @@
 - hosts: controller_nodes
   gather_facts: yes
   become: yes
+  vars_files:
+    - "{{ playbook_dir }}/../group_vars/all.yaml"
   roles:
     - tap_orchestrator


### PR DESCRIPTION
Replaced invalid out-of-bounds relative paths pointing outside of the expected directory structures (e.g. `{{ playbook_dir }}/../../`, `{{ inventory_dir }}/../`, etc) with correct ones.

---
*PR created automatically by Jules for task [2819666568335095320](https://jules.google.com/task/2819666568335095320) started by @LokiMetaSmith*