### PR TITLE
Implement Gitea and Radicle hybrid Git backbone

### DIFF
--- a/ansible/roles/gitea/tasks/main.yaml
+++ b/ansible/roles/gitea/tasks/main.yaml
@@ -1,0 +1,33 @@
+- name: Create Gitea data directory
+  ansible.builtin.file:
+    path: "{{ nomad_volumes_dir }}/gitea_data"
+    state: directory
+    mode: '0755'
+    owner: "1000"
+    group: "1000"
+
+- name: Render Gitea Nomad job template
+  ansible.builtin.template:
+    src: gitea.nomad.j2
+    dest: /tmp/gitea.nomad
+    mode: '0644'
+
+- name: Check if Nomad CLI certificate exists
+  ansible.builtin.stat:
+    path: "{{ nomad_tls_dir }}/cli.pem"
+  register: nomad_cli_cert_stat
+
+- name: Run Gitea Nomad job
+  ansible.builtin.command: /usr/local/bin/nomad job run -detach /tmp/gitea.nomad
+  environment:
+    NOMAD_ADDR: "https://127.0.0.1:4646"
+    NOMAD_CACERT: "{{ nomad_tls_dir }}/ca.pem"
+    NOMAD_CLIENT_CERT: "{{ nomad_tls_dir }}/cli.pem"
+    NOMAD_CLIENT_KEY: "{{ nomad_tls_dir }}/cli-key.pem"
+  when: nomad_cli_cert_stat.stat.exists
+
+- name: Run Gitea Nomad job (No TLS)
+  ansible.builtin.command: /usr/local/bin/nomad job run -detach /tmp/gitea.nomad
+  environment:
+    NOMAD_ADDR: "http://127.0.0.1:4646"
+  when: not nomad_cli_cert_stat.stat.exists

--- a/ansible/roles/gitea/templates/gitea.nomad.j2
+++ b/ansible/roles/gitea/templates/gitea.nomad.j2
@@ -1,0 +1,145 @@
+job "gitea" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "gitea-server" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 3000
+      }
+      port "ssh" {
+        to = 2222
+      }
+    }
+
+    volume "gitea_data" {
+      type      = "host"
+      source    = "gitea_data"
+      read_only = false
+    }
+
+    service {
+      name = "gitea"
+      port = "http"
+
+      tags = [
+        "gitea",
+        "git",
+        "http",
+        "traefik.enable=true",
+        "traefik.http.routers.gitea.rule=Host(`gitea.service.consul`)",
+        "traefik.http.routers.gitea.entrypoints=web"
+      ]
+
+      check {
+        type     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    service {
+      name = "gitea-ssh"
+      port = "ssh"
+
+      tags = [
+        "gitea",
+        "git",
+        "ssh"
+      ]
+
+      check {
+        type     = "tcp"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "gitea" {
+      driver = "docker"
+
+      # We override the entrypoint to install the 'rad' CLI binary into the container
+      # upon startup so that the post-receive hook can actually interact with the Radicle node.
+      # We also link the post-receive hook template into the global gitea git hooks directory.
+      config {
+        image = "gitea/gitea:latest"
+        ports = ["http", "ssh"]
+        entrypoint = ["/bin/sh", "-c"]
+        command = <<-EOF
+          # Install radicle CLI if not present
+          if ! command -v rad >/dev/null 2>&1; then
+             apk add --no-cache curl && \
+             curl -sSf https://radicle.xyz/install | sh && \
+             mv /root/.radicle/bin/* /usr/local/bin/
+          fi
+
+          # Setup global hooks
+          mkdir -p /data/git/hooks/post-receive.d
+          cp /local/post-receive-radicle.sh /data/git/hooks/post-receive.d/radicle-mirror
+          chmod +x /data/git/hooks/post-receive.d/radicle-mirror
+
+          # Call original entrypoint with default CMD arguments to start s6 supervisor
+          exec /usr/bin/entrypoint /bin/s6-svscan /etc/s6
+        EOF
+      }
+
+      template {
+        data = <<EOF
+#!/bin/sh
+# Gitea post-receive hook to auto-mirror changes to the local Radicle seed node
+
+echo "Mirroring to Radicle Seed Node..."
+export RAD_PASSPHRASE="changeme_in_production"
+export RAD_HOME="/data/radicle"
+
+# Ensure rad auth is initialized for the git user
+if [ ! -d "$RAD_HOME" ]; then
+    echo "Initializing Radicle identity for Gitea automation user..."
+    rad auth --alias gitea-automation
+fi
+
+# Ensure the repository is initialized as a radicle repository
+if [ ! -d ".rad" ]; then
+    echo "Initializing repository as a Radicle project..."
+    rad init --name "$(basename "$PWD" .git)" --description "Auto-mirrored from Gitea" --default-branch main --public --no-confirm
+fi
+
+# Push and sync to the local seed node
+echo "Pushing changes to Radicle..."
+rad push
+rad sync --node radicle.service.consul:8776
+echo "Mirror complete."
+EOF
+        destination = "local/post-receive-radicle.sh"
+        perms = "0755"
+      }
+
+      volume_mount {
+        volume      = "gitea_data"
+        destination = "/data"
+      }
+
+      env {
+        USER_UID = "1000"
+        USER_GID = "1000"
+        # Database settings
+        GITEA__database__DB_TYPE = "sqlite3"
+        GITEA__database__PATH    = "/data/gitea/gitea.db"
+        # Server settings
+        GITEA__server__DOMAIN           = "gitea.service.consul"
+        GITEA__server__ROOT_URL         = "http://gitea.service.consul:3000/"
+        GITEA__server__SSH_DOMAIN       = "gitea.service.consul"
+        GITEA__server__SSH_PORT         = "${NOMAD_PORT_ssh}"
+        GITEA__server__SSH_LISTEN_PORT  = "2222"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+    }
+  }
+}

--- a/ansible/roles/nomad/templates/client.hcl.j2
+++ b/ansible/roles/nomad/templates/client.hcl.j2
@@ -152,6 +152,16 @@ client {
     read_only = false
   }
 
+  host_volume "gitea_data" {
+    path      = "{{ nomad_volumes_dir }}/gitea_data"
+    read_only = false
+  }
+
+  host_volume "radicle_data" {
+    path      = "{{ nomad_volumes_dir }}/radicle_data"
+    read_only = false
+  }
+
 }
 
 tls {

--- a/ansible/roles/nomad/templates/nomad.hcl.server.j2
+++ b/ansible/roles/nomad/templates/nomad.hcl.server.j2
@@ -135,6 +135,16 @@ client {
     path      = "{{ mcp_dir }}"
     read_only = false
   }
+
+  host_volume "gitea_data" {
+    path      = "{{ nomad_volumes_dir }}/gitea_data"
+    read_only = false
+  }
+
+  host_volume "radicle_data" {
+    path      = "{{ nomad_volumes_dir }}/radicle_data"
+    read_only = false
+  }
 }
 
 

--- a/ansible/roles/nomad/templates/server.hcl.j2
+++ b/ansible/roles/nomad/templates/server.hcl.j2
@@ -139,6 +139,16 @@ client {
     read_only = false
   }
 
+  host_volume "gitea_data" {
+    path      = "{{ nomad_volumes_dir }}/gitea_data"
+    read_only = false
+  }
+
+  host_volume "radicle_data" {
+    path      = "{{ nomad_volumes_dir }}/radicle_data"
+    read_only = false
+  }
+
 }
 
 tls {

--- a/ansible/roles/radicle/tasks/main.yaml
+++ b/ansible/roles/radicle/tasks/main.yaml
@@ -1,0 +1,33 @@
+- name: Create Radicle data directory
+  ansible.builtin.file:
+    path: "{{ nomad_volumes_dir }}/radicle_data"
+    state: directory
+    mode: '0755'
+    owner: "1000"
+    group: "1000"
+
+- name: Render Radicle Nomad job template
+  ansible.builtin.template:
+    src: radicle.nomad.j2
+    dest: /tmp/radicle.nomad
+    mode: '0644'
+
+- name: Check if Nomad CLI certificate exists
+  ansible.builtin.stat:
+    path: "{{ nomad_tls_dir }}/cli.pem"
+  register: nomad_cli_cert_stat
+
+- name: Run Radicle Nomad job
+  ansible.builtin.command: /usr/local/bin/nomad job run -detach /tmp/radicle.nomad
+  environment:
+    NOMAD_ADDR: "https://127.0.0.1:4646"
+    NOMAD_CACERT: "{{ nomad_tls_dir }}/ca.pem"
+    NOMAD_CLIENT_CERT: "{{ nomad_tls_dir }}/cli.pem"
+    NOMAD_CLIENT_KEY: "{{ nomad_tls_dir }}/cli-key.pem"
+  when: nomad_cli_cert_stat.stat.exists
+
+- name: Run Radicle Nomad job (No TLS)
+  ansible.builtin.command: /usr/local/bin/nomad job run -detach /tmp/radicle.nomad
+  environment:
+    NOMAD_ADDR: "http://127.0.0.1:4646"
+  when: not nomad_cli_cert_stat.stat.exists

--- a/ansible/roles/radicle/templates/radicle.nomad.j2
+++ b/ansible/roles/radicle/templates/radicle.nomad.j2
@@ -1,0 +1,112 @@
+job "radicle" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "radicle-seed" {
+    count = 1
+
+    network {
+      port "node" {
+        to = 8776
+      }
+      port "http" {
+        to = 8080
+      }
+    }
+
+    volume "radicle_data" {
+      type      = "host"
+      source    = "radicle_data"
+      read_only = false
+    }
+
+    service {
+      name = "radicle-node"
+      port = "node"
+
+      tags = [
+        "radicle",
+        "git",
+        "p2p"
+      ]
+
+      check {
+        type     = "tcp"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    service {
+      name = "radicle-http"
+      port = "http"
+
+      tags = [
+        "radicle",
+        "git",
+        "http",
+        "traefik.enable=true",
+        "traefik.http.routers.radicle.rule=Host(`radicle.service.consul`)",
+        "traefik.http.routers.radicle.entrypoints=web"
+      ]
+
+      check {
+        type     = "http"
+        path     = "/api/v1/node"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "radicle" {
+      driver = "docker"
+
+      config {
+        image = "radicle/node:latest"
+        ports = ["node", "http"]
+        command = "radicle-node"
+        args = ["--listen", "0.0.0.0:8776", "--force"]
+      }
+
+      volume_mount {
+        volume      = "radicle_data"
+        destination = "/root/.radicle"
+      }
+
+      env {
+        RAD_HOME = "/root/.radicle"
+        RAD_PASSPHRASE = "changeme_in_production"
+      }
+
+      resources {
+        cpu    = 250
+        memory = 256
+      }
+    }
+
+    task "radicle-httpd" {
+      driver = "docker"
+
+      config {
+        image = "radicle/httpd:latest"
+        ports = ["http"]
+        command = "radicle-httpd"
+        args = ["--listen", "0.0.0.0:8080"]
+      }
+
+      volume_mount {
+        volume      = "radicle_data"
+        destination = "/root/.radicle"
+      }
+
+      env {
+        RAD_HOME = "/root/.radicle"
+      }
+
+      resources {
+        cpu    = 250
+        memory = 256
+      }
+    }
+  }
+}

--- a/playbooks/services/app_services.yaml
+++ b/playbooks/services/app_services.yaml
@@ -124,6 +124,8 @@
         - llmfit
         - openclaw
         - forgejo
+        - gitea
+        - radicle
         - paperless
         - opengist
         - e2a
@@ -138,6 +140,8 @@
         - world_model_service
         - tool_server
         - forgejo
+        - gitea
+        - radicle
         - paperless
         - opengist
         - e2a


### PR DESCRIPTION
Creates standard Ansible roles to deploy the Gitea and Radicle Nomad jobs evaluated in previous steps. It updates the Nomad client and server configurations to provision the required host volumes (`gitea_data` and `radicle_data`). The roles are integrated into the `app_services.yaml` playbook.

Additionally, it automates the Radicle mirroring setup by injecting an initialization script into the Gitea container that configures Radicle identity (`rad auth`) and creates a global post-receive Git hook to push to the local seed node.