### PR TITLE
feat: network routing capabilities using swarm_router

### DIFF
--- a/ansible/roles/swarm_router/handlers/main.yaml
+++ b/ansible/roles/swarm_router/handlers/main.yaml
@@ -1,0 +1,9 @@
+- name: Restart systemd-networkd
+  ansible.builtin.systemd:
+    name: systemd-networkd
+    state: restarted
+
+- name: Restart nftables
+  ansible.builtin.systemd:
+    name: nftables
+    state: restarted

--- a/ansible/roles/swarm_router/tasks/main.yaml
+++ b/ansible/roles/swarm_router/tasks/main.yaml
@@ -1,0 +1,51 @@
+- name: Ensure systemd-networkd and nftables are installed
+  ansible.builtin.apt:
+    name:
+      - systemd
+      - nftables
+    state: present
+    update_cache: yes
+
+- name: Enable IPv4 and IPv6 forwarding
+  ansible.posix.sysctl:
+    name: "{{ item }}"
+    value: '1'
+    sysctl_set: yes
+    state: present
+    reload: yes
+  loop:
+    - net.ipv4.ip_forward
+    - net.ipv6.conf.all.forwarding
+
+- name: Create systemd-networkd WAN config
+  ansible.builtin.template:
+    src: wan.network.j2
+    dest: /etc/systemd/network/11_wan.network
+    mode: '0644'
+  notify: Restart systemd-networkd
+
+- name: Create systemd-networkd LAN config
+  ansible.builtin.template:
+    src: lan.network.j2
+    dest: /etc/systemd/network/31_lan.network
+    mode: '0644'
+  notify: Restart systemd-networkd
+
+- name: Deploy nftables ruleset for router
+  ansible.builtin.template:
+    src: nftables.conf.j2
+    dest: /etc/nftables.conf
+    mode: '0644'
+  notify: Restart nftables
+
+- name: Ensure systemd-networkd is enabled and started
+  ansible.builtin.systemd:
+    name: systemd-networkd
+    enabled: yes
+    state: started
+
+- name: Ensure nftables is enabled and started
+  ansible.builtin.systemd:
+    name: nftables
+    enabled: yes
+    state: started

--- a/ansible/roles/swarm_router/templates/lan.network.j2
+++ b/ansible/roles/swarm_router/templates/lan.network.j2
@@ -1,0 +1,29 @@
+[Match]
+Name={{ swarm_router_lan_interface }}
+
+[Network]
+# Ensure LAN acts as router, using DHCPServer and IPMasquerade for IPv6
+IPv6SendRA=yes
+IPv6AcceptRA=no
+DHCPServer=yes
+DHCPPrefixDelegation=yes
+IPMasquerade=ipv6
+
+[DHCPServer]
+PoolOffset=100
+PoolSize=100
+EmitDNS=yes
+# Assuming this node also handles DNS if requested, otherwise external DNS
+DNS=1.1.1.1 8.8.8.8
+
+[IPv6SendRA]
+Managed=no
+OtherInformation=no
+RouterLifetimeSec=1800
+
+[DHCPPrefixDelegation]
+UplinkInterface={{ swarm_router_wan_interface }}
+SubnetId=0x2
+Announce=yes
+Assign=yes
+Token=::1

--- a/ansible/roles/swarm_router/templates/nftables.conf.j2
+++ b/ansible/roles/swarm_router/templates/nftables.conf.j2
@@ -1,0 +1,77 @@
+#!/usr/sbin/nft -f
+
+flush ruleset
+
+define WAN = {{ swarm_router_wan_interface }}
+define LAN = {{ swarm_router_lan_interface }}
+define TAILSCALE = "tailscale0"
+
+# IPv4/IPv6 stateful firewall
+table inet filter {
+    chain input {
+        type filter hook input priority filter;
+        policy drop;
+
+        iifname "lo" accept
+
+        # Allow traffic from Tailscale interface
+        iifname $TAILSCALE accept
+
+        ct state established,related accept
+        ct state invalid drop
+
+        ip protocol icmp accept
+        ip6 nexthdr icmpv6 accept
+        ip6 nexthdr 41 accept
+
+        # DHCP client -> server
+        iifname $WAN udp sport 68 udp dport 67 accept
+        iifname $WAN udp sport 546 udp dport 547 accept
+
+        # DHCP server for LAN
+        iifname $LAN udp sport 68 udp dport 67 accept
+        iifname $LAN udp sport 546 udp dport 547 accept
+
+        # SSH Admin
+        iifname $LAN tcp dport 22 accept
+    }
+
+    chain forward {
+        type filter hook forward priority filter;
+        policy drop;
+
+        ct state established,related accept
+        ct state invalid drop
+
+        # LAN -> WAN
+        iifname $LAN oifname $WAN accept
+
+        # Tailscale -> WAN
+        iifname $TAILSCALE oifname $WAN accept
+
+        # Tailscale <-> LAN
+        iifname $TAILSCALE oifname $LAN accept
+        iifname $LAN oifname $TAILSCALE accept
+    }
+
+    chain output {
+        type filter hook output priority filter;
+        policy accept;
+    }
+}
+
+# IPv4 NAT
+table ip nat {
+    chain prerouting {
+        type nat hook prerouting priority dstnat;
+        policy accept;
+    }
+
+    chain postrouting {
+        type nat hook postrouting priority srcnat;
+        policy accept;
+
+        # IPv4 LAN Internet access
+        oifname $WAN masquerade
+    }
+}

