### PR TITLE
fix: refactor Ansible playbooks to use global project_root variable

### DIFF
--- a/ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml
+++ b/ansible/roles/llama_cpp/tasks/run_single_rpc_job.yaml
@@ -17,7 +17,7 @@
 
 - name: Template rpc job for {{ model_item.filename }}
   ansible.builtin.template:
-    src: ../jobs/llamacpp-rpc.nomad.j2
+    src: "{{ ansible_jobs_dir }}/llamacpp-rpc.nomad.j2"
     dest: "/tmp/rpc-{{ model_item.filename | regex_replace('[^a-zA-Z0-9-]', '-') }}.nomad"
     mode: '0644'
   vars:

--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -1098,7 +1098,7 @@
 - name: Template prompt evolution Nomad job file
   ansible.builtin.template:
     mode: '0644'
-    src: ../jobs/evolve-prompt.nomad.j2
+    src: "{{ ansible_jobs_dir }}/evolve-prompt.nomad.j2"
     dest: "{{ nomad_jobs_dir }}/evolve-prompt.nomad"
   become: yes
 
@@ -1128,14 +1128,14 @@
 - name: Create router job file from template
   ansible.builtin.template:
     mode: '0644'
-    src: ../jobs/router.nomad.j2
+    src: "{{ ansible_jobs_dir }}/router.nomad.j2"
     dest: "{{ nomad_jobs_dir }}/router.nomad"
   become: yes
 
 - name: Create ds4 expert job files from template
   ansible.builtin.template:
     mode: '0644'
-    src: ../jobs/ds4-server.nomad.j2
+    src: "{{ ansible_jobs_dir }}/ds4-server.nomad.j2"
     dest: "{{ nomad_jobs_dir }}/ds4-server-{{ item.name | lower | replace(' ', '-') }}.nomad"
   loop: "{{ expert_models.ds4 | default([]) }}"
   when: >
@@ -1148,7 +1148,7 @@
 - name: Create expert job files from template for verified models
   ansible.builtin.template:
     mode: '0644'
-    src: ../jobs/expert.nomad.j2
+    src: "{{ ansible_jobs_dir }}/expert.nomad.j2"
     dest: "{{ nomad_jobs_dir }}/expert-{{ current_expert }}.nomad"
   loop: "{{ verified_experts | default([]) }}"
   loop_control:
@@ -1187,7 +1187,7 @@
 - name: Copy test runner Nomad job template
   ansible.builtin.copy:
     mode: '0644'
-    src: ../jobs/test-runner.nomad.j2
+    src: "{{ ansible_jobs_dir }}/test-runner.nomad.j2"
     dest: "{{ nomad_jobs_dir }}/test-runner.nomad.j2"
   become: yes
 

--- a/ansible/roles/smol_agent_server/tasks/main.yaml
+++ b/ansible/roles/smol_agent_server/tasks/main.yaml
@@ -9,7 +9,7 @@
 
 - name: Template smol-agent-server job
   ansible.builtin.template:
-    src: ../jobs/smol-agent-server.nomad.j2
+    src: "{{ ansible_jobs_dir }}/smol-agent-server.nomad.j2"
     dest: /tmp/smol-agent-server.nomad
     mode: '0644'
 

--- a/ansible/roles/tml_interaction/tasks/main.yaml
+++ b/ansible/roles/tml_interaction/tasks/main.yaml
@@ -26,7 +26,7 @@
     NOMAD_CLIENT_KEY: "{{ (nomad_tls_dir | default('/etc/nomad.d/tls') ~ '/cli.key.pem') if nomad_cli_cert_stat.stat.exists else omit }}"
 - name: Template tml-interaction nomad job for each model
   ansible.builtin.template:
-    src: ../jobs/tml-interaction.nomad.j2
+    src: "{{ ansible_jobs_dir }}/tml-interaction.nomad.j2"
     dest: "/tmp/tml-interaction-{{ item.name | regex_replace('[^a-zA-Z0-9-]', '-') | lower }}.nomad"
     mode: '0644'
   loop: "{{ tml_models }}"

--- a/ansible/roles/world_model_service/tasks/main.yaml
+++ b/ansible/roles/world_model_service/tasks/main.yaml
@@ -246,7 +246,7 @@
   tags:
     - world_model_service
   ansible.builtin.template:
-    src: "../jobs/llamacpp-batch.nomad.j2"
+    src: "{{ ansible_jobs_dir }}/llamacpp-batch.nomad.j2"
     dest: "{{ nomad_jobs_dir }}/llamacpp-batch.nomad"
     owner: "root"
     group: "root"

--- a/ansible/tasks/create_expert_job.yaml
+++ b/ansible/tasks/create_expert_job.yaml
@@ -1,6 +1,6 @@
 - name: Create Expert Orchestrator job file for {{ current_expert }}
   ansible.builtin.template:
-    src: "../jobs/expert.nomad.j2"
+    src: "{{ ansible_jobs_dir }}/expert.nomad.j2"
     dest: "/tmp/expert-{{ current_expert }}.nomad"
   when: expert_benchmark_data is defined
   vars:


### PR DESCRIPTION
Replaced invalid out-of-bounds relative paths pointing outside of the expected directory structures (e.g. `{{ playbook_dir }}/../../`, `{{ inventory_dir }}/../`, etc) with correct ones using a new global `project_root` variable defined in `group_vars/all.yaml` as `{{ inventory_dir }}`.

Additionally, added `ansible_jobs_dir` and `ansible_tasks_dir` per code review suggestion to further centralize and simplify job and task path references across the codebase.