### PR TITLE
Fix Headscale route auto-approval syntax

### DIFF
--- a/ansible/roles/headscale/tasks/auto_approve_routes.yaml
+++ b/ansible/roles/headscale/tasks/auto_approve_routes.yaml
@@ -5,8 +5,8 @@
 
 - name: Enable all routes for all nodes in Headscale
   ansible.builtin.shell: |
-    for NODE_ID in $(/usr/local/bin/headscale nodes list -o json | jq -r '.[].id'); do
-      /usr/local/bin/headscale routes enable -i $NODE_ID -a
+    for ROUTE_ID in $(/usr/local/bin/headscale routes list -o json | jq -r '.[].id'); do
+      /usr/local/bin/headscale routes enable -r $ROUTE_ID
     done
   args:
     executable: /bin/bash


### PR DESCRIPTION
Fixes a failing Ansible task in `playbooks/network/mesh.yaml` where auto-approving Headscale routes failed due to an outdated CLI command.

The script in `ansible/roles/headscale/tasks/auto_approve_routes.yaml` was attempting to use `headscale routes enable -i <node_id> -a`, which is no longer supported in newer versions of Headscale and resulted in the error: `unknown shorthand flag: 'i' in -i`.

This commit updates the bash script to fetch the list of routes via `headscale routes list -o json`, parse their IDs using `jq`, and enable each route using the correct syntax: `headscale routes enable -r <route_id>`.

---
*PR created automatically by Jules for task [13586566275789831622](https://jules.google.com/task/13586566275789831622) started by @LokiMetaSmith*