### PR TITLE
Fix overlapping groups and touch device ContextMenu in LiteGraph

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -245,6 +245,7 @@ This section tracks actionable ideas derived from the `docs/analysis/GNUTELLA_AN
 
 This section tracks identified placeholder files, corrupted binaries, and code that needs to be fixed or removed.
 
+- [x] **LiteGraph Inline TODOs:** Fixed overlapping group logic in `getNodeOnPos` and touch device auto-close in `ContextMenu`.
 - [x] **Remove or Implement Empty Handler:**
   - [x] `ansible/roles/bootstrap_agent/handlers/main.yaml` is currently empty.
 

--- a/pipecatapp/static/js/litegraph.js
+++ b/pipecatapp/static/js/litegraph.js
@@ -1727,12 +1727,12 @@
         for (var i = nodes_list.length - 1; i >= 0; i--) {
             var n = nodes_list[i];
             if (n.isPointInside(x, y, margin)) {
-                // check for lesser interest nodes (TODO check for overlapping, use the top)
-				/*if (typeof n == "LGraphGroup"){
+                // check for lesser interest nodes, use the top
+				if (n.constructor === LiteGraph.LGraphGroup){
 					nRet = n;
-				}else{*/
+				}else{
 					return n;
-				/*}*/
+				}
             }
         }
         return nRet;
@@ -13818,18 +13818,20 @@ LGraphNode.prototype.executeAction = function(action)
             num++;
         }
 
-        //close on leave? touch enabled devices won't work TODO use a global device detector and condition on that
-        /*LiteGraph.pointerListenerAdd(root,"leave", function(e) {
-			console.log("pointerevents: ContextMenu leave");
-            if (that.lock) {
-                return;
-            }
-            if (root.closing_timer) {
-                clearTimeout(root.closing_timer);
-            }
-            root.closing_timer = setTimeout(that.close.bind(that, e), 500);
-            //that.close(e);
-        });*/
+        // auto-close on leave (disabled on touch devices)
+        if (typeof window !== "undefined" && window.matchMedia && !window.matchMedia("(pointer: coarse)").matches) {
+            LiteGraph.pointerListenerAdd(root,"leave", function(e) {
+                //console.log("pointerevents: ContextMenu leave");
+                if (that.lock) {
+                    return;
+                }
+                if (root.closing_timer) {
+                    clearTimeout(root.closing_timer);
+                }
+                root.closing_timer = setTimeout(that.close.bind(that, e), 500);
+                //that.close(e);
+            });
+        }
 
 		LiteGraph.pointerListenerAdd(root,"enter", function(e) {
 			//console.log("pointerevents: ContextMenu enter");


### PR DESCRIPTION
This PR implements the missing mobile UI and overlapping group bug fixes inside `pipecatapp/static/js/litegraph.js` as tracked by the inline `// TODO` comments. It correctly prioritizes standard nodes beneath groups when clicked, and allows context menus to stay open on touch devices where `mouseleave` events behave unexpectedly.

The task is marked complete in `TODO.md`.

---
*PR created automatically by Jules for task [522087452041488218](https://jules.google.com/task/522087452041488218) started by @LokiMetaSmith*