--- a/ansible/roles/swarm_router/templates/wan.network.j2
+++ b/ansible/roles/swarm_router/templates/wan.network.j2
@@ -1,0 +1,19 @@
+[Match]
+Name={{ swarm_router_wan_interface }}
+
+[Network]
+Description=WAN
+DHCP=both
+IPv6AcceptRA=yes
+
+[DHCPv4]
+UseRoutes=yes
+RouteMetric=100
+
+[IPv6AcceptRA]
+RouteMetric=100
+DHCPv6Client=always
+
+[DHCPv6]
+ForceDHCPv6PDOtherInformation=yes
+PrefixDelegationHint=::/59

--- a/ansible/roles/tailscale/tasks/main.yaml
+++ b/ansible/roles/tailscale/tasks/main.yaml
@@ -69,15 +69,43 @@
       {%- endif -%}
   when: tailscale_status.rc != 0
 
-- name: Connect to Headscale
+- name: Connect to Headscale (Standard Node)
   command: >
     tailscale up
     --login-server={{ resolved_login_server }}
     --authkey={{ resolved_authkey }}
     --accept-routes
-  when: tailscale_status.rc != 0
-  register: tailscale_up
-  changed_when: "'Success' in tailscale_up.stdout"
+  when:
+    - tailscale_status.rc != 0
+    - not (is_swarm_router | default(false) | bool)
+  register: tailscale_up_standard
+  changed_when: "'Success' in tailscale_up_standard.stdout"
+
+- name: Connect to Headscale (Swarm Router)
+  command: >
+    tailscale up
+    --login-server={{ resolved_login_server }}
+    --authkey={{ resolved_authkey }}
+    --accept-routes
+    --advertise-routes={{ swarm_router_guest_subnets }}
+    --advertise-exit-node
+  when:
+    - tailscale_status.rc != 0
+    - is_swarm_router | default(false) | bool
+  register: tailscale_up_router
+  changed_when: "'Success' in tailscale_up_router.stdout"
+
+- name: Update Tailscale routing (Swarm Router) if already running
+  command: >
+    tailscale up
+    --accept-routes
+    --advertise-routes={{ swarm_router_guest_subnets }}
+    --advertise-exit-node
+  when:
+    - tailscale_status.rc == 0
+    - is_swarm_router | default(false) | bool
+  register: tailscale_update_router
+  changed_when: "'Success' in tailscale_update_router.stdout"
 
 - name: Wait for tailscale0 interface to have an IP
   ansible.builtin.shell: 'tailscale ip -4 | grep "^100\."'

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -265,6 +265,12 @@ pxe_router: "10.0.0.1"
 # Cluster Overlay Network (Tailscale/Headscale)
 overlay_subnet: "100.64.0.0/10"
 
+# -- Swarm Router Configuration --
+is_swarm_router: false
+swarm_router_wan_interface: "eth0"
+swarm_router_lan_interface: "eth1"
+swarm_router_guest_subnets: "10.10.0.0/16"
+
 # -- Tap Orchestrator Configuration --
 tap_orchestrator_port: 8011
 tap_orchestrator_secret: "change_me_in_prod_tap_secret"

--- a/playbooks/network/mesh.yaml
+++ b/playbooks/network/mesh.yaml
@@ -7,3 +7,11 @@
   become: yes
   roles:
     - tailscale
+
+- hosts: all
+  become: yes
+  tasks:
+    - name: Include Swarm Router setup
+      ansible.builtin.include_role:
+        name: swarm_router
+      when: is_swarm_router | default(false) | bool


### PR DESCRIPTION
This pull request implements the requested feature to configure a specific node within the swarm as a network router.

The `is_swarm_router` variable can be set on a specific host in the inventory to designate it as the network router. 
The new `swarm_router` Ansible role configures IPv4/IPv6 forwarding, systemd-networkd for LAN and WAN interfaces, and deploys `nftables` for secure local NAT and routing into the tailnet overlay. The core tailscale role was also updated to dynamically broadcast the guest local network subnets into the swarm and act as an exit node for the network.

---
*PR created automatically by Jules for task [12732218001122114170](https://jules.google.com/task/12732218001122114170) started by @LokiMetaSmith*