### PR TITLE
feat(workflows): implement Pi agent integration PoC

### DIFF
--- a/ansible/roles/pipecatapp/tasks/main.yaml
+++ b/ansible/roles/pipecatapp/tasks/main.yaml
@@ -133,6 +133,11 @@
   when: verified_experts is not defined or verified_experts | length == 0
 
 
+- name: Install @earendil-works/pi-coding-agent via npm globally
+  ansible.builtin.command:
+    cmd: "npm install -g --ignore-scripts @earendil-works/pi-coding-agent"
+  become: yes
+
 - name: Ensure correct ownership of the application directory
   ansible.builtin.file:
     path: "{{ pipecat_app_dir }}"

--- a/pipecatapp/workflow/nodes/__init__.py
+++ b/pipecatapp/workflow/nodes/__init__.py
@@ -10,3 +10,4 @@ from . import consolidation_nodes
 from . import schema_nodes
 from . import research_nodes
 from . import reservoir_nodes
+from . import pi_node

--- a/pipecatapp/workflow/nodes/pi_node.py
+++ b/pipecatapp/workflow/nodes/pi_node.py
@@ -1,0 +1,63 @@
+import json
+import asyncio
+import os
+import shutil
+import subprocess
+from ..node import Node
+from ..context import WorkflowContext
+from .registry import registry
+
+@registry.register
+class PiAgentNode(Node):
+    """
+    A workflow node that delegates execution to the Pi agent CLI (@earendil-works/pi-coding-agent).
+    It expects a prompt input and passes it to the `pi -p` command for JSON/print output mode.
+    """
+    async def execute(self, context: WorkflowContext):
+        try:
+            prompt = self.get_input(context, "prompt")
+        except ValueError:
+            prompt = None
+
+        if not prompt:
+            self.set_output(context, "result", "Error: 'prompt' input is required for PiAgentNode.")
+            return
+
+        # Check if pi is installed globally via npm or in PATH
+        pi_executable = shutil.which("pi")
+        if not pi_executable:
+            self.set_output(context, "result", "Error: 'pi' executable not found. Ensure @earendil-works/pi-coding-agent is installed.")
+            return
+
+        timeout = self.config.get("timeout", 120)
+
+        # Build the command: pi -p "prompt"
+        # -p is for print/JSON mode, skipping the interactive TUI
+        command = [pi_executable, "-p", prompt]
+
+        try:
+            # We run this in a thread executor to not block the async event loop
+            loop = asyncio.get_running_loop()
+
+            def run_subprocess():
+                return subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=timeout,
+                    env=os.environ.copy()
+                )
+
+            process = await loop.run_in_executor(None, run_subprocess)
+
+            if process.returncode == 0:
+                self.set_output(context, "result", process.stdout.strip())
+            else:
+                error_msg = f"Pi agent failed (code {process.returncode}):\nSTDOUT: {process.stdout}\nSTDERR: {process.stderr}"
+                self.set_output(context, "result", error_msg)
+
+        except subprocess.TimeoutExpired:
+            self.set_output(context, "result", f"Error: Pi execution timed out after {timeout} seconds.")
+        except Exception as e:
+            self.set_output(context, "result", f"Error executing PiAgentNode: {e}")

--- a/pipecatapp/workflows/pi_integration_test.yaml
+++ b/pipecatapp/workflows/pi_integration_test.yaml
@@ -1,0 +1,23 @@
+name: "Pi Agent Integration Test Workflow"
+nodes:
+  - id: "Input"
+    type: "InputNode"
+    inputs: []
+
+  - id: "PiExecution"
+    type: "PiAgentNode"
+    config:
+      timeout: 120
+    inputs:
+      - name: "prompt"
+        connection:
+          from_node: "Input"
+          from_output: "user_text"
+
+  - id: "Output"
+    type: "OutputNode"
+    inputs:
+      - name: "final_output"
+        connection:
+          from_node: "PiExecution"
+          from_output: "result"

--- a/tests/unit/workflow/nodes/test_pi_node.py
+++ b/tests/unit/workflow/nodes/test_pi_node.py
@@ -1,0 +1,96 @@
+import pytest
+import asyncio
+from unittest.mock import patch, MagicMock
+from pipecatapp.workflow.nodes.pi_node import PiAgentNode
+from pipecatapp.workflow.context import WorkflowContext
+
+@pytest.fixture
+def workflow_context():
+    context = WorkflowContext(workflow_definition={
+        "name": "test_workflow",
+        "nodes": [
+            {
+                "id": "PiExecution",
+                "inputs": [
+                    {"name": "prompt", "connection": {"from_node": "Input", "from_output": "user_text"}}
+                ]
+            }
+        ]
+    })
+    context.set_output("Input", "user_text", "hello pi")
+    return context
+
+@pytest.mark.asyncio
+@patch('shutil.which')
+@patch('subprocess.run')
+async def test_pi_agent_node_success(mock_run, mock_which, workflow_context):
+    mock_which.return_value = "/usr/bin/pi"
+
+    mock_process = MagicMock()
+    mock_process.returncode = 0
+    mock_process.stdout = '{"status": "success", "response": "Hello from Pi!"}'
+    mock_process.stderr = ""
+    mock_run.return_value = mock_process
+
+    node = PiAgentNode({
+        "id": "PiExecution",
+        "config": {"timeout": 60},
+        "inputs": [{
+            "name": "prompt",
+            "connection": {"from_node": "Input", "from_output": "user_text"}
+        }]
+    })
+
+    await node.execute(workflow_context)
+
+    # Verify subprocess arguments
+    mock_run.assert_called_once()
+    args, kwargs = mock_run.call_args
+    assert args[0] == ["/usr/bin/pi", "-p", "hello pi"]
+
+    result = workflow_context.node_outputs["PiExecution"]["result"]
+    assert 'Hello from Pi!' in result
+
+
+@pytest.mark.asyncio
+@patch('shutil.which')
+async def test_pi_agent_node_missing_executable(mock_which, workflow_context):
+    mock_which.return_value = None
+
+    node = PiAgentNode({
+        "id": "PiExecution",
+        "config": {},
+        "inputs": [{
+            "name": "prompt",
+            "connection": {"from_node": "Input", "from_output": "user_text"}
+        }]
+    })
+
+    await node.execute(workflow_context)
+
+    result = workflow_context.node_outputs["PiExecution"]["result"]
+    assert "Error: 'pi' executable not found" in result
+
+
+@pytest.mark.asyncio
+async def test_pi_agent_node_missing_prompt():
+    context = WorkflowContext(workflow_definition={
+        "name": "test_workflow",
+        "nodes": [
+            {
+                "id": "PiExecution",
+                "inputs": []
+            }
+        ]
+    })
+
+    node = PiAgentNode({
+        "id": "PiExecution",
+        "config": {},
+        "inputs": []
+    })
+
+    await node.execute(context)
+
+    result = context.node_outputs["PiExecution"]["result"]
+    assert "Error: 'prompt' input is required" in result


### PR DESCRIPTION
Implements the actionable items detailed in the Pi agent evaluation report:
1. Adds `npm install -g --ignore-scripts @earendil-works/pi-coding-agent` to the `pipecatapp` Ansible role to ensure the CLI is available globally.
2. Creates `PiAgentNode` (`pi_node.py`), a native workflow node that wraps the Pi CLI using Python's `subprocess` for non-interactive execution.
3. Registers the new node in the workflow registry.
4. Provides an example workflow definition (`pi_integration_test.yaml`).
5. Adds comprehensive unit tests for `PiAgentNode`, mocking the subprocess and validating execution paths.