### PR TITLE
fix(bootstrap): prevent nodeenv crash on repeated runs

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -710,7 +710,7 @@ ensure_python_environment() {
     fi
 
     if [ "$DO_DRY_RUN" != true ]; then
-        run_step "Installing Node.js Environment" "pip install nodeenv && nodeenv -p"
+        run_step "Installing Node.js Environment" "pip install nodeenv && (command -v node >/dev/null 2>&1 || nodeenv -p)"
         run_step "Installing OpenCode AI Agent" "npm ci"
     fi
 


### PR DESCRIPTION
When `nodeenv -p` is run in an existing virtual environment where Node.js is already installed, it throws a `shutil.SameFileError` or `FileExistsError`, causing `bootstrap.sh` to fail on repeated executions. This commit adds a check to only run `nodeenv -p` if the `node` binary is not already in the PATH, making the bootstrap script safely re-entrant.

---
*PR created automatically by Jules for task [16979779534100479994](https://jules.google.com/task/16979779534100479994) started by @LokiMetaSmith*