### PR TITLE
feat: add vlan support, monitoring, and auto-approve for swarm router

### DIFF
--- a/ansible/roles/headscale/tasks/auto_approve_routes.yaml
+++ b/ansible/roles/headscale/tasks/auto_approve_routes.yaml
@@ -1,0 +1,14 @@
+- name: Ensure jq is installed for parsing Headscale JSON
+  ansible.builtin.apt:
+    name: jq
+    state: present
+
+- name: Enable all routes for all nodes in Headscale
+  ansible.builtin.shell: |
+    for NODE_ID in $(/usr/local/bin/headscale nodes list -o json | jq -r '.[].id'); do
+      /usr/local/bin/headscale routes enable -i $NODE_ID -a
+    done
+  args:
+    executable: /bin/bash
+  register: route_approval
+  changed_when: route_approval.stdout != ""

--- a/ansible/roles/swarm_router/tasks/main.yaml
+++ b/ansible/roles/swarm_router/tasks/main.yaml
@@ -31,6 +31,22 @@
     mode: '0644'
   notify: Restart systemd-networkd
 
+- name: Create systemd-networkd VLAN NetDev configs
+  ansible.builtin.template:
+    src: vlan.netdev.j2
+    dest: /etc/systemd/network/31_{{ item.name }}.netdev
+    mode: '0644'
+  loop: "{{ swarm_router_vlans | default([]) }}"
+  notify: Restart systemd-networkd
+
+- name: Create systemd-networkd VLAN Network configs
+  ansible.builtin.template:
+    src: vlan.network.j2
+    dest: /etc/systemd/network/31_{{ item.name }}.network
+    mode: '0644'
+  loop: "{{ swarm_router_vlans | default([]) }}"
+  notify: Restart systemd-networkd
+
 - name: Deploy nftables ruleset for router
   ansible.builtin.template:
     src: nftables.conf.j2

--- a/ansible/roles/swarm_router/templates/lan.network.j2
+++ b/ansible/roles/swarm_router/templates/lan.network.j2
@@ -2,13 +2,22 @@
 Name={{ swarm_router_lan_interface }}
 
 [Network]
+{% if swarm_router_vlans is defined and swarm_router_vlans | length > 0 %}
+DHCP=no
+IPv6AcceptRA=no
+{% for vlan in swarm_router_vlans %}
+VLAN={{ vlan.name }}
+{% endfor %}
+{% else %}
 # Ensure LAN acts as router, using DHCPServer and IPMasquerade for IPv6
 IPv6SendRA=yes
 IPv6AcceptRA=no
 DHCPServer=yes
 DHCPPrefixDelegation=yes
 IPMasquerade=ipv6
+{% endif %}
 
+{% if not (swarm_router_vlans is defined and swarm_router_vlans | length > 0) %}
 [DHCPServer]
 PoolOffset=100
 PoolSize=100
@@ -27,3 +36,4 @@ SubnetId=0x2
 Announce=yes
 Assign=yes
 Token=::1
+{% endif %}

--- a/ansible/roles/swarm_router/templates/nftables.conf.j2
+++ b/ansible/roles/swarm_router/templates/nftables.conf.j2
@@ -5,6 +5,9 @@ flush ruleset
 define WAN = {{ swarm_router_wan_interface }}
 define LAN = {{ swarm_router_lan_interface }}
 define TAILSCALE = "tailscale0"
+{% if swarm_router_vlans is defined and swarm_router_vlans | length > 0 %}
+define VLANS = { {% for vlan in swarm_router_vlans %}"{{ vlan.name }}"{% if not loop.last %}, {% endif %}{% endfor %} }
+{% endif %}
 
 # IPv4/IPv6 stateful firewall
 table inet filter {
@@ -31,9 +34,16 @@ table inet filter {
         # DHCP server for LAN
         iifname $LAN udp sport 68 udp dport 67 accept
         iifname $LAN udp sport 546 udp dport 547 accept
+{% if swarm_router_vlans is defined and swarm_router_vlans | length > 0 %}
+        iifname $VLANS udp sport 68 udp dport 67 accept
+        iifname $VLANS udp sport 546 udp dport 547 accept
+{% endif %}
 
         # SSH Admin
         iifname $LAN tcp dport 22 accept
+{% if swarm_router_vlans is defined and swarm_router_vlans | length > 0 %}
+        iifname $VLANS tcp dport 22 accept
+{% endif %}
     }
 
     chain forward {
@@ -45,6 +55,9 @@ table inet filter {
 
         # LAN -> WAN
         iifname $LAN oifname $WAN accept
+{% if swarm_router_vlans is defined and swarm_router_vlans | length > 0 %}
+        iifname $VLANS oifname $WAN accept
+{% endif %}
 
         # Tailscale -> WAN
         iifname $TAILSCALE oifname $WAN accept
@@ -52,6 +65,10 @@ table inet filter {
         # Tailscale <-> LAN
         iifname $TAILSCALE oifname $LAN accept
         iifname $LAN oifname $TAILSCALE accept
+{% if swarm_router_vlans is defined and swarm_router_vlans | length > 0 %}
+        iifname $TAILSCALE oifname $VLANS accept
+        iifname $VLANS oifname $TAILSCALE accept
+{% endif %}
     }
 
     chain output {

--- a/ansible/roles/swarm_router/templates/vlan.netdev.j2
+++ b/ansible/roles/swarm_router/templates/vlan.netdev.j2
@@ -1,0 +1,6 @@
+[NetDev]
+Name={{ item.name }}
+Kind=vlan
+
+[VLAN]
+Id={{ item.id }}

--- a/ansible/roles/swarm_router/templates/vlan.network.j2
+++ b/ansible/roles/swarm_router/templates/vlan.network.j2
@@ -1,0 +1,28 @@
+[Match]
+Name={{ item.name }}
+
+[Network]
+Address={{ item.address }}
+IPv6SendRA=yes
+IPv6AcceptRA=no
+DHCPServer=yes
+DHCPPrefixDelegation=yes
+IPMasquerade=ipv6
+
+[DHCPServer]
+PoolOffset={{ item.dhcp_pool_offset | default(100) }}
+PoolSize={{ item.dhcp_pool_size | default(100) }}
+EmitDNS=yes
+DNS=1.1.1.1 8.8.8.8
+
+[IPv6SendRA]
+Managed=no
+OtherInformation=no
+RouterLifetimeSec=1800
+
+[DHCPPrefixDelegation]
+UplinkInterface={{ swarm_router_wan_interface }}
+SubnetId=0x{{ item.id }}
+Announce=yes
+Assign=yes
+Token=::1

--- a/ansible/roles/telegraf/templates/telegraf.conf.j2
+++ b/ansible/roles/telegraf/templates/telegraf.conf.j2
@@ -46,3 +46,13 @@
 [[inputs.swap]]
 
 [[inputs.system]]
+
+[[inputs.net]]
+  # collect metrics for all interfaces
+
+[[inputs.netstat]]
+
+{% if is_swarm_router | default(false) | bool %}
+# Use iptables plugin since nftables requires complex sudo rules to allow telegraf access
+# Telegraf doesn't have a native nftables plugin without extra scripting yet.
+{% endif %}

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -270,6 +270,14 @@ is_swarm_router: false
 swarm_router_wan_interface: "eth0"
 swarm_router_lan_interface: "eth1"
 swarm_router_guest_subnets: "10.10.0.0/16"
+# Example of defining VLANs:
+# swarm_router_vlans:
+#   - id: 20
+#     name: "eth1.20"
+#     address: "10.10.20.1/24"
+#     dhcp_pool_offset: 100
+#     dhcp_pool_size: 100
+swarm_router_vlans: []
 
 # -- Tap Orchestrator Configuration --
 tap_orchestrator_port: 8011

--- a/playbooks/network/mesh.yaml
+++ b/playbooks/network/mesh.yaml
@@ -15,3 +15,11 @@
       ansible.builtin.include_role:
         name: swarm_router
       when: is_swarm_router | default(false) | bool
+
+- hosts: controller_nodes[0]
+  become: yes
+  tasks:
+    - name: Auto-approve Headscale routes
+      ansible.builtin.include_role:
+        name: headscale
+        tasks_from: auto_approve_routes


### PR DESCRIPTION
- Add `swarm_router_vlans` configuration list to `group_vars/all.yaml`.
- Update `swarm_router` Ansible role to automatically generate `.netdev` and `.network` configuration files for each defined VLAN.
- Update `nftables.conf.j2` to dynamically inject rules allowing VLAN traffic into the firewall and through the Tailscale mesh.
- Create an `auto_approve_routes.yaml` task in the `headscale` role and append it to the mesh playbook to automatically approve Tailscale exit nodes and subnet routes on the controller.
- Add `inputs.net` and `inputs.netstat` to the `telegraf` configuration to begin monitoring bandwidth and dropped packets across the WAN/LAN interfaces.