### PR TITLE
Fix Nomad job validation errors for missing certificates

### DIFF
--- a/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
+++ b/ansible/roles/pipecatapp/templates/pipecatapp.nomad.j2
@@ -118,13 +118,17 @@ job "{{ job_name | default('pipecat-app') }}" {
       {{ env_vars }}
 
       template {
-        data        = "{{ lookup('file', internal_cert_path | default('/etc/ssl/certs/internal-cert.pem'), errors='ignore') | default('', true) }}"
+        data        = <<EOT
+{{ lookup('file', internal_cert_path | default('/etc/ssl/certs/internal-cert.pem'), errors='ignore') | default('ERROR_MISSING_CERTIFICATES: Node has not yet provisioned TLS keys.', true) }}
+EOT
         destination = "/secrets/internal-cert.pem"
         change_mode = "restart"
       }
 
       template {
-        data        = "{{ lookup('file', internal_key_path | default('/etc/ssl/private/internal-key.pem'), errors='ignore') | default('', true) }}"
+        data        = <<EOT
+{{ lookup('file', internal_key_path | default('/etc/ssl/private/internal-key.pem'), errors='ignore') | default('ERROR_MISSING_CERTIFICATES: Node has not yet provisioned TLS keys.', true) }}
+EOT
         destination = "/secrets/internal-key.pem"
         change_mode = "restart"
       }
@@ -167,13 +171,17 @@ job "{{ job_name | default('pipecat-app') }}" {
       {{ env_vars }}
 
       template {
-        data        = "{{ lookup('file', internal_cert_path | default('/etc/ssl/certs/internal-cert.pem'), errors='ignore') | default('', true) }}"
+        data        = <<EOT
+{{ lookup('file', internal_cert_path | default('/etc/ssl/certs/internal-cert.pem'), errors='ignore') | default('ERROR_MISSING_CERTIFICATES: Node has not yet provisioned TLS keys.', true) }}
+EOT
         destination = "/secrets/internal-cert.pem"
         change_mode = "restart"
       }
 
       template {
-        data        = "{{ lookup('file', internal_key_path | default('/etc/ssl/private/internal-key.pem'), errors='ignore') | default('', true) }}"
+        data        = <<EOT
+{{ lookup('file', internal_key_path | default('/etc/ssl/private/internal-key.pem'), errors='ignore') | default('ERROR_MISSING_CERTIFICATES: Node has not yet provisioned TLS keys.', true) }}
+EOT
         destination = "/secrets/internal-key.pem"
         change_mode = "restart"
       }


### PR DESCRIPTION
Fixes an issue where Nomad job validation was failing with the error "Must specify a source path or have an embedded template". This occurred because the `pipecatapp.nomad.j2` file used a default empty string (`""`) for certificate `template` blocks when the actual certificate files (`internal-cert.pem` and `internal-key.pem`) did not exist on the Ansible controller. Nomad rejects `data = ""` as invalid.

By replacing the empty string with an explicit "poison pill" (`ERROR_MISSING_CERTIFICATES: Node has not yet provisioned TLS keys.`) inside an HCL heredoc block (`<<EOT ... EOT`), the template correctly parses. Additionally, if the job actually starts without the necessary files, the application will hard crash on parsing the invalid certificate data, fulfilling the strict "Defense in Depth" policy.

---
*PR created automatically by Jules for task [6556104527708148821](https://jules.google.com/task/6556104527708148821) started by @LokiMetaSmith*