### PR TITLE
Fix missing file failure in pipecatapp Nomad template

### DIFF
--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -118,13 +118,13 @@ job "{{ job_name | default('pipecat-app') }}" {
       {{ env_vars }}
 
       template {
-        data        = "{{ lookup('file', '{{ internal_cert_path | default(\'/etc/ssl/certs/internal-cert.pem\') }}') | default('', true) }}"
+        data        = "{{ lookup('file', internal_cert_path | default('/etc/ssl/certs/internal-cert.pem'), errors='ignore') | default('', true) }}"
         destination = "/secrets/internal-cert.pem"
         change_mode = "restart"
       }
 
       template {
-        data        = "{{ lookup('file', '{{ internal_key_path | default(\'/etc/ssl/private/internal-key.pem\') }}') | default('', true) }}"
+        data        = "{{ lookup('file', internal_key_path | default('/etc/ssl/private/internal-key.pem'), errors='ignore') | default('', true) }}"
         destination = "/secrets/internal-key.pem"
         change_mode = "restart"
       }
@@ -167,13 +167,13 @@ job "{{ job_name | default('pipecat-app') }}" {
       {{ env_vars }}
 
       template {
-        data        = "{{ lookup('file', '{{ internal_cert_path | default(\'/etc/ssl/certs/internal-cert.pem\') }}') | default('', true) }}"
+        data        = "{{ lookup('file', internal_cert_path | default('/etc/ssl/certs/internal-cert.pem'), errors='ignore') | default('', true) }}"
         destination = "/secrets/internal-cert.pem"
         change_mode = "restart"
       }
 
       template {
-        data        = "{{ lookup('file', '{{ internal_key_path | default(\'/etc/ssl/private/internal-key.pem\') }}') | default('', true) }}"
+        data        = "{{ lookup('file', internal_key_path | default('/etc/ssl/private/internal-key.pem'), errors='ignore') | default('', true) }}"
         destination = "/secrets/internal-key.pem"
         change_mode = "restart"
       }


### PR DESCRIPTION
Fixes a Jinja templating error caused by nested curly braces inside `lookup('file')` in `ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2`.

This caused a complete task failure on early node provisioning when internal certificates do not exist yet. Added `errors='ignore'` so that missing files will just fallback silently as intended.

---
*PR created automatically by Jules for task [10448666430046634944](https://jules.google.com/task/10448666430046634944) started by @LokiMetaSmith